### PR TITLE
Process and split world provincial capitals data

### DIFF
--- a/README_world_provincial_capitals.txt
+++ b/README_world_provincial_capitals.txt
@@ -1,0 +1,18 @@
+world_provincial_capitals_geo_regions dataset
+
+Produced by build_world_provincial_capitals_split.py
+
+Sources and attribution:
+- dr5hn / countries-states-cities-database (GitHub) — public dataset (commonly ODbL). Please review license and attribution requirements.
+- UN M49 / regional mappings (UN Statistics Division) where available.
+
+Output files:
+- world_provincial_capitals_geo_regions.csv
+- world_provincial_capitals_APAC.csv
+- world_provincial_capitals_EMEA.csv
+- world_provincial_capitals_Americas.csv
+
+Notes:
+- Province_Capital is detected best-effort from the dr5hn cities.csv; some provinces may not have a detected capital and will be blank.
+- Major_Cities lists the top N cities for each state, preferring population if available.
+

--- a/build_world_provincial_capitals_split.py
+++ b/build_world_provincial_capitals_split.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+build_world_provincial_capitals_split.py
+
+Produces:
+ - world_provincial_capitals_geo_regions.csv  (combined)
+ - world_provincial_capitals_APAC.csv
+ - world_provincial_capitals_EMEA.csv
+ - world_provincial_capitals_Americas.csv
+ - README_world_provincial_capitals.txt
+
+Requirements:
+ - Python 3.8+
+ - pip install pandas requests
+
+Notes:
+ - Uses dr5hn/countries-states-cities-database (GitHub master zip).
+ - Attempts to fetch UN M49 mapping; if not available, some UN_Sub_Region values may be blank.
+ - Dataset license: dr5hn is typically ODbL. Respect attribution.
+"""
+
+import os
+import io
+import zipfile
+import requests
+import pandas as pd
+from collections import defaultdict
+
+# Config
+OUT_COMBINED = "world_provincial_capitals_geo_regions.csv"
+OUT_APAC = "world_provincial_capitals_APAC.csv"
+OUT_EMEA = "world_provincial_capitals_EMEA.csv"
+OUT_AMERICAS = "world_provincial_capitals_Americas.csv"
+README = "README_world_provincial_capitals.txt"
+
+DR5HN_ZIP = "https://github.com/dr5hn/countries-states-cities-database/archive/refs/heads/master.zip"
+# Try a generic UN M49 CSV mirror. If it fails, script continues (UN_Sub_Region may be blank).
+UN_M49_CSV = "https://unstats.un.org/unsd/methodology/m49/overview"  # NOTE: UN page, not CSV; we handle fallback
+
+TOP_N_CITIES = 3
+TIMEOUT = 60
+
+session = requests.Session()
+session.headers.update({"User-Agent": "world-crm-export-script/1.0 (mailto:you@example.com)"})
+
+def download_and_extract_dr5hn():
+    print("Downloading dr5hn dataset (this may take ~10-30s)...")
+    r = session.get(DR5HN_ZIP, stream=True, timeout=TIMEOUT)
+    r.raise_for_status()
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    names = z.namelist()
+
+    # find CSV file paths (case-insensitive)
+    countries_fp = next((n for n in names if n.lower().endswith("countries.csv")), None)
+    states_fp = next((n for n in names if n.lower().endswith("states.csv")), None)
+    cities_fp = next((n for n in names if n.lower().endswith("cities.csv")), None)
+
+    if not (countries_fp and states_fp and cities_fp):
+        raise RuntimeError("Could not find countries/states/cities CSV files in dr5hn zip. Files found: " + ", ".join(names))
+
+    print("Reading CSVs from zip...")
+    countries = pd.read_csv(z.open(countries_fp), dtype=str)
+    states = pd.read_csv(z.open(states_fp), dtype=str)
+    cities = pd.read_csv(z.open(cities_fp), dtype=str)
+    print(f"Loaded: {len(countries)} countries, {len(states)} states, {len(cities)} cities (approx).")
+    return countries, states, cities
+
+def download_un_m49_guess():
+    # The UN site doesn't provide a single neat CSV URL consistently. Try a few known mirrors.
+    candidate_urls = [
+        # Common mirrors / copies - these may or may not be reachable. Script will try them in order.
+        "https://datahub.io/core/country-codes/r/country-codes.csv",  # large but contains region info
+        "https://raw.githubusercontent.com/lukes/ISO-3166-Countries-with-Regional-Codes/master/all/all.csv",
+        # A small M49-style table may be maintained on other mirrors; add more if you want.
+    ]
+    for url in candidate_urls:
+        try:
+            print("Attempting to download UN / region mapping from:", url)
+            r = session.get(url, timeout=30)
+            if r.status_code == 200 and r.text:
+                df = pd.read_csv(io.StringIO(r.text), dtype=str)
+                print(f"Downloaded region mapping from {url} (rows: {len(df)})")
+                return df
+        except Exception as e:
+            print("Failed to fetch", url, ":", str(e))
+    print("Could not download a UN M49 CSV from known mirrors - continuing with fallback (UN_Sub_Region may be blank).")
+    return pd.DataFrame()
+
+def normalize_columns(df):
+    # Trim whitespace from column names
+    df.columns = [c.strip() for c in df.columns]
+    return df
+
+def build_un_map(un_df):
+    if un_df.empty:
+        return {}, {}
+    un_df = normalize_columns(un_df)
+    # Try to find an ISO2 column, a country-name column, and subregion column
+    iso2_col = None
+    name_col = None
+    sub_col = None
+    for c in un_df.columns:
+        cl = c.lower()
+        if not iso2_col and ("iso" in cl and ("alpha2" in cl or "iso2" in cl or cl == "iso")):
+            iso2_col = c
+        if not name_col and ("name" in cl and ("country" in cl or "country or area" in cl or "official_name" in cl or cl == "name")):
+            name_col = c
+        # subregion heuristics
+        if not sub_col and ("sub" in cl and "region" in cl or "subregion" in cl or "region" in cl):
+            sub_col = c
+    # Fallbacks to likely columns
+    if iso2_col is None:
+        for c in un_df.columns:
+            if c.lower() in ("iso2", "alpha2", "iso"):
+                iso2_col = c
+    if name_col is None:
+        for c in un_df.columns:
+            if "country" in c.lower() or "name" in c.lower():
+                name_col = c
+                break
+    if sub_col is None:
+        for c in un_df.columns:
+            if "sub" in c.lower() and "region" in c.lower():
+                sub_col = c
+                break
+
+    map_iso2 = {}
+    map_name = {}
+    if iso2_col:
+        for _, r in un_df.iterrows():
+            iso = r.get(iso2_col)
+            sub = r.get(sub_col) if sub_col else None
+            name = r.get(name_col) if name_col else None
+            if pd.notna(iso):
+                map_iso2[str(iso).strip().upper()] = str(sub).strip() if pd.notna(sub) else ""
+            if pd.notna(name):
+                map_name[str(name).strip().lower()] = str(sub).strip() if pd.notna(sub) else ""
+    else:
+        # if no iso2 found, map by name only
+        for _, r in un_df.iterrows():
+            name = r.get(name_col) if name_col else None
+            sub = r.get(sub_col) if sub_col else None
+            if pd.notna(name):
+                map_name[str(name).strip().lower()] = str(sub).strip() if pd.notna(sub) else ""
+    return map_iso2, map_name
+
+def choose_business_region(un_subregion):
+    if not un_subregion or not isinstance(un_subregion, str):
+        return ""
+    lower = un_subregion.lower()
+    if any(x in lower for x in ("asia", "oceania", "australia", "micronesia", "melanesia", "polynesia")):
+        return "APAC"
+    if any(x in lower for x in ("america", "caribbean", "south america", "northern america", "central america")):
+        return "Americas"
+    # fallback EMEA
+    return "EMEA"
+
+def build_output_df(countries, states, cities, un_map_iso2, un_map_name, top_n=TOP_N_CITIES):
+    # normalize colnames
+    countries = normalize_columns(countries)
+    states = normalize_columns(states)
+    cities = normalize_columns(cities)
+
+    # ensure id and linking fields are strings
+    for df, col in ((countries, "id"), (states, "id"), (states, "country_id")):
+        if col in df.columns:
+            df[col] = df[col].astype(str)
+
+    if 'country_id' in cities.columns:
+        cities['country_id'] = cities['country_id'].astype(str)
+    if 'state_id' in cities.columns:
+        cities['state_id'] = cities['state_id'].astype(str)
+    else:
+        # some datasets include 'state_code' or 'state_code' linking; keep as-is (best-effort)
+        cities['state_id'] = cities.get('state_id', cities.get('state_code', '')).astype(str)
+
+    country_index = {}
+    if 'id' in countries.columns:
+        country_index = {str(r['id']): r for _, r in countries.iterrows()}
+    else:
+        # fallback on iso2 mapping if ids missing
+        for _, r in countries.iterrows():
+            key = str(r.get('iso2') or r.get('iso') or "").upper()
+            if key:
+                country_index[key] = r
+
+    # Group cities by (country_id, state_id)
+    cities_grouped = defaultdict(list)
+    for _, r in cities.iterrows():
+        key = (str(r.get('country_id','')), str(r.get('state_id','')))
+        cities_grouped[key].append(r)
+
+    # detect useful city columns
+    pop_col = None
+    lat_col = None
+    lon_col = None
+    for c in cities.columns:
+        lc = c.lower()
+        if not pop_col and "pop" in lc:
+            pop_col = c
+        if not lat_col and lc in ("latitude","lat"):
+            lat_col = c
+        if not lon_col and lc in ("longitude","lon","lng","long"):
+            lon_col = c
+
+    # detect city capital flag columns
+    capital_flags = [c for c in cities.columns if "cap" in c.lower()]
+
+    rows = []
+    # iterate states
+    if 'id' in states.columns:
+        iter_states = states.itertuples(index=False)
+    else:
+        iter_states = states.itertuples(index=False)
+
+    for _, srow in states.iterrows():
+        country_id = str(srow.get('country_id',''))
+        state_id = str(srow.get('id', ''))
+        state_name = srow.get('name') or srow.get('state') or ''
+        # get country info
+        cinfo = country_index.get(country_id)
+        if cinfo is None:
+            cinfo = {}
+        # if country_index keyed by ISO2, try to fallback get iso2 from country row
+        if cinfo.empty and 'iso2' in srow and pd.notna(srow.get('iso2')):
+            cinfo = country_index.get(str(srow.get('iso2')).upper())
+            if cinfo is None:
+                cinfo = {}
+
+        country_name = str(cinfo.get('name') or cinfo.get('country') or srow.get('country_name') or '')
+        country_iso2 = str(cinfo.get('iso2') or cinfo.get('iso') or '').upper()
+        country_capital = str(cinfo.get('capital') or '')
+
+        # candidate cities in this state
+        key = (country_id, state_id)
+        candidates = cities_grouped.get(key, [])
+
+        # find province capital first by explicit flag
+        prov_cap = ""
+        prov_lat = ""
+        prov_lon = ""
+        found_cap = False
+        for city in candidates:
+            for f in capital_flags:
+                try:
+                    val = city.get(f)
+                    if pd.notna(val) and str(val).strip().lower() in ("1","true","yes","y","t"):
+                        prov_cap = city.get('name') or ''
+                        prov_lat = city.get(lat_col) if lat_col and lat_col in city else city.get('latitude', '')
+                        prov_lon = city.get(lon_col) if lon_col and lon_col in city else city.get('longitude', '') or city.get('lng','') or city.get('lon','')
+                        found_cap = True
+                        break
+                except Exception:
+                    continue
+            if found_cap:
+                break
+
+        # fallback heuristics
+        if not found_cap and candidates:
+            # match equal name
+            for city in candidates:
+                if str(city.get('name','')).strip().lower() == str(state_name).strip().lower():
+                    prov_cap = city.get('name') or ''
+                    prov_lat = city.get(lat_col,'') or city.get('latitude','')
+                    prov_lon = city.get(lon_col,'') or city.get('longitude','') or city.get('lng','') or city.get('lon','')
+                    found_cap = True
+                    break
+        if not found_cap and candidates:
+            # fallback to first candidate
+            city = candidates[0]
+            prov_cap = city.get('name') or ''
+            prov_lat = city.get(lat_col,'') or city.get('latitude','')
+            prov_lon = city.get(lon_col,'') or city.get('longitude','') or city.get('lng','') or city.get('lon','')
+
+        # select top N major cities for this state
+        major_cities = []
+        major_cities_latlon = []
+        if candidates:
+            # sort by population if available
+            if pop_col and pop_col in cities.columns:
+                try:
+                    sorted_cities = sorted(candidates, key=lambda r: float(r.get(pop_col) or 0), reverse=True)
+                except Exception:
+                    sorted_cities = candidates
+            else:
+                sorted_cities = candidates
+
+            seen = set()
+            for city in sorted_cities:
+                nm = str(city.get('name') or '').strip()
+                if not nm or nm in seen:
+                    continue
+                seen.add(nm)
+                lat = city.get(lat_col,'') or city.get('latitude','') or ''
+                lon = city.get(lon_col,'') or city.get('longitude','') or city.get('lng','') or city.get('lon','')
+                major_cities.append(nm)
+                major_cities_latlon.append(f"{nm}|({lat},{lon})")
+                if len(major_cities) >= top_n:
+                    break
+
+        major_cities_str = ";".join(major_cities)
+        major_cities_latlon_str = ";".join(major_cities_latlon)
+
+        # UN subregion lookup
+        un_sub = ""
+        if country_iso2 and country_iso2 in un_map_iso2:
+            un_sub = un_map_iso2.get(country_iso2, "")
+        elif country_name and country_name.lower() in un_map_name:
+            un_sub = un_map_name.get(country_name.lower(), "")
+
+        business_region = choose_business_region(un_sub)
+
+        rows.append({
+            "Country": country_name or '',
+            "Country_Code": country_iso2 or '',
+            "State_or_Province": state_name or '',
+            "Province_Capital": prov_cap or '',
+            "Country_Capital": country_capital or '',
+            "Business_Region": business_region,
+            "UN_Sub_Region": un_sub or '',
+            "Latitude": prov_lat or '',
+            "Longitude": prov_lon or '',
+            "Major_Cities": major_cities_str,
+            "Major_Cities_LatLon": major_cities_latlon_str,
+        })
+
+    df_out = pd.DataFrame(rows)
+    return df_out
+
+def save_splits_and_combined(df):
+    # Combined
+    df.to_csv(OUT_COMBINED, index=False, encoding='utf-8')
+    print("Saved combined:", OUT_COMBINED)
+
+    # Splits
+    apac = df[df['Business_Region'] == 'APAC']
+    emea = df[df['Business_Region'] == 'EMEA']
+    amer = df[df['Business_Region'] == 'Americas']
+
+    apac.to_csv(OUT_APAC, index=False, encoding='utf-8')
+    emea.to_csv(OUT_EMEA, index=False, encoding='utf-8')
+    amer.to_csv(OUT_AMERICAS, index=False, encoding='utf-8')
+
+    print("Saved splits:", OUT_APAC, OUT_EMEA, OUT_AMERICAS)
+
+def write_readme():
+    with open(README, "w", encoding="utf-8") as fh:
+        fh.write("world_provincial_capitals_geo_regions dataset\n")
+        fh.write("\n")
+        fh.write("Produced by build_world_provincial_capitals_split.py\n")
+        fh.write("\n")
+        fh.write("Sources and attribution:\n")
+        fh.write("- dr5hn / countries-states-cities-database (GitHub) — public dataset (commonly ODbL). Please review license and attribution requirements.\n")
+        fh.write("- UN M49 / regional mappings (UN Statistics Division) where available.\n")
+        fh.write("\n")
+        fh.write("Output files:\n")
+        fh.write(f"- {OUT_COMBINED}\n")
+        fh.write(f"- {OUT_APAC}\n")
+        fh.write(f"- {OUT_EMEA}\n")
+        fh.write(f"- {OUT_AMERICAS}\n")
+        fh.write("\n")
+        fh.write("Notes:\n")
+        fh.write("- Province_Capital is detected best-effort from the dr5hn cities.csv; some provinces may not have a detected capital and will be blank.\n")
+        fh.write("- Major_Cities lists the top N cities for each state, preferring population if available.\n")
+        fh.write("\n")
+    print("Wrote README:", README)
+
+def main():
+    try:
+        countries, states, cities = download_and_extract_dr5hn()
+    except Exception as e:
+        print("Error downloading dr5hn dataset:", e)
+        return
+
+    un_df = download_un_m49_guess()
+    un_map_iso2, un_map_name = build_un_map(un_df) if not un_df.empty else ({}, {})
+
+    print("Building output table. This may take a minute for large city tables.")
+    df_out = build_output_df(countries, states, cities, un_map_iso2, un_map_name, top_n=TOP_N_CITIES)
+
+    print("Total rows (states/provinces) in output:", len(df_out))
+    save_splits_and_combined(df_out)
+    write_readme()
+    print("Done. Please inspect the 'Province_Capital' column and 'Major_Cities' for completeness; manual verification may be required for a few countries.")
+
+if __name__ == "__main__":
+    main()

--- a/world_provincial_capitals_APAC.csv
+++ b/world_provincial_capitals_APAC.csv
@@ -1,0 +1,1 @@
+Country,Country_Code,State_or_Province,Province_Capital,Country_Capital,Business_Region,UN_Sub_Region,Latitude,Longitude,Major_Cities,Major_Cities_LatLon

--- a/world_provincial_capitals_Americas.csv
+++ b/world_provincial_capitals_Americas.csv
@@ -1,0 +1,1 @@
+Country,Country_Code,State_or_Province,Province_Capital,Country_Capital,Business_Region,UN_Sub_Region,Latitude,Longitude,Major_Cities,Major_Cities_LatLon

--- a/world_provincial_capitals_EMEA.csv
+++ b/world_provincial_capitals_EMEA.csv
@@ -1,0 +1,541 @@
+Country,Country_Code,State_or_Province,Province_Capital,Country_Capital,Business_Region,UN_Sub_Region,Latitude,Longitude,Major_Cities,Major_Cities_LatLon
+Angola,AO,Bengo,Ambriz,Luanda,EMEA,17,-7.85740000,13.12510000,Ambriz;Bula Atumba;Caxito,"Ambriz|(-7.85740000,13.12510000);Bula Atumba|(-7.31170000,14.31470000);Caxito|(-8.57848000,13.66425000)"
+Angola,AO,Benguela,Benguela,Luanda,EMEA,17,-12.57626000,13.40547000,Baía Farta;Balombo;Benguela,"Baía Farta|(-12.57660000,13.47760000);Balombo|(-12.90460000,13.59590000);Benguela|(-12.57626000,13.40547000)"
+Angola,AO,Bié,Camacupa,Luanda,EMEA,17,-12.01667000,17.48333000,Camacupa;Catabola;Chissamba,"Camacupa|(-12.01667000,17.48333000);Catabola|(-12.15000000,17.28333000);Chissamba|(-12.16667000,17.33333000)"
+Angola,AO,Cabinda,Cabinda,Luanda,EMEA,17,-5.55000000,12.20000000,Cabinda,"Cabinda|(-5.55000000,12.20000000)"
+Angola,AO,Cuando Cubango,Menongue,Luanda,EMEA,17,-14.65850000,17.69099000,Menongue,"Menongue|(-14.65850000,17.69099000)"
+Angola,AO,Cuanza,Quibala,Luanda,EMEA,17,-10.73366000,14.97995000,Quibala;Sumbe;Uacu Cungo,"Quibala|(-10.73366000,14.97995000);Sumbe|(-11.20605000,13.84371000);Uacu Cungo|(-11.35669000,15.11719000)"
+Angola,AO,Cuanza Norte,Camabatela,Luanda,EMEA,17,-8.18812000,15.37495000,Camabatela;N’dalatando,"Camabatela|(-8.18812000,15.37495000);N’dalatando|(-9.29782000,14.91162000)"
+Angola,AO,Cunene,Ondjiva,Luanda,EMEA,17,-17.06667000,15.73333000,Ondjiva,"Ondjiva|(-17.06667000,15.73333000)"
+Angola,AO,Huambo,Huambo,Luanda,EMEA,17,-12.77611000,15.73917000,Caála;Chela;Huambo,"Caála|(-12.85250000,15.56056000);Chela|(-12.30261000,15.43358000);Huambo|(-12.77611000,15.73917000)"
+Angola,AO,Huíla,Caconda,Luanda,EMEA,17,-13.73333000,15.06667000,Caconda;Caluquembe;Chibia,"Caconda|(-13.73333000,15.06667000);Caluquembe|(-13.92093000,14.53476000);Chibia|(-15.23657000,13.88468000)"
+Angola,AO,Luanda,Luanda,Luanda,EMEA,17,-8.83682000,13.23432000,Belas;Cacuaco;Cazenga,"Belas|(-9.06875000,13.16072000);Cacuaco|(-8.82960000,13.29730000);Cazenga|(-8.82860000,13.26650000)"
+Angola,AO,Lunda Norte,Lucapa,Luanda,EMEA,17,-8.68337000,20.27045000,Lucapa,"Lucapa|(-8.68337000,20.27045000)"
+Angola,AO,Lunda Sul,Cazaji,Luanda,EMEA,17,-11.06715000,20.70148000,Cazaji;Saurimo,"Cazaji|(-11.06715000,20.70148000);Saurimo|(-9.66078000,20.39155000)"
+Angola,AO,Malanje,Malanje,Luanda,EMEA,17,-9.54015000,16.34096000,Malanje,"Malanje|(-9.54015000,16.34096000)"
+Angola,AO,Moxico,Léua,Luanda,EMEA,17,-11.65000000,20.45000000,Léua;Luau;Luena,"Léua|(-11.65000000,20.45000000);Luau|(-10.70727000,22.22466000);Luena|(-11.78333000,19.91667000)"
+Angola,AO,Uíge,Uíge,Luanda,EMEA,17,-7.60874000,15.06131000,Uíge,"Uíge|(-7.60874000,15.06131000)"
+Angola,AO,Zaire,Mbanza Congo,Luanda,EMEA,17,-6.26703000,14.24010000,Mbanza Congo;N'zeto;Soio,"Mbanza Congo|(-6.26703000,14.24010000);N'zeto|(-7.23116000,12.86660000);Soio|(-6.13490000,12.36894000)"
+Anguilla,AI,Blowing Point,,The Valley,EMEA,29,,,,
+Anguilla,AI,East End,,The Valley,EMEA,29,,,,
+Anguilla,AI,George Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,Island Harbour,,The Valley,EMEA,29,,,,
+Anguilla,AI,North Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,North Side,,The Valley,EMEA,29,,,,
+Anguilla,AI,Sandy Ground,,The Valley,EMEA,29,,,,
+Anguilla,AI,Sandy Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,South Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,Stoney Ground,,The Valley,EMEA,29,,,,
+Anguilla,AI,The Farrington,,The Valley,EMEA,29,,,,
+Anguilla,AI,The Quarter,,The Valley,EMEA,29,,,,
+Anguilla,AI,The Valley,,The Valley,EMEA,29,,,,
+Anguilla,AI,West End,,The Valley,EMEA,29,,,,
+Aruba,AW,Noord,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Oranjestad,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Oranjestad East,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Oranjestad West,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Paradera,,Oranjestad,EMEA,29,,,,
+Aruba,AW,San Nicolaas Noord,,Oranjestad,EMEA,29,,,,
+Aruba,AW,San Nicolaas Zuid,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Santa Cruz,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Savaneta,,Oranjestad,EMEA,29,,,,
+Belize,BZ,Belize,Belize City,Belmopan,EMEA,13,17.49952000,-88.19756000,Belize City;San Pedro,"Belize City|(17.49952000,-88.19756000);San Pedro|(17.91598000,-87.96590000)"
+Belize,BZ,Cayo,Belmopan,Belmopan,EMEA,13,17.25000000,-88.76667000,Belmopan;Benque Viejo el Carmen;San Ignacio,"Belmopan|(17.25000000,-88.76667000);Benque Viejo el Carmen|(17.07500000,-89.13917000);San Ignacio|(17.15880000,-89.06960000)"
+Belize,BZ,Corozal,Corozal,Belmopan,EMEA,13,18.39375000,-88.38849000,Corozal,"Corozal|(18.39375000,-88.38849000)"
+Belize,BZ,Orange Walk,Orange Walk,Belmopan,EMEA,13,18.08124000,-88.56328000,Hopelchén;Orange Walk;Shipyard,"Hopelchén|(17.80000000,-89.10000000);Orange Walk|(18.08124000,-88.56328000);Shipyard|(17.89382000,-88.65452000)"
+Belize,BZ,Stann Creek,Dangriga,Belmopan,EMEA,13,16.96970000,-88.23313000,Dangriga;Placencia,"Dangriga|(16.96970000,-88.23313000);Placencia|(16.51419000,-88.36647000)"
+Belize,BZ,Toledo,Punta Gorda,Belmopan,EMEA,13,16.09835000,-88.80970000,Punta Gorda,"Punta Gorda|(16.09835000,-88.80970000)"
+Botswana,BW,Central,Gobojango,Gaborone,EMEA,18,-21.83270000,28.72882000,Gobojango;Gweta;Kalamare,"Gobojango|(-21.83270000,28.72882000);Gweta|(-20.18333000,25.23333000);Kalamare|(-22.93369000,26.57032000)"
+Botswana,BW,Ghanzi,Ghanzi,Gaborone,EMEA,18,-21.69785000,21.64581000,Dekar;Ghanzi,"Dekar|(-21.53333000,21.93333000);Ghanzi|(-21.69785000,21.64581000)"
+Botswana,BW,Kgalagadi,Hukuntsi,Gaborone,EMEA,18,-23.99880000,21.77962000,Hukuntsi;Kang;Lehututu,"Hukuntsi|(-23.99880000,21.77962000);Kang|(-23.67518000,22.78762000);Lehututu|(-23.96667000,21.86667000)"
+Botswana,BW,Kgatleng,Bokaa,Gaborone,EMEA,18,-24.45000000,26.01667000,Bokaa;Mmathubudukwane;Mochudi,"Bokaa|(-24.45000000,26.01667000);Mmathubudukwane|(-24.60000000,26.43333000);Mochudi|(-24.41667000,26.15000000)"
+Botswana,BW,Kweneng,Botlhapatlou,Gaborone,EMEA,18,-24.02591000,25.48976000,Botlhapatlou;Dutlwe;Gabane,"Botlhapatlou|(-24.02591000,25.48976000);Dutlwe|(-23.98333000,23.90000000);Gabane|(-24.66667000,25.78222000)"
+Botswana,BW,Ngamiland,,Gaborone,EMEA,18,,,,
+Botswana,BW,North-East,Dukwe,Gaborone,EMEA,18,-20.58333000,26.41667000,Dukwe;Makaleng;Masunga,"Dukwe|(-20.58333000,26.41667000);Makaleng|(-20.90000000,27.28333000);Masunga|(-20.62455000,27.44875000)"
+Botswana,BW,North-West,Maun,Gaborone,EMEA,18,-19.98333000,23.41667000,Maun;Nokaneng;Pandamatenga,"Maun|(-19.98333000,23.41667000);Nokaneng|(-19.66667000,22.26667000);Pandamatenga|(-18.52779000,25.62698000)"
+Botswana,BW,South-East,Gaborone,Gaborone,EMEA,18,-24.76234000,25.79950000,Gaborone;Janeng;Kopong,"Gaborone|(-24.76234000,25.79950000);Janeng|(-25.41667000,25.55000000);Kopong|(-24.48333000,25.88333000)"
+Botswana,BW,Southern,Kanye,Gaborone,EMEA,18,-24.96675000,25.33273000,Kanye;Khakhea;Mosopa,"Kanye|(-24.96675000,25.33273000);Khakhea|(-24.68954000,23.49403000);Mosopa|(-24.77180000,25.42156000)"
+Burkina Faso,BF,Balé,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Bam,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Banwa,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Bazèga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Boucle du Mouhoun,Barani,Ouagadougou,EMEA,11,13.16910000,-3.88990000,Barani;Boromo;Dédougou,"Barani|(13.16910000,-3.88990000);Boromo|(11.74542000,-2.93006000);Dédougou|(12.46338000,-3.46075000)"
+Burkina Faso,BF,Bougouriba,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Boulgou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Boulkiemde,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Cascades,Banfora,Ouagadougou,EMEA,11,10.63333000,-4.76667000,Banfora;Province de la Comoé;Province de la Léraba,"Banfora|(10.63333000,-4.76667000);Province de la Comoé|(10.33333000,-4.41667000);Province de la Léraba|(10.66667000,-5.20000000)"
+Burkina Faso,BF,Centre,Kadiogo Province,Ouagadougou,EMEA,11,12.33333000,-1.50000000,Kadiogo Province;Ouagadougou,"Kadiogo Province|(12.33333000,-1.50000000);Ouagadougou|(12.36566000,-1.53388000)"
+Burkina Faso,BF,Centre-Est,Garango,Ouagadougou,EMEA,11,11.80000000,-0.55056000,Garango;Koupéla;Kouritenga Province,"Garango|(11.80000000,-0.55056000);Koupéla|(12.17864000,-0.35103000);Kouritenga Province|(12.20000000,-0.30000000)"
+Burkina Faso,BF,Centre-Nord,Boulsa,Ouagadougou,EMEA,11,12.66664000,-0.57469000,Boulsa;Kaya;Kongoussi,"Boulsa|(12.66664000,-0.57469000);Kaya|(13.09167000,-1.08444000);Kongoussi|(13.32583000,-1.53472000)"
+Burkina Faso,BF,Centre-Ouest,Goulouré,Ouagadougou,EMEA,11,12.23484000,-1.93394000,Goulouré;Kokologo;Koudougou,"Goulouré|(12.23484000,-1.93394000);Kokologo|(12.19392000,-1.87687000);Koudougou|(12.25263000,-2.36272000)"
+Burkina Faso,BF,Centre-Sud,Bazega Province,Ouagadougou,EMEA,11,11.91667000,-1.50000000,Bazega Province;Kombissiri;Manga,"Bazega Province|(11.91667000,-1.50000000);Kombissiri|(12.06884000,-1.33644000);Manga|(11.66361000,-1.07306000)"
+Burkina Faso,BF,Comoé,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Est,Bogandé,Ouagadougou,EMEA,11,12.97040000,-0.14953000,Bogandé;Diapaga;Fada N'gourma,"Bogandé|(12.97040000,-0.14953000);Diapaga|(12.07305000,1.78838000);Fada N'gourma|(12.06157000,0.35843000)"
+Burkina Faso,BF,Ganzourgou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Gnagna,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Gourma,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Hauts-Bassins,Bobo-Dioulasso,Ouagadougou,EMEA,11,11.17715000,-4.29790000,Bobo-Dioulasso;Houndé;Province du Houet,"Bobo-Dioulasso|(11.17715000,-4.29790000);Houndé|(11.50000000,-3.51667000);Province du Houet|(11.33333000,-4.25000000)"
+Burkina Faso,BF,Houet,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Ioba,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kadiogo,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kénédougou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Komondjari,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kompienga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kossi,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Koulpélogo,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kouritenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kourwéogo,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Léraba,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Loroum,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Mouhoun,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Nahouri,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Namentenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Nayala,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Nord,Gourcy,Ouagadougou,EMEA,11,13.20776000,-2.35893000,Gourcy;Ouahigouya;Province du Loroum,"Gourcy|(13.20776000,-2.35893000);Ouahigouya|(13.58278000,-2.42158000);Province du Loroum|(13.91667000,-2.16667000)"
+Burkina Faso,BF,Noumbiel,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Oubritenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Oudalan,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Passoré,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Plateau-Central,Boussé,Ouagadougou,EMEA,11,12.66121000,-1.89515000,Boussé;Oubritenga;Province du Ganzourgou,"Boussé|(12.66121000,-1.89515000);Oubritenga|(12.66667000,-1.33333000);Province du Ganzourgou|(12.26667000,-0.76667000)"
+Burkina Faso,BF,Poni,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sahel,Djibo,Ouagadougou,EMEA,11,14.09940000,-1.62554000,Djibo;Dori;Gorom-Gorom,"Djibo|(14.09940000,-1.62554000);Dori|(14.03540000,-0.03450000);Gorom-Gorom|(14.44290000,-0.23468000)"
+Burkina Faso,BF,Sanguié,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sanmatenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Séno,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sissili,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Soum,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sourou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sud-Ouest,Batié,Ouagadougou,EMEA,11,9.88333000,-2.91667000,Batié;Dano;Diébougou,"Batié|(9.88333000,-2.91667000);Dano|(11.14640000,-3.05784000);Diébougou|(10.96209000,-3.24967000)"
+Burkina Faso,BF,Tapoa,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Tuy,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Yagha,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Yatenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Ziro,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Zondoma,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Zoundwéogo,,Ouagadougou,EMEA,11,,,,
+Burundi,BI,Bubanza,Bubanza,Bujumbura,EMEA,14,-3.08040000,29.39100000,Bubanza,"Bubanza|(-3.08040000,29.39100000)"
+Burundi,BI,Bujumbura Mairie,Bujumbura,Bujumbura,EMEA,14,-3.38193000,29.36142000,Bujumbura,"Bujumbura|(-3.38193000,29.36142000)"
+Burundi,BI,Bujumbura Rural,,Bujumbura,EMEA,14,,,,
+Burundi,BI,Bururi,Bururi,Bujumbura,EMEA,14,-3.94877000,29.62438000,Bururi,"Bururi|(-3.94877000,29.62438000)"
+Burundi,BI,Cankuzo,Cankuzo,Bujumbura,EMEA,14,-3.21860000,30.55280000,Cankuzo,"Cankuzo|(-3.21860000,30.55280000)"
+Burundi,BI,Cibitoke,Cibitoke,Bujumbura,EMEA,14,-2.88690000,29.12480000,Cibitoke,"Cibitoke|(-2.88690000,29.12480000)"
+Burundi,BI,Gitega,Gitega,Bujumbura,EMEA,14,-3.42708000,29.92463000,Gitega,"Gitega|(-3.42708000,29.92463000)"
+Burundi,BI,Karuzi,Karuzi,Bujumbura,EMEA,14,-3.10139000,30.16278000,Karuzi,"Karuzi|(-3.10139000,30.16278000)"
+Burundi,BI,Kayanza,Kayanza,Bujumbura,EMEA,14,-2.92210000,29.62930000,Kayanza,"Kayanza|(-2.92210000,29.62930000)"
+Burundi,BI,Kirundo,Kirundo,Bujumbura,EMEA,14,-2.58450000,30.09590000,Kirundo,"Kirundo|(-2.58450000,30.09590000)"
+Burundi,BI,Makamba,Makamba,Bujumbura,EMEA,14,-4.13480000,29.80400000,Makamba,"Makamba|(-4.13480000,29.80400000)"
+Burundi,BI,Muramvya,Muramvya,Bujumbura,EMEA,14,-3.26820000,29.60790000,Muramvya,"Muramvya|(-3.26820000,29.60790000)"
+Burundi,BI,Muyinga,Muyinga,Bujumbura,EMEA,14,-2.84510000,30.34140000,Muyinga,"Muyinga|(-2.84510000,30.34140000)"
+Burundi,BI,Mwaro,Mwaro,Bujumbura,EMEA,14,-3.51128000,29.70334000,Mwaro,"Mwaro|(-3.51128000,29.70334000)"
+Burundi,BI,Ngozi,Ngozi,Bujumbura,EMEA,14,-2.90750000,29.83060000,Ngozi,"Ngozi|(-2.90750000,29.83060000)"
+Burundi,BI,Rumonge,Rumonge,Bujumbura,EMEA,14,-3.97360000,29.43860000,Rumonge,"Rumonge|(-3.97360000,29.43860000)"
+Burundi,BI,Rutana,Rutana,Bujumbura,EMEA,14,-3.92790000,29.99200000,Rutana,"Rutana|(-3.92790000,29.99200000)"
+Burundi,BI,Ruyigi,Ruyigi,Bujumbura,EMEA,14,-3.47639000,30.24861000,Ruyigi,"Ruyigi|(-3.47639000,30.24861000)"
+Congo,CG,Bouenza,Kayes,Brazzaville,EMEA,17,-4.20493000,13.28608000,Kayes;Madingou,"Kayes|(-4.20493000,13.28608000);Madingou|(-4.15361000,13.55000000)"
+Congo,CG,Brazzaville,Brazzaville,Brazzaville,EMEA,17,-4.26613000,15.28318000,Brazzaville,"Brazzaville|(-4.26613000,15.28318000)"
+Congo,CG,Cuvette,Makoua,Brazzaville,EMEA,17,0.00694000,15.63333000,Makoua;Owando,"Makoua|(0.00694000,15.63333000);Owando|(-0.48193000,15.89988000)"
+Congo,CG,Cuvette-Ouest,Ewo,Brazzaville,EMEA,17,-0.87250000,14.82056000,Ewo,"Ewo|(-0.87250000,14.82056000)"
+Congo,CG,Kouilou,,Brazzaville,EMEA,17,,,,
+Congo,CG,Lékoumou,Sibiti,Brazzaville,EMEA,17,-3.68192000,13.34985000,Sibiti,"Sibiti|(-3.68192000,13.34985000)"
+Congo,CG,Likouala,Impfondo,Brazzaville,EMEA,17,1.61804000,18.05981000,Impfondo,"Impfondo|(1.61804000,18.05981000)"
+Congo,CG,Niari,Dolisie,Brazzaville,EMEA,17,-4.19834000,12.66664000,Dolisie;Mossendjo,"Dolisie|(-4.19834000,12.66664000);Mossendjo|(-2.94968000,12.70423000)"
+Congo,CG,Plateaux,Djambala,Brazzaville,EMEA,17,-2.54472000,14.75333000,Djambala;Gamboma,"Djambala|(-2.54472000,14.75333000);Gamboma|(-1.87639000,15.86444000)"
+Congo,CG,Pointe-Noire,Pointe-Noire,Brazzaville,EMEA,17,-4.77609000,11.86352000,Loandjili;Pointe-Noire,"Loandjili|(-4.75611000,11.85778000);Pointe-Noire|(-4.77609000,11.86352000)"
+Congo,CG,Pool,Kinkala,Brazzaville,EMEA,17,-4.36139000,14.76444000,Kinkala,"Kinkala|(-4.36139000,14.76444000)"
+Congo,CG,Sangha,Ouésso,Brazzaville,EMEA,17,1.61361000,16.05167000,Ouésso;Sémbé,"Ouésso|(1.61361000,16.05167000);Sémbé|(1.64806000,14.58056000)"
+Costa Rica,CR,Alajuela,Alajuela,San Jose,EMEA,13,10.01625000,-84.21163000,Alajuela;Atenas;Bijagua,"Alajuela|(10.01625000,-84.21163000);Atenas|(9.98333000,-84.38333000);Bijagua|(10.73279000,-85.05676000)"
+Costa Rica,CR,Cartago,Cartago,San Jose,EMEA,13,9.86444000,-83.91944000,Alvarado;Cartago;Concepción,"Alvarado|(9.93333000,-83.80000000);Cartago|(9.86444000,-83.91944000);Concepción|(9.93333000,-84.00000000)"
+Costa Rica,CR,Guanacaste,Abangares,San Jose,EMEA,13,10.21667000,-85.00000000,Abangares;Bagaces;Belén,"Abangares|(10.21667000,-85.00000000);Bagaces|(10.50000000,-85.25000000);Belén|(10.40789000,-85.58836000)"
+Costa Rica,CR,Heredia,Heredia,San Jose,EMEA,13,10.00236000,-84.11651000,Ángeles;Barva;Belén,"Ángeles|(9.99591000,-84.05126000);Barva|(10.08333000,-84.10000000);Belén|(9.98333000,-84.16667000)"
+Costa Rica,CR,Limón,Limón,San Jose,EMEA,13,9.99074000,-83.03596000,Batán;Guácimo;Guápiles,"Batán|(10.08354000,-83.33413000);Guácimo|(10.20000000,-83.66667000);Guápiles|(10.21682000,-83.78483000)"
+Costa Rica,CR,Puntarenas,Puntarenas,San Jose,EMEA,13,9.97625000,-84.83836000,Buenos Aires;Canoas;Chacarita,"Buenos Aires|(9.11667000,-83.25000000);Canoas|(8.53305000,-82.83844000);Chacarita|(9.98424000,-84.77892000)"
+Costa Rica,CR,San José,San José,San Jose,EMEA,13,9.93333000,-84.08333000,Acosta;Alajuelita;Aserrí,"Acosta|(9.80000000,-84.20000000);Alajuelita|(9.90000000,-84.10000000);Aserrí|(9.86667000,-84.10000000)"
+Cuba,CU,Artemisa,Artemisa,Havana,EMEA,29,22.81667000,-82.75944000,Alquízar;Artemisa;Bahía Honda,"Alquízar|(22.80517000,-82.58392000);Artemisa|(22.81667000,-82.75944000);Bahía Honda|(22.90332000,-83.15994000)"
+Cuba,CU,Camagüey,Camagüey,Havana,EMEA,29,21.38083000,-77.91694000,Camagüey;El Caney;Esmeralda,"Camagüey|(21.38083000,-77.91694000);El Caney|(21.30000000,-78.48333000);Esmeralda|(21.85139000,-78.11725000)"
+Cuba,CU,Ciego de Ávila,Ciego de Ávila,Havana,EMEA,29,21.84000000,-78.76194000,Baraguá;Chambas;Ciego de Ávila,"Baraguá|(21.68216000,-78.62567000);Chambas|(22.19534000,-78.91230000);Ciego de Ávila|(21.84000000,-78.76194000)"
+Cuba,CU,Cienfuegos,Cienfuegos,Havana,EMEA,29,22.14957000,-80.44662000,Abreus;Aguada de Pasajeros;Cienfuegos,"Abreus|(22.27797000,-80.56931000);Aguada de Pasajeros|(22.38520000,-80.84792000);Cienfuegos|(22.14957000,-80.44662000)"
+Cuba,CU,Granma,Bartolomé Masó,Havana,EMEA,29,20.16635000,-76.94291000,Bartolomé Masó;Bayamo;Campechuela,"Bartolomé Masó|(20.16635000,-76.94291000);Bayamo|(20.37417000,-76.64361000);Campechuela|(20.23329000,-77.27990000)"
+Cuba,CU,Guantánamo,Guantánamo,Havana,EMEA,29,20.14444000,-75.20917000,Baracoa;Guantánamo;Maisí,"Baracoa|(20.34711000,-74.49624000);Guantánamo|(20.14444000,-75.20917000);Maisí|(20.24673000,-74.15181000)"
+Cuba,CU,Havana,Havana,Havana,EMEA,29,23.13302000,-82.38304000,Alamar;Arroyo Naranjo;Boyeros,"Alamar|(23.15794000,-82.27837000);Arroyo Naranjo|(23.03677000,-82.36937000);Boyeros|(23.00720000,-82.40170000)"
+Cuba,CU,Holguín,Holguín,Havana,EMEA,29,20.88722000,-76.26306000,Banes;Cacocum;Cueto,"Banes|(20.96116000,-75.72200000);Cacocum|(20.73775000,-76.32574000);Cueto|(20.64855000,-75.92967000)"
+Cuba,CU,Isla de la Juventud,Nueva Gerona,Havana,EMEA,29,21.88667000,-82.80556000,Nueva Gerona,"Nueva Gerona|(21.88667000,-82.80556000)"
+Cuba,CU,Las Tunas,Las Tunas,Havana,EMEA,29,20.96167000,-76.95111000,Amancio;Colombia;Jesús Menéndez,"Amancio|(20.81914000,-77.57958000);Colombia|(20.98812000,-77.42598000);Jesús Menéndez|(21.16139000,-76.47919000)"
+Cuba,CU,Matanzas,Matanzas,Havana,EMEA,29,23.04111000,-81.57750000,Alacranes;Bolondrón;Calimete,"Alacranes|(22.76719000,-81.56803000);Bolondrón|(22.76307000,-81.44780000);Calimete|(22.53420000,-80.91105000)"
+Cuba,CU,Mayabeque,Batabanó,Havana,EMEA,29,22.71794000,-82.28965000,Batabanó;Bejucal;Güines,"Batabanó|(22.71794000,-82.28965000);Bejucal|(22.92861000,-82.38861000);Güines|(22.83727000,-82.02641000)"
+Cuba,CU,Pinar del Río,Pinar del Río,Havana,EMEA,29,22.41667000,-83.69667000,Consolación del Sur;Guane;Los Palacios,"Consolación del Sur|(22.50419000,-83.51442000);Guane|(22.20179000,-84.08484000);Los Palacios|(22.58882000,-83.24671000)"
+Cuba,CU,Sancti Spíritus,Sancti Spíritus,Havana,EMEA,29,21.92972000,-79.44250000,Cabaiguán;Condado;Fomento,"Cabaiguán|(22.07874000,-79.49726000);Condado|(21.87670000,-79.84014000);Fomento|(22.10475000,-79.72141000)"
+Cuba,CU,Santiago de Cuba,Santiago de Cuba,Havana,EMEA,29,20.02083000,-75.82667000,Contramaestre;El Cobre;Municipio de Palma Soriano,"Contramaestre|(20.29879000,-76.24511000);El Cobre|(20.04850000,-75.94579000);Municipio de Palma Soriano|(20.20897000,-76.05776000)"
+Cuba,CU,Villa Clara,Caibarién,Havana,EMEA,29,22.51996000,-79.46599000,Caibarién;Calabazar de Sagua;Camajuaní,"Caibarién|(22.51996000,-79.46599000);Calabazar de Sagua|(22.64515000,-79.89510000);Camajuaní|(22.48333000,-79.75000000)"
+Djibouti,DJ,Ali Sabieh,'Ali Sabieh,Djibouti,EMEA,14,11.15583000,42.71250000,'Ali Sabieh;Goubétto;Holhol,"'Ali Sabieh|(11.15583000,42.71250000);Goubétto|(11.42389000,43.00028000);Holhol|(11.31028000,42.92944000)"
+Djibouti,DJ,Arta,Arta,Djibouti,EMEA,14,11.52639000,42.85194000,Arta,"Arta|(11.52639000,42.85194000)"
+Djibouti,DJ,Dikhil,Dikhil,Djibouti,EMEA,14,11.10454000,42.36971000,Dikhil;Gâlâfi,"Dikhil|(11.10454000,42.36971000);Gâlâfi|(11.71583000,41.83611000)"
+Djibouti,DJ,Djibouti,Djibouti,Djibouti,EMEA,14,11.58901000,43.14503000,Djibouti;Loyada,"Djibouti|(11.58901000,43.14503000);Loyada|(11.46111000,43.25278000)"
+Djibouti,DJ,Obock,Obock,Djibouti,EMEA,14,11.96693000,43.28835000,Alaïli Ḏaḏḏa‘;Obock,"Alaïli Ḏaḏḏa‘|(12.42167000,42.89556000);Obock|(11.96693000,43.28835000)"
+Djibouti,DJ,Tadjourah,Tadjourah,Djibouti,EMEA,14,11.78778000,42.88222000,Dorra;Tadjourah,"Dorra|(12.15028000,42.47624000);Tadjourah|(11.78778000,42.88222000)"
+El Salvador,SV,Ahuachapán,Ahuachapán,San Salvador,EMEA,13,13.92139000,-89.84500000,Ahuachapán;Atiquizaya;Concepción de Ataco,"Ahuachapán|(13.92139000,-89.84500000);Atiquizaya|(13.97694000,-89.75250000);Concepción de Ataco|(13.87028000,-89.84861000)"
+El Salvador,SV,Cabañas,Sensuntepeque,San Salvador,EMEA,13,13.86667000,-88.63333000,Sensuntepeque;Victoria,"Sensuntepeque|(13.86667000,-88.63333000);Victoria|(13.95000000,-88.63333000)"
+El Salvador,SV,Chalatenango,Chalatenango,San Salvador,EMEA,13,14.03333000,-88.93333000,Chalatenango;Nueva Concepción,"Chalatenango|(14.03333000,-88.93333000);Nueva Concepción|(14.13333000,-89.30000000)"
+El Salvador,SV,Cuscatlán,Cojutepeque,San Salvador,EMEA,13,13.71667000,-88.93333000,Cojutepeque;San Martín;Suchitoto,"Cojutepeque|(13.71667000,-88.93333000);San Martín|(13.78333000,-88.91667000);Suchitoto|(13.93806000,-89.02778000)"
+El Salvador,SV,La Libertad,La Libertad,San Salvador,EMEA,13,13.48833000,-89.32222000,Antiguo Cuscatlán;Ciudad Arce;La Libertad,"Antiguo Cuscatlán|(13.66492000,-89.25319000);Ciudad Arce|(13.84028000,-89.44722000);La Libertad|(13.48833000,-89.32222000)"
+El Salvador,SV,La Paz,El Rosario,San Salvador,EMEA,13,13.49778000,-89.02972000,El Rosario;Olocuilta;San Pedro Masahuat,"El Rosario|(13.49778000,-89.02972000);Olocuilta|(13.56972000,-89.11722000);San Pedro Masahuat|(13.54361000,-89.03861000)"
+El Salvador,SV,La Unión ,La Unión,San Salvador,EMEA,13,13.33694000,-87.84389000,Anamorós;Conchagua;Intipucá,"Anamorós|(13.74056000,-87.87361000);Conchagua|(13.30778000,-87.86472000);Intipucá|(13.19694000,-88.05444000)"
+El Salvador,SV,Morazán,Cacaopera,San Salvador,EMEA,13,13.76667000,-88.08333000,Cacaopera;Corinto;Guatajiagua,"Cacaopera|(13.76667000,-88.08333000);Corinto|(13.81083000,-87.97139000);Guatajiagua|(13.66667000,-88.20000000)"
+El Salvador,SV,San Miguel,San Miguel,San Salvador,EMEA,13,13.48333000,-88.18333000,Chapeltique;Chinameca;Chirilagua,"Chapeltique|(13.63333000,-88.26667000);Chinameca|(13.50000000,-88.35000000);Chirilagua|(13.22028000,-88.13861000)"
+El Salvador,SV,San Salvador,San Salvador,San Salvador,EMEA,13,13.68935000,-89.18718000,Aguilares;Apopa;Ayutuxtepeque,"Aguilares|(13.95722000,-89.18972000);Apopa|(13.80722000,-89.17917000);Ayutuxtepeque|(13.74556000,-89.20639000)"
+El Salvador,SV,San Vicente,San Vicente,San Salvador,EMEA,13,13.63333000,-88.80000000,Apastepeque;San Sebastián;San Vicente,"Apastepeque|(13.66667000,-88.78333000);San Sebastián|(13.73333000,-88.83333000);San Vicente|(13.63333000,-88.80000000)"
+El Salvador,SV,Santa Ana,Santa Ana,San Salvador,EMEA,13,13.99417000,-89.55972000,Candelaria de La Frontera;Chalchuapa;Coatepeque,"Candelaria de La Frontera|(14.11667000,-89.65000000);Chalchuapa|(13.98667000,-89.68111000);Coatepeque|(13.92861000,-89.50417000)"
+El Salvador,SV,Sonsonate,Sonsonate,San Salvador,EMEA,13,13.71889000,-89.72417000,Acajutla;Armenia;Izalco,"Acajutla|(13.59278000,-89.82750000);Armenia|(13.74361000,-89.49889000);Izalco|(13.74472000,-89.67306000)"
+El Salvador,SV,Usulután,Usulután,San Salvador,EMEA,13,13.35000000,-88.45000000,Berlín;Concepción Batres;Jiquilisco,"Berlín|(13.50000000,-88.53333000);Concepción Batres|(13.35000000,-88.36667000);Jiquilisco|(13.31667000,-88.58333000)"
+Eswatini,SZ,Hhohho,Bulembu,Mbabane,EMEA,18,-25.96667000,31.13333000,Bulembu;Hhukwini;Lobamba,"Bulembu|(-25.96667000,31.13333000);Hhukwini|(-26.31972000,31.22222000);Lobamba|(-26.46667000,31.20000000)"
+Eswatini,SZ,Lubombo,Big Bend,Mbabane,EMEA,18,-26.81667000,31.93333000,Big Bend;Dvokodvweni Inkhundla;Lomashasha,"Big Bend|(-26.81667000,31.93333000);Dvokodvweni Inkhundla|(-26.45398000,31.76456000);Lomashasha|(-26.06644000,32.00768000)"
+Eswatini,SZ,Manzini,Manzini,Mbabane,EMEA,18,-26.49884000,31.38004000,Bhunya;Ekukhanyeni;Kwaluseni,"Bhunya|(-26.55000000,31.01667000);Ekukhanyeni|(-26.38750000,31.52806000);Kwaluseni|(-26.48333000,31.33333000)"
+Eswatini,SZ,Shiselweni,Hlatikulu,Mbabane,EMEA,18,-26.97917000,31.32444000,Hlatikulu;Hluti;Kubuta,"Hlatikulu|(-26.97917000,31.32444000);Hluti|(-27.21667000,31.61667000);Kubuta|(-26.88333000,31.48333000)"
+Gabon,GA,Estuaire,Cocobeach,Libreville,EMEA,17,1.00019000,9.58229000,Cocobeach;Libreville;Ntoum,"Cocobeach|(1.00019000,9.58229000);Libreville|(0.39241000,9.45356000);Ntoum|(0.39051000,9.76096000)"
+Gabon,GA,Haut-Ogooué,Franceville,Libreville,EMEA,17,-1.63333000,13.58357000,Franceville;Lékoni;Moanda,"Franceville|(-1.63333000,13.58357000);Lékoni|(-1.58431000,14.25905000);Moanda|(-1.56652000,13.19870000)"
+Gabon,GA,Moyen-Ogooué,Lambaréné,Libreville,EMEA,17,-0.70010000,10.24055000,Lambaréné;Ndjolé,"Lambaréné|(-0.70010000,10.24055000);Ndjolé|(-0.17827000,10.76488000)"
+Gabon,GA,Ngounié,Fougamou,Libreville,EMEA,17,-1.21544000,10.58378000,Fougamou;Mbigou;Mimongo,"Fougamou|(-1.21544000,10.58378000);Mbigou|(-1.90046000,11.90600000);Mimongo|(-1.61952000,11.60675000)"
+Gabon,GA,Nyanga,Mayumba,Libreville,EMEA,17,-3.43198000,10.65540000,Mayumba;Tchibanga,"Mayumba|(-3.43198000,10.65540000);Tchibanga|(-2.93323000,10.98178000)"
+Gabon,GA,Ogooué-Ivindo,Booué,Libreville,EMEA,17,-0.09207000,11.93846000,Booué;Makokou;Zadie,"Booué|(-0.09207000,11.93846000);Makokou|(0.57381000,12.86419000);Zadie|(0.92582000,13.90813000)"
+Gabon,GA,Ogooué-Lolo,Koulamoutou,Libreville,EMEA,17,-1.13667000,12.46399000,Koulamoutou;Lastoursville,"Koulamoutou|(-1.13667000,12.46399000);Lastoursville|(-0.81742000,12.70818000)"
+Gabon,GA,Ogooué-Maritime,Gamba,Libreville,EMEA,17,-2.65000000,10.00000000,Gamba;Omboué;Port-Gentil,"Gamba|(-2.65000000,10.00000000);Omboué|(-1.57464000,9.26184000);Port-Gentil|(-0.71933000,8.78151000)"
+Gabon,GA,Woleu-Ntem,Bitam,Libreville,EMEA,17,2.07597000,11.50065000,Bitam;Mitzic;Oyem,"Bitam|(2.07597000,11.50065000);Mitzic|(0.78205000,11.54904000);Oyem|(1.59950000,11.57933000)"
+Ghana,GH,Ahafo,Asunafo North,Accra,EMEA,11,6.81968910,-2.80770500,Asunafo North;Asunafo South;Asutifi North,"Asunafo North|(6.81968910,-2.80770500);Asunafo South|(6.68210000,-2.43997530);Asutifi North|(6.94774860,-2.76757160)"
+Ghana,GH,Ashanti,Agogo,Accra,EMEA,11,6.80004000,-1.08193000,Agogo;Bekwai;Ejura,"Agogo|(6.80004000,-1.08193000);Bekwai|(6.45195000,-1.57866000);Ejura|(7.38558000,-1.35617000)"
+Ghana,GH,Bono,Banda,Accra,EMEA,11,8.14956710,-2.36639500,Banda;Berekum East;Berekum West,"Banda|(8.14956710,-2.36639500);Berekum East|(7.43846190,-2.60295780);Berekum West|(7.43934160,-2.65497050)"
+Ghana,GH,Bono East,Atebubu-Amantin,Accra,EMEA,11,7.70237000,-1.21979430,Atebubu-Amantin;Kintampo North;Kintampo South,"Atebubu-Amantin|(7.70237000,-1.21979430);Kintampo North|(8.39635790,-1.82000070);Kintampo South|(7.98971320,-2.00711150)"
+Ghana,GH,Central,Apam,Accra,EMEA,11,5.28483000,-0.73711000,Apam;Cape Coast;Dunkwa,"Apam|(5.28483000,-0.73711000);Cape Coast|(5.10535000,-1.24660000);Dunkwa|(5.95996000,-1.77792000)"
+Ghana,GH,Eastern,Aburi,Accra,EMEA,11,5.84802000,-0.17449000,Aburi;Akim Oda;Akim Swedru,"Aburi|(5.84802000,-0.17449000);Akim Oda|(5.92665000,-0.98577000);Akim Swedru|(5.89380000,-1.01636000)"
+Ghana,GH,Greater Accra,Accra,Accra,EMEA,11,5.55602000,-0.19690000,Accra;Atsiaman;Dome,"Accra|(5.55602000,-0.19690000);Atsiaman|(5.69775000,-0.32824000);Dome|(5.65003000,-0.23610000)"
+Ghana,GH,North East,Bunkpurugu-Nyakpanduri,Accra,EMEA,11,10.46609170,-0.22711950,Bunkpurugu-Nyakpanduri;Chereponi;East Mamprusi,"Bunkpurugu-Nyakpanduri|(10.46609170,-0.22711950);Chereponi|(10.13827720,0.28242580);East Mamprusi|(10.42931860,-0.53078850)"
+Ghana,GH,Northern,Kpandae,Accra,EMEA,11,8.46885000,-0.01127000,Kpandae;Salaga;Savelugu,"Kpandae|(8.46885000,-0.01127000);Salaga|(8.55083000,-0.51875000);Savelugu|(9.62441000,-0.82530000)"
+Ghana,GH,Oti,Biakoye,Accra,EMEA,11,7.11698690,0.32324300,Biakoye;Jasikan;Kadjebi,"Biakoye|(7.11698690,0.32324300);Jasikan|(7.40940880,0.44301500);Kadjebi|(7.52631920,0.46704770)"
+Ghana,GH,Savannah,Bole,Accra,EMEA,11,9.02996640,-2.50694300,Bole;Central Gonja;East Gonja,"Bole|(9.02996640,-2.50694300);Central Gonja|(8.92784320,-1.95369720);East Gonja|(8.72568400,-1.07135790)"
+Ghana,GH,Upper East,Bawku,Accra,EMEA,11,11.06160000,-0.24169000,Bawku;Bolgatanga;Navrongo,"Bawku|(11.06160000,-0.24169000);Bolgatanga|(10.78556000,-0.85139000);Navrongo|(10.89557000,-1.09210000)"
+Ghana,GH,Upper West,Wa,Accra,EMEA,11,10.06069000,-2.50192000,Wa,"Wa|(10.06069000,-2.50192000)"
+Ghana,GH,Volta,Aflao,Accra,EMEA,11,6.11982000,1.19012000,Aflao;Anloga;Ho,"Aflao|(6.11982000,1.19012000);Anloga|(5.79473000,0.89728000);Ho|(6.60084000,0.47130000)"
+Ghana,GH,Western,Aboso,Accra,EMEA,11,5.36073000,-1.94856000,Aboso;Axim;Bibiani,"Aboso|(5.36073000,-1.94856000);Axim|(4.86641000,-2.24181000);Bibiani|(6.46346000,-2.31938000)"
+Ghana,GH,Western North,Aowin,Accra,EMEA,11,5.82143850,-2.82360430,Aowin;Bia East;Bia West,"Aowin|(5.82143850,-2.82360430);Bia East|(6.81614450,-3.00383950);Bia West|(6.56894170,-3.06628880)"
+Guadeloupe,GP,Basse-Terre,Basse-Terre,Basse-Terre,EMEA,29,15.99916310,-61.74998100,Baie-Mahault;Baillif;Basse-Terre,"Baie-Mahault|(16.24976070,-61.67750720);Baillif|(16.04973310,-61.75705910);Basse-Terre|(15.99916310,-61.74998100)"
+Guadeloupe,GP,Pointe-à-Pitre,Pointe-à-Pitre,Basse-Terre,EMEA,29,16.23313040,-61.56234850,Anse-Bertrand;Capesterre-de-Marie-Galante;Grand-Bourg,"Anse-Bertrand|(16.46681810,-61.55217680);Capesterre-de-Marie-Galante|(15.91763990,-61.27077860);Grand-Bourg|(15.90853800,-61.33406180)"
+Guatemala,GT,Alta Verapaz ,Cahabón,Guatemala City,EMEA,13,15.56667000,-89.81667000,Cahabón;Chahal Guatemala;Chisec,"Cahabón|(15.56667000,-89.81667000);Chahal Guatemala|(15.79122000,-89.60518000);Chisec|(15.81667000,-90.28333000)"
+Guatemala,GT,Baja Verapaz ,Cubulco,Guatemala City,EMEA,13,15.10452000,-90.62871000,Cubulco;El Chol;Granados,"Cubulco|(15.10452000,-90.62871000);El Chol|(14.96055000,-90.48799000);Granados|(14.91649000,-90.52292000)"
+Guatemala,GT,Chimaltenango ,Chimaltenango,Guatemala City,EMEA,13,14.66111000,-90.81944000,Acatenango;Chimaltenango;Comalapa,"Acatenango|(14.55451000,-90.94368000);Chimaltenango|(14.66111000,-90.81944000);Comalapa|(14.74086000,-90.88761000)"
+Guatemala,GT,Chiquimula ,Chiquimula,Guatemala City,EMEA,13,14.80000000,-89.54583000,Camotán;Chiquimula;Concepción Las Minas,"Camotán|(14.82017000,-89.37224000);Chiquimula|(14.80000000,-89.54583000);Concepción Las Minas|(14.52173000,-89.45717000)"
+Guatemala,GT,El Progreso ,El Jícaro,Guatemala City,EMEA,13,14.91667000,-89.90000000,El Jícaro;Guastatoya;Morazán,"El Jícaro|(14.91667000,-89.90000000);Guastatoya|(14.85417000,-90.06944000);Morazán|(14.93278000,-90.14306000)"
+Guatemala,GT,Escuintla ,Escuintla,Guatemala City,EMEA,13,14.30500000,-90.78500000,Escuintla;Guanagazapa;Iztapa,"Escuintla|(14.30500000,-90.78500000);Guanagazapa|(14.22528000,-90.64333000);Iztapa|(13.93333000,-90.70750000)"
+Guatemala,GT,Guatemala ,Amatitlán,Guatemala City,EMEA,13,14.47740000,-90.63489000,Amatitlán;Chinautla;Chuarrancho,"Amatitlán|(14.47740000,-90.63489000);Chinautla|(14.70289000,-90.49983000);Chuarrancho|(14.81794000,-90.51568000)"
+Guatemala,GT,Huehuetenango ,Huehuetenango,Guatemala City,EMEA,13,15.31918000,-91.47241000,Aguacatán;Barillas;Chiantla,"Aguacatán|(15.34222000,-91.31141000);Barillas|(15.80361000,-91.31583000);Chiantla|(15.35484000,-91.45807000)"
+Guatemala,GT,Izabal ,El Estor,Guatemala City,EMEA,13,15.53333000,-89.35000000,El Estor;Lívingston;Los Amates,"El Estor|(15.53333000,-89.35000000);Lívingston|(15.82826000,-88.75039000);Los Amates|(15.25645000,-89.09723000)"
+Guatemala,GT,Jalapa ,Jalapa,Guatemala City,EMEA,13,14.63472000,-89.98889000,Jalapa;Mataquescuintla;Monjas,"Jalapa|(14.63472000,-89.98889000);Mataquescuintla|(14.52917000,-90.18417000);Monjas|(14.50000000,-89.86667000)"
+Guatemala,GT,Jutiapa ,Jutiapa,Guatemala City,EMEA,13,14.29167000,-89.89583000,Agua Blanca;Asunción Mita;Atescatempa,"Agua Blanca|(14.50000000,-89.65000000);Asunción Mita|(14.33083000,-89.71083000);Atescatempa|(14.17444000,-89.74250000)"
+Guatemala,GT,Petén ,Dolores,Guatemala City,EMEA,13,16.51178000,-89.41704000,Dolores;Flores;La Libertad,"Dolores|(16.51178000,-89.41704000);Flores|(16.92258000,-89.89941000);La Libertad|(16.78850000,-90.11698000)"
+Guatemala,GT,Quetzaltenango ,Quetzaltenango,Guatemala City,EMEA,13,14.83472000,-91.51806000,Almolonga;Cabricán;Cajolá,"Almolonga|(14.81591000,-91.49464000);Cabricán|(15.07485000,-91.64800000);Cajolá|(14.92205000,-91.61478000)"
+Guatemala,GT,Quiché ,Canillá,Guatemala City,EMEA,13,15.16549000,-90.85256000,Canillá;Chajul;Chicamán,"Canillá|(15.16549000,-90.85256000);Chajul|(15.48523000,-91.03520000);Chicamán|(15.34786000,-90.79968000)"
+Guatemala,GT,Retalhuleu ,Retalhuleu,Guatemala City,EMEA,13,14.53611000,-91.67778000,Champerico;El Asintal;Municipio de San Felipe,"Champerico|(14.29337000,-91.91214000);El Asintal|(14.59626000,-91.72744000);Municipio de San Felipe|(14.63009000,-91.60261000)"
+Guatemala,GT,Sacatepéquez ,Alotenango,Guatemala City,EMEA,13,14.48028000,-90.80750000,Alotenango;Antigua Guatemala;Ciudad Vieja,"Alotenango|(14.48028000,-90.80750000);Antigua Guatemala|(14.56111000,-90.73444000);Ciudad Vieja|(14.52396000,-90.76308000)"
+Guatemala,GT,San Marcos ,San Marcos,Guatemala City,EMEA,13,14.96389000,-91.79444000,Catarina;Ciudad Tecún Umán;Comitancillo,"Catarina|(14.85354000,-92.07682000);Ciudad Tecún Umán|(14.67737000,-92.14039000);Comitancillo|(15.08937000,-91.74971000)"
+Guatemala,GT,Santa Rosa ,Barberena,Guatemala City,EMEA,13,14.30739000,-90.36156000,Barberena;Casillas;Chiquimulilla,"Barberena|(14.30739000,-90.36156000);Casillas|(14.42222000,-90.24417000);Chiquimulilla|(14.08380000,-90.38547000)"
+Guatemala,GT,Sololá ,Sololá,Guatemala City,EMEA,13,14.77222000,-91.18333000,Concepción;Municipio de Nahualá;Municipio de Panajachel,"Concepción|(14.78417000,-91.14754000);Municipio de Nahualá|(14.77548000,-91.41616000);Municipio de Panajachel|(14.74676000,-91.14935000)"
+Guatemala,GT,Suchitepéquez ,Chicacao,Guatemala City,EMEA,13,14.54295000,-91.32636000,Chicacao;Cuyotenango;Mazatenango,"Chicacao|(14.54295000,-91.32636000);Cuyotenango|(14.54006000,-91.57179000);Mazatenango|(14.53417000,-91.50333000)"
+Guatemala,GT,Totonicapán ,Totonicapán,Guatemala City,EMEA,13,14.91167000,-91.36111000,Momostenango;Municipio de Momostenango;Municipio de Santa María Chiquimula,"Momostenango|(15.04437000,-91.40864000);Municipio de Momostenango|(15.04726000,-91.40625000);Municipio de Santa María Chiquimula|(15.02886000,-91.32917000)"
+Guatemala,GT,Zacapa,,Guatemala City,EMEA,13,,,,
+Guyana,GY,Barima-Waini,Mabaruma,Georgetown,EMEA,5,8.20000000,-59.78333000,Mabaruma,"Mabaruma|(8.20000000,-59.78333000)"
+Guyana,GY,Cuyuni-Mazaruni,Bartica,Georgetown,EMEA,5,6.40799000,-58.62192000,Bartica,"Bartica|(6.40799000,-58.62192000)"
+Guyana,GY,Demerara-Mahaica,Georgetown,Georgetown,EMEA,5,6.80448000,-58.15527000,Georgetown;Mahaica Village,"Georgetown|(6.80448000,-58.15527000);Mahaica Village|(6.68405000,-57.92181000)"
+Guyana,GY,East Berbice-Corentyne,New Amsterdam,Georgetown,EMEA,5,6.24793000,-57.51710000,New Amsterdam;Skeldon,"New Amsterdam|(6.24793000,-57.51710000);Skeldon|(5.88333000,-57.13333000)"
+Guyana,GY,Essequibo Islands-West Demerara,Parika,Georgetown,EMEA,5,6.83712000,-58.42941000,Parika;Vreed-en-Hoop,"Parika|(6.83712000,-58.42941000);Vreed-en-Hoop|(6.80927000,-58.19798000)"
+Guyana,GY,Mahaica-Berbice,Mahaicony Village,Georgetown,EMEA,5,6.57633000,-57.80486000,Mahaicony Village;Rosignol,"Mahaicony Village|(6.57633000,-57.80486000);Rosignol|(6.27095000,-57.53697000)"
+Guyana,GY,Pomeroon-Supenaam,Anna Regina,Georgetown,EMEA,5,7.26439000,-58.50769000,Anna Regina,"Anna Regina|(7.26439000,-58.50769000)"
+Guyana,GY,Potaro-Siparuni,Mahdia,Georgetown,EMEA,5,5.26667000,-59.15000000,Mahdia,"Mahdia|(5.26667000,-59.15000000)"
+Guyana,GY,Upper Demerara-Berbice,Linden,Georgetown,EMEA,5,6.00809000,-58.30714000,Linden,"Linden|(6.00809000,-58.30714000)"
+Guyana,GY,Upper Takutu-Upper Essequibo,Lethem,Georgetown,EMEA,5,3.38333000,-59.80000000,Lethem,"Lethem|(3.38333000,-59.80000000)"
+Honduras,HN,Atlántida,Arizona,Tegucigalpa,EMEA,13,15.63333000,-87.31667000,Arizona;Atenas de San Cristóbal;Corozal,"Arizona|(15.63333000,-87.31667000);Atenas de San Cristóbal|(15.68333000,-87.31667000);Corozal|(15.80000000,-86.71667000)"
+Honduras,HN,Bay Islands,Coxen Hole,Tegucigalpa,EMEA,13,16.31759000,-86.53793000,Coxen Hole;French Harbor;Guanaja,"Coxen Hole|(16.31759000,-86.53793000);French Harbor|(16.35000000,-86.43333000);Guanaja|(16.44795000,-85.89431000)"
+Honduras,HN,Choluteca,Choluteca,Tegucigalpa,EMEA,13,13.28261000,-87.20119000,Apacilagua;Choluteca;Ciudad Choluteca,"Apacilagua|(13.45821000,-87.01122000);Choluteca|(13.28261000,-87.20119000);Ciudad Choluteca|(13.30028000,-87.19083000)"
+Honduras,HN,Colón,Balfate,Tegucigalpa,EMEA,13,15.75709000,-86.29048000,Balfate;Bonito Oriental;Corocito,"Balfate|(15.75709000,-86.29048000);Bonito Oriental|(15.74641000,-85.73610000);Corocito|(15.75000000,-85.78333000)"
+Honduras,HN,Comayagua,Comayagua,Tegucigalpa,EMEA,13,14.48412000,-87.60060000,Aguas del Padre;Ajuterique;Cerro Blanco,"Aguas del Padre|(14.56667000,-87.88333000);Ajuterique|(14.38333000,-87.70000000);Cerro Blanco|(14.66667000,-87.78333000)"
+Honduras,HN,Copán,Copán,Tegucigalpa,EMEA,13,14.83333000,-89.15000000,Agua Caliente;Buenos Aires;Cabañas,"Agua Caliente|(14.88333000,-88.81667000);Buenos Aires|(15.03333000,-88.96667000);Cabañas|(14.76000000,-89.06000000)"
+Honduras,HN,Cortés,Agua Azul,Tegucigalpa,EMEA,13,14.91667000,-87.96667000,Agua Azul;Agua Azul Rancho;Armenta,"Agua Azul|(14.91667000,-87.96667000);Agua Azul Rancho|(14.90000000,-87.95000000);Armenta|(15.50000000,-88.05000000)"
+Honduras,HN,El Paraíso,El Paraíso,Tegucigalpa,EMEA,13,13.85381000,-86.53094000,Alauca;Araulí;Cuyalí,"Alauca|(13.84020000,-86.69526000);Araulí|(13.95000000,-86.55000000);Cuyalí|(13.88333000,-86.55000000)"
+Honduras,HN,Francisco Morazán,Agalteca,Tegucigalpa,EMEA,13,14.45000000,-87.26667000,Agalteca;Alubarén;Cedros,"Agalteca|(14.45000000,-87.26667000);Alubarén|(13.78226000,-87.46990000);Cedros|(14.50464000,-87.21680000)"
+Honduras,HN,Gracias a Dios,Ahuas,Tegucigalpa,EMEA,13,15.46923000,-84.34479000,Ahuas;Auas;Auka,"Ahuas|(15.46923000,-84.34479000);Auas|(15.48333000,-84.33333000);Auka|(14.94087000,-83.83229000)"
+Honduras,HN,Intibucá,Intibucá,Tegucigalpa,EMEA,13,14.43000000,-88.17000000,Camasca;Colomoncagua;Concepción,"Camasca|(14.00000000,-88.38333000);Colomoncagua|(13.97245000,-88.27673000);Concepción|(14.04725000,-88.31942000)"
+Honduras,HN,La Paz,La Paz,Tegucigalpa,EMEA,13,14.31944000,-87.67917000,Aguanqueterique;Cabañas;Cane,"Aguanqueterique|(13.98606000,-87.64622000);Cabañas|(13.99419000,-88.02864000);Cane|(14.28333000,-87.66667000)"
+Honduras,HN,Lempira,Belén,Tegucigalpa,EMEA,13,14.50834000,-88.42819000,Belén;Candelaria;Cololaca,"Belén|(14.50834000,-88.42819000);Candelaria|(14.06072000,-88.55913000);Cololaca|(14.31189000,-88.87720000)"
+Honduras,HN,Ocotepeque,Antigua Ocotepeque,Tegucigalpa,EMEA,13,14.40000000,-89.20000000,Antigua Ocotepeque;Belén Gualcho;Concepción,"Antigua Ocotepeque|(14.40000000,-89.20000000);Belén Gualcho|(14.48333000,-88.80000000);Concepción|(14.52383000,-89.19371000)"
+Honduras,HN,Olancho,Arimís,Tegucigalpa,EMEA,13,14.78333000,-86.00000000,Arimís;Campamento;Catacamas,"Arimís|(14.78333000,-86.00000000);Campamento|(14.55000000,-86.65000000);Catacamas|(14.60384000,-85.54261000)"
+Honduras,HN,Santa Bárbara,Santa Bárbara,Tegucigalpa,EMEA,13,14.91944000,-88.23611000,Agualote;Arada;Atima,"Agualote|(15.33528000,-88.55306000);Arada|(14.85000000,-88.30000000);Atima|(14.93333000,-88.48333000)"
+Honduras,HN,Valle,Agua Fría,Tegucigalpa,EMEA,13,13.46889000,-87.55111000,Agua Fría;Alianza;Amapala,"Agua Fría|(13.46889000,-87.55111000);Alianza|(13.44815000,-87.68643000);Amapala|(13.29222000,-87.65389000)"
+Honduras,HN,Yoro,Yoro,Tegucigalpa,EMEA,13,15.13750000,-87.12778000,Agua Blanca Sur;Arenal;Armenia,"Agua Blanca Sur|(15.25000000,-87.88333000);Arenal|(15.35000000,-86.83333000);Armenia|(15.46667000,-86.36667000)"
+Kenya,KE,Baringo,Baringo,Nairobi,EMEA,14,0.46667000,35.96667000,Baringo;Eldama Ravine;Kabarnet,"Baringo|(0.46667000,35.96667000);Eldama Ravine|(0.05196000,35.72734000);Kabarnet|(0.49194000,35.74303000)"
+Kenya,KE,Bomet,Sotik,Nairobi,EMEA,14,-0.69069000,35.11102000,Sotik;Sotik Post,"Sotik|(-0.69069000,35.11102000);Sotik Post|(-0.78129000,35.34156000)"
+Kenya,KE,Bungoma,Bungoma,Nairobi,EMEA,14,0.56350000,34.56055000,Bungoma;Malikisi;Webuye,"Bungoma|(0.56350000,34.56055000);Malikisi|(0.67694000,34.42167000);Webuye|(0.60040000,34.77119000)"
+Kenya,KE,Busia,Busia,Nairobi,EMEA,14,0.46005000,34.11169000,Busia;Luanda;Lugulu,"Busia|(0.46005000,34.11169000);Luanda|(0.31354000,34.07146000);Lugulu|(0.39337000,34.30399000)"
+Kenya,KE,Elgeyo-Marakwet,Chebiemit,Nairobi,EMEA,14,1.05000000,35.40000000,Chebiemit;Chepkorio;Chesoi,"Chebiemit|(1.05000000,35.40000000);Chepkorio|(0.38330000,35.45000000);Chesoi|(1.15000000,35.65000000)"
+Kenya,KE,Embu,Embu,Nairobi,EMEA,14,-0.53987000,37.45743000,Embu,"Embu|(-0.53987000,37.45743000)"
+Kenya,KE,Garissa,Garissa,Nairobi,EMEA,14,-0.45275000,39.64601000,Garissa,"Garissa|(-0.45275000,39.64601000)"
+Kenya,KE,Homa Bay,Homa Bay,Nairobi,EMEA,14,-0.52731000,34.45714000,Homa Bay;Oyugis;Rachuonyo District,"Homa Bay|(-0.52731000,34.45714000);Oyugis|(-0.50974000,34.73067000);Rachuonyo District|(-0.44000000,34.73900000)"
+Kenya,KE,Isiolo,Isiolo,Nairobi,EMEA,14,0.35462000,37.58218000,Isiolo,"Isiolo|(0.35462000,37.58218000)"
+Kenya,KE,Kajiado,Kajiado,Nairobi,EMEA,14,-1.85238000,36.77683000,Kajiado;Magadi;Ngong,"Kajiado|(-1.85238000,36.77683000);Magadi|(-1.90122000,36.28700000);Ngong|(-1.35270000,36.66990000)"
+Kenya,KE,Kakamega,Kakamega,Nairobi,EMEA,14,0.28422000,34.75229000,Butere;Kakamega;Mumias,"Butere|(0.20694000,34.49006000);Kakamega|(0.28422000,34.75229000);Mumias|(0.33474000,34.48796000)"
+Kenya,KE,Kericho,Kericho,Nairobi,EMEA,14,-0.36774000,35.28314000,Kericho;Kipkelion;Litein,"Kericho|(-0.36774000,35.28314000);Kipkelion|(-0.19982000,35.46735000);Litein|(-0.58249000,35.18969000)"
+Kenya,KE,Kiambu,Kiambu,Nairobi,EMEA,14,-1.17139000,36.83556000,Kiambu;Kikuyu;Limuru,"Kiambu|(-1.17139000,36.83556000);Kikuyu|(-1.24627000,36.66291000);Limuru|(-1.11360000,36.64205000)"
+Kenya,KE,Kilifi,Kilifi,Nairobi,EMEA,14,-3.63045000,39.84992000,Iten;Kapsowar;Kilifi,"Iten|(0.67028000,35.50806000);Kapsowar|(0.97890000,35.55854000);Kilifi|(-3.63045000,39.84992000)"
+Kenya,KE,Kirinyaga,Kerugoya,Nairobi,EMEA,14,-0.49887000,37.28031000,Kerugoya;Sagana,"Kerugoya|(-0.49887000,37.28031000);Sagana|(-0.66806000,37.20875000)"
+Kenya,KE,Kisii,Kisii,Nairobi,EMEA,14,-0.68174000,34.76666000,Kisii;Ogembo,"Kisii|(-0.68174000,34.76666000);Ogembo|(-0.80116000,34.72579000)"
+Kenya,KE,Kisumu,Kisumu,Nairobi,EMEA,14,-0.10221000,34.76171000,Ahero;Kisumu;Muhoroni,"Ahero|(-0.17359000,34.91890000);Kisumu|(-0.10221000,34.76171000);Muhoroni|(-0.15816000,35.19645000)"
+Kenya,KE,Kitui,Kitui,Nairobi,EMEA,14,-1.36696000,38.01055000,Kitui;Mwingi,"Kitui|(-1.36696000,38.01055000);Mwingi|(-0.93605000,38.05955000)"
+Kenya,KE,Kwale,Kwale,Nairobi,EMEA,14,-4.17375000,39.45206000,Gazi;Kinango;Kwale,"Gazi|(-4.42402000,39.50588000);Kinango|(-4.13723000,39.31528000);Kwale|(-4.17375000,39.45206000)"
+Kenya,KE,Laikipia,Nanyuki,Nairobi,EMEA,14,0.00624000,37.07398000,Nanyuki;Nyahururu;Rumuruti,"Nanyuki|(0.00624000,37.07398000);Nyahururu|(0.03813000,36.36339000);Rumuruti|(0.27250000,36.53806000)"
+Kenya,KE,Lamu,Lamu,Nairobi,EMEA,14,-2.27169000,40.90201000,Lamu;Witu,"Lamu|(-2.27169000,40.90201000);Witu|(-2.38892000,40.43827000)"
+Kenya,KE,Machakos,Machakos,Nairobi,EMEA,14,-1.52233000,37.26521000,Athi River;Kangundo;Konza,"Athi River|(-1.45630000,36.97826000);Kangundo|(-1.30342000,37.34813000);Konza|(-1.73947000,37.13195000)"
+Kenya,KE,Makueni,Makueni Boma,Nairobi,EMEA,14,-1.80388000,37.62405000,Makueni Boma;Mtito Andei;Wote,"Makueni Boma|(-1.80388000,37.62405000);Mtito Andei|(-2.68987000,38.16687000);Wote|(-1.78079000,37.62882000)"
+Kenya,KE,Mandera,Mandera,Nairobi,EMEA,14,3.93726000,41.85688000,Mandera,"Mandera|(3.93726000,41.85688000)"
+Kenya,KE,Marsabit,Marsabit,Nairobi,EMEA,14,2.33468000,37.99086000,Marsabit;Moyale,"Marsabit|(2.33468000,37.99086000);Moyale|(3.52661000,39.05610000)"
+Kenya,KE,Meru,Meru,Nairobi,EMEA,14,0.04626000,37.65587000,Maua;Meru,"Maua|(0.23320000,37.94086000);Meru|(0.04626000,37.65587000)"
+Kenya,KE,Migori,Migori,Nairobi,EMEA,14,-1.06343000,34.47313000,Kihancha;Migori,"Kihancha|(-1.19347000,34.61967000);Migori|(-1.06343000,34.47313000)"
+Kenya,KE,Mombasa,Mombasa,Nairobi,EMEA,14,-4.05466000,39.66359000,Mombasa,"Mombasa|(-4.05466000,39.66359000)"
+Kenya,KE,Murang'a,Kangema,Nairobi,EMEA,14,-0.68553000,36.96463000,Kangema;Karuri;Maragua,"Kangema|(-0.68553000,36.96463000);Karuri|(-0.70000000,37.18333000);Maragua|(-0.79602000,37.13292000)"
+Kenya,KE,Nairobi City,Nairobi,Nairobi,EMEA,14,-1.28333000,36.81667000,Nairobi;Pumwani,"Nairobi|(-1.28333000,36.81667000);Pumwani|(-1.28333000,36.85000000)"
+Kenya,KE,Nakuru,Nakuru,Nairobi,EMEA,14,-0.30719000,36.07225000,Kijabe;Molo;Naivasha,"Kijabe|(-0.93334000,36.57233000);Molo|(-0.24849000,35.73194000);Naivasha|(-0.71383000,36.43261000)"
+Kenya,KE,Nandi,Kapsabet,Nairobi,EMEA,14,0.20387000,35.10500000,Kapsabet;Nandi Hills,"Kapsabet|(0.20387000,35.10500000);Nandi Hills|(0.10366000,35.18426000)"
+Kenya,KE,Narok,Narok,Nairobi,EMEA,14,-1.08083000,35.87111000,Narok,"Narok|(-1.08083000,35.87111000)"
+Kenya,KE,Nyamira,Nyamira,Nairobi,EMEA,14,-0.56333000,34.93583000,Keroka;Nyamira,"Keroka|(-0.77612000,34.94678000);Nyamira|(-0.56333000,34.93583000)"
+Kenya,KE,Nyandarua,Ol Kalou,Nairobi,EMEA,14,-0.27088000,36.37917000,Ol Kalou,"Ol Kalou|(-0.27088000,36.37917000)"
+Kenya,KE,Nyeri,Nyeri,Nairobi,EMEA,14,-0.42013000,36.94759000,Naro Moru;Nyeri;Othaya,"Naro Moru|(-0.16357000,37.01773000);Nyeri|(-0.42013000,36.94759000);Othaya|(-0.54655000,36.93178000)"
+Kenya,KE,Samburu,Maralal,Nairobi,EMEA,14,1.09667000,36.69806000,Maralal,"Maralal|(1.09667000,36.69806000)"
+Kenya,KE,Siaya,Siaya,Nairobi,EMEA,14,0.06070000,34.28806000,Bondo;Siaya;Yala,"Bondo|(0.23522000,34.28086000);Siaya|(0.06070000,34.28806000);Yala|(0.09438000,34.53602000)"
+Kenya,KE,Taita–Taveta,Bura,Nairobi,EMEA,14,-3.50000000,38.30000000,Bura;Chala;Maktau,"Bura|(-3.50000000,38.30000000);Chala|(-3.38330000,37.68330000);Maktau|(-3.40000000,38.13330000)"
+Kenya,KE,Tana River,Hola,Nairobi,EMEA,14,-1.48256000,40.03341000,Hola;Kipini,"Hola|(-1.48256000,40.03341000);Kipini|(-2.52565000,40.52620000)"
+Kenya,KE,Tharaka-Nithi,Chuka,Nairobi,EMEA,14,-0.33316000,37.64587000,Chuka,"Chuka|(-0.33316000,37.64587000)"
+Kenya,KE,Trans Nzoia,Kitale,Nairobi,EMEA,14,1.01572000,35.00622000,Kitale,"Kitale|(1.01572000,35.00622000)"
+Kenya,KE,Turkana,Lodwar,Nairobi,EMEA,14,3.11988000,35.59642000,Lodwar,"Lodwar|(3.11988000,35.59642000)"
+Kenya,KE,Uasin Gishu,Eldoret,Nairobi,EMEA,14,0.52036000,35.26993000,Eldoret,"Eldoret|(0.52036000,35.26993000)"
+Kenya,KE,Vihiga,Chavakali,Nairobi,EMEA,14,0.11670000,34.70000000,Chavakali;Esabalu;Gambogi,"Chavakali|(0.11670000,34.70000000);Esabalu|(0.01670000,34.61670000);Gambogi|(0.08330000,34.80000000)"
+Kenya,KE,Wajir,Wajir,Nairobi,EMEA,14,1.74710000,40.05732000,Wajir,"Wajir|(1.74710000,40.05732000)"
+Kenya,KE,West Pokot,Chepareria,Nairobi,EMEA,14,1.30583000,35.20365000,Chepareria;Kapenguria;Taveta,"Chepareria|(1.30583000,35.20365000);Kapenguria|(1.23889000,35.11194000);Taveta|(-3.39879000,37.68336000)"
+Lesotho,LS,Berea,Teyateyaneng,Maseru,EMEA,18,-29.14719000,27.74895000,Teyateyaneng,"Teyateyaneng|(-29.14719000,27.74895000)"
+Lesotho,LS,Butha-Buthe,Butha-Buthe,Maseru,EMEA,18,-28.76659000,28.24937000,Butha-Buthe,"Butha-Buthe|(-28.76659000,28.24937000)"
+Lesotho,LS,Leribe,Leribe,Maseru,EMEA,18,-28.87185000,28.04501000,Leribe;Maputsoe,"Leribe|(-28.87185000,28.04501000);Maputsoe|(-28.88660000,27.89915000)"
+Lesotho,LS,Mafeteng,Mafeteng,Maseru,EMEA,18,-29.82299000,27.23744000,Mafeteng,"Mafeteng|(-29.82299000,27.23744000)"
+Lesotho,LS,Maseru,Maseru,Maseru,EMEA,18,-29.31667000,27.48333000,Maseru;Nako,"Maseru|(-29.31667000,27.48333000);Nako|(-29.61667000,27.76667000)"
+Lesotho,LS,Mohale's Hoek,Mohale’s Hoek,Maseru,EMEA,18,-30.15137000,27.47691000,Mohale’s Hoek,"Mohale’s Hoek|(-30.15137000,27.47691000)"
+Lesotho,LS,Mokhotlong,Mokhotlong,Maseru,EMEA,18,-29.28939000,29.06751000,Mokhotlong,"Mokhotlong|(-29.28939000,29.06751000)"
+Lesotho,LS,Qacha's Nek,Qacha’s Nek,Maseru,EMEA,18,-30.11537000,28.68936000,Qacha’s Nek,"Qacha’s Nek|(-30.11537000,28.68936000)"
+Lesotho,LS,Quthing,Quthing,Maseru,EMEA,18,-30.40001000,27.70027000,Quthing,"Quthing|(-30.40001000,27.70027000)"
+Lesotho,LS,Thaba-Tseka,Thaba-Tseka,Maseru,EMEA,18,-29.52204000,28.60840000,Thaba-Tseka,"Thaba-Tseka|(-29.52204000,28.60840000)"
+Madagascar,MG,Antananarivo,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Antsiranana,Ampasimanolotra,Antananarivo,EMEA,14,-18.81667000,49.06667000,Ampasimanolotra;Andovoranto;Mahanoro,"Ampasimanolotra|(-18.81667000,49.06667000);Andovoranto|(-18.95443000,49.10940000);Mahanoro|(-19.90000000,48.80000000)"
+Madagascar,MG,Fianarantsoa,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Mahajanga,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Toamasina,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Toliara,,Antananarivo,EMEA,14,,,,
+Malawi,MW,Balaka,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Blantyre,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Central,Chipoka,Lilongwe,EMEA,14,-13.99329000,34.51566000,Chipoka;Dedza;Dedza District,"Chipoka|(-13.99329000,34.51566000);Dedza|(-14.37790000,34.33322000);Dedza District|(-14.26273000,34.18559000)"
+Malawi,MW,Chikwawa,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Chiradzulu,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Chitipa,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Dedza,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Dowa,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Karonga,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Kasungu,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Likoma,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Lilongwe,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Machinga,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mangochi,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mchinji,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mulanje,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mwanza,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mzimba,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Neno,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Nkhata Bay,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Nkhotakota,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Northern,Chitipa,Lilongwe,EMEA,14,-9.70237000,33.26969000,Chitipa;Chitipa District;Karonga,"Chitipa|(-9.70237000,33.26969000);Chitipa District|(-9.92727000,33.42541000);Karonga|(-9.93333000,33.93333000)"
+Malawi,MW,Nsanje,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Ntcheu,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Ntchisi,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Phalombe,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Rumphi,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Salima,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Southern,Balaka,Lilongwe,EMEA,14,-14.97928000,34.95575000,Balaka;Balaka District;Blantyre,"Balaka|(-14.97928000,34.95575000);Balaka District|(-15.04839000,35.05910000);Blantyre|(-15.78499000,35.00854000)"
+Malawi,MW,Thyolo,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Zomba,,Lilongwe,EMEA,14,,,,
+Mali,ML,Bamako,Bamako,Bamako,EMEA,11,12.65000000,-8.00000000,Bamako,"Bamako|(12.65000000,-8.00000000)"
+Mali,ML,Gao,Gao,Bamako,EMEA,11,16.27167000,-0.04472000,Ansongo;Cercle de Bourem;Gao,"Ansongo|(15.65970000,0.50220000);Cercle de Bourem|(17.71192000,-0.34284000);Gao|(16.27167000,-0.04472000)"
+Mali,ML,Kayes,Kayes,Bamako,EMEA,11,14.44693000,-11.44448000,Bafoulabé;Kayes;Kita,"Bafoulabé|(13.80650000,-10.83210000);Kayes|(14.44693000,-11.44448000);Kita|(13.03490000,-9.48950000)"
+Mali,ML,Kidal,Kidal,Bamako,EMEA,11,18.44111000,1.40778000,Abeïbara;Cercle d’Abeïbara;Kidal,"Abeïbara|(19.11667000,1.75000000);Cercle d’Abeïbara|(19.48878000,2.20025000);Kidal|(18.44111000,1.40778000)"
+Mali,ML,Koulikoro,Koulikoro,Bamako,EMEA,11,12.86273000,-7.55985000,Banamba;Kangaba;Kati,"Banamba|(13.54773000,-7.44808000);Kangaba|(11.93333000,-8.41667000);Kati|(12.74409000,-8.07257000)"
+Mali,ML,Ménaka,,Bamako,EMEA,11,,,,
+Mali,ML,Mopti,Mopti,Bamako,EMEA,11,14.48430000,-4.18296000,Bandiagara;Djénné;Douentza,"Bandiagara|(14.35005000,-3.61038000);Djénné|(13.90608000,-4.55332000);Douentza|(15.00155000,-2.94978000)"
+Mali,ML,Ségou,Ségou,Bamako,EMEA,11,13.43170000,-6.21570000,Baroueli;Cercle de San;Ké-Macina,"Baroueli|(13.07489000,-6.57171000);Cercle de San|(13.17895000,-5.01617000);Ké-Macina|(13.96410000,-5.35791000)"
+Mali,ML,Sikasso,Sikasso,Bamako,EMEA,11,11.31755000,-5.66654000,Bougouni;Kolondiéba;Koutiala,"Bougouni|(11.41769000,-7.48323000);Kolondiéba|(11.08943000,-6.89290000);Koutiala|(12.39173000,-5.46421000)"
+Mali,ML,Taoudénit,,Bamako,EMEA,11,,,,
+Mali,ML,Tombouctou,Araouane,Bamako,EMEA,11,18.90476000,-3.52649000,Araouane;Cercle de Goundam;Dire,"Araouane|(18.90476000,-3.52649000);Cercle de Goundam|(18.60035000,-4.99306000);Dire|(16.28017000,-3.31302000)"
+Martinique,MQ,Fort-de-France,Fort-de-France,Fort-de-France,EMEA,29,14.64924180,-61.10984450,Fort-de-France;Le Lamentin;Saint-Joseph,"Fort-de-France|(14.64924180,-61.10984450);Le Lamentin|(14.62308620,-61.03347490);Saint-Joseph|(14.68353400,-61.08186620)"
+Martinique,MQ,La Trinité,La Trinité,Fort-de-France,EMEA,29,14.73804150,-61.02929560,Basse-Pointe;Grand'Rivière;Gros-Morne,"Basse-Pointe|(14.84097080,-61.16485230);Grand'Rivière|(14.84696630,-61.20427640);Gros-Morne|(14.70841840,-61.11271220)"
+Martinique,MQ,Le Marin,Le Marin,Fort-de-France,EMEA,29,14.48221690,-60.90011410,Ducos;Le Diamant;Le François,"Ducos|(14.57854420,-61.00973860);Le Diamant|(14.47680040,-61.05973840);Le François|(14.60928850,-60.97999110)"
+Martinique,MQ,Saint-Pierre,Saint-Pierre,Fort-de-France,EMEA,29,14.77167190,-61.21475010,Bellefontaine;Case-Pilote;Fonds-Saint-Denis,"Bellefontaine|(14.67474760,-61.16653080);Case-Pilote|(14.65933990,-61.15026120);Fonds-Saint-Denis|(14.72275460,-61.16189190)"
+Mayotte,YT,Acoua,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Bandraboua,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Bandrélé,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Boueni,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Chiconi,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Chirongui,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Dembeni,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Dzaoudzi,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Kani Keli,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Koungou,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,M'Tsangamouji,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Mamoudzou,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Mtsamboro,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Ouangani,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Pamandzi,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Sada,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Tsingoni,,Mamoudzou,EMEA,14,,,,
+Montserrat,MS,Saint Anthony,,Plymouth,EMEA,29,,,,
+Montserrat,MS,Saint Georges,,Plymouth,EMEA,29,,,,
+Montserrat,MS,Saint Peter,,Plymouth,EMEA,29,,,,
+Mozambique,MZ,Cabo Delgado,Chiure,Maputo,EMEA,14,-13.46665000,39.70317000,Chiure;Mocímboa;Montepuez,"Chiure|(-13.46665000,39.70317000);Mocímboa|(-11.31667000,40.35000000);Montepuez|(-13.12556000,38.99972000)"
+Mozambique,MZ,Gaza,Chibuto,Maputo,EMEA,14,-24.68667000,33.53056000,Chibuto;Chokwé;Macia,"Chibuto|(-24.68667000,33.53056000);Chokwé|(-24.53333000,32.98333000);Macia|(-25.02694000,33.09889000)"
+Mozambique,MZ,Inhambane,Inhambane,Maputo,EMEA,14,-23.86500000,35.38333000,Inhambane;Maxixe,"Inhambane|(-23.86500000,35.38333000);Maxixe|(-23.85972000,35.34722000)"
+Mozambique,MZ,Manica,Chimoio,Maputo,EMEA,14,-19.11639000,33.48333000,Chimoio,"Chimoio|(-19.11639000,33.48333000)"
+Mozambique,MZ,Maputo,Boane District,Maputo,EMEA,14,-26.02900000,32.38900000,Boane District;Concelho de Matola;Magude District,"Boane District|(-26.02900000,32.38900000);Concelho de Matola|(-25.83472000,32.49516000);Magude District|(-25.02389000,32.65150000)"
+Mozambique,MZ,Maputo,Maputo,Maputo,EMEA,14,-25.96553000,32.58322000,KaTembe;Maputo,"KaTembe|(-26.02985000,32.53204000);Maputo|(-25.96553000,32.58322000)"
+Mozambique,MZ,Nampula,Nampula,Maputo,EMEA,14,-15.11646000,39.26660000,António Enes;Ilha de Moçambique;Mutuáli,"António Enes|(-16.23250000,39.90861000);Ilha de Moçambique|(-15.03417000,40.73583000);Mutuáli|(-14.87056000,37.00444000)"
+Mozambique,MZ,Niassa,Cuamba,Maputo,EMEA,14,-14.80306000,36.53722000,Cuamba;Lichinga;Mandimba,"Cuamba|(-14.80306000,36.53722000);Lichinga|(-13.31278000,35.24056000);Mandimba|(-14.35250000,35.65056000)"
+Mozambique,MZ,Sofala,Beira,Maputo,EMEA,14,-19.84361000,34.83889000,Beira;Dondo;Nhamatanda District,"Beira|(-19.84361000,34.83889000);Dondo|(-19.60944000,34.74306000);Nhamatanda District|(-19.34900000,34.26800000)"
+Mozambique,MZ,Tete,Tete,Maputo,EMEA,14,-16.15639000,33.58667000,Tete,"Tete|(-16.15639000,33.58667000)"
+Mozambique,MZ,Zambezia,Alto Molócuè,Maputo,EMEA,14,-15.64932000,37.66384000,Alto Molócuè;Chinde;Quelimane,"Alto Molócuè|(-15.64932000,37.66384000);Chinde|(-18.58111000,36.45861000);Quelimane|(-17.87861000,36.88833000)"
+Nicaragua,NI,Boaco,Boaco,Managua,EMEA,13,12.47224000,-85.65860000,Boaco;Camoapa;San José de los Remates,"Boaco|(12.47224000,-85.65860000);Camoapa|(12.38383000,-85.51277000);San José de los Remates|(12.59750000,-85.76174000)"
+Nicaragua,NI,Carazo,Diriamba,Managua,EMEA,13,11.85812000,-86.23922000,Diriamba;Dolores;El Rosario,"Diriamba|(11.85812000,-86.23922000);Dolores|(11.85672000,-86.21552000);El Rosario|(11.77756000,-86.37374000)"
+Nicaragua,NI,Chinandega,Chinandega,Managua,EMEA,13,12.62937000,-87.13105000,Chichigalpa;Chinandega;Cinco Pinos,"Chichigalpa|(12.57758000,-87.02705000);Chinandega|(12.62937000,-87.13105000);Cinco Pinos|(13.22956000,-86.86808000)"
+Nicaragua,NI,Chontales,Acoyapa,Managua,EMEA,13,11.97028000,-85.17113000,Acoyapa;Comalapa;Cuapa,"Acoyapa|(11.97028000,-85.17113000);Comalapa|(12.28345000,-85.51081000);Cuapa|(12.26875000,-85.38205000)"
+Nicaragua,NI,Estelí,Estelí,Managua,EMEA,13,13.09185000,-86.35384000,Condega;Estelí;La Trinidad,"Condega|(13.36502000,-86.39846000);Estelí|(13.09185000,-86.35384000);La Trinidad|(12.96881000,-86.23534000)"
+Nicaragua,NI,Granada,Granada,Managua,EMEA,13,11.92988000,-85.95602000,Diriá;Diriomo;Granada,"Diriá|(11.88420000,-86.05508000);Diriomo|(11.87631000,-86.05184000);Granada|(11.92988000,-85.95602000)"
+Nicaragua,NI,Jinotega,Jinotega,Managua,EMEA,13,13.09103000,-86.00234000,El Cuá;Jinotega;La Concordia,"El Cuá|(13.41667000,-85.75000000);Jinotega|(13.09103000,-86.00234000);La Concordia|(13.19528000,-86.16659000)"
+Nicaragua,NI,León,León,Managua,EMEA,13,12.43787000,-86.87804000,Achuapa;El Jicaral;El Sauce,"Achuapa|(13.05370000,-86.59004000);El Jicaral|(12.72676000,-86.38057000);El Sauce|(12.88687000,-86.53903000)"
+Nicaragua,NI,Madriz,Las Sabanas,Managua,EMEA,13,13.34302000,-86.62184000,Las Sabanas;Palacagüina;San José de Cusmapa,"Las Sabanas|(13.34302000,-86.62184000);Palacagüina|(13.45566000,-86.40622000);San José de Cusmapa|(13.28841000,-86.65539000)"
+Nicaragua,NI,Managua,Managua,Managua,EMEA,13,12.13282000,-86.25040000,Ciudad Sandino;El Crucero;Managua,"Ciudad Sandino|(12.15889000,-86.34417000);El Crucero|(11.99008000,-86.30954000);Managua|(12.13282000,-86.25040000)"
+Nicaragua,NI,Masaya,Masaya,Managua,EMEA,13,11.97444000,-86.09417000,Catarina;La Concepción;Masatepe,"Catarina|(11.91197000,-86.07383000);La Concepción|(11.93711000,-86.18976000);Masatepe|(11.91445000,-86.14458000)"
+Nicaragua,NI,Matagalpa,Matagalpa,Managua,EMEA,13,12.92559000,-85.91747000,Ciudad Darío;Matagalpa;Matiguás,"Ciudad Darío|(12.73143000,-86.12402000);Matagalpa|(12.92559000,-85.91747000);Matiguás|(12.83734000,-85.46218000)"
+Nicaragua,NI,North Caribbean Coast,Bonanza,Managua,EMEA,13,14.02885000,-84.59103000,Bonanza;Prinzapolka;Puerto Cabezas,"Bonanza|(14.02885000,-84.59103000);Prinzapolka|(13.40708000,-83.56452000);Puerto Cabezas|(14.03507000,-83.38882000)"
+Nicaragua,NI,Nueva Segovia,Ciudad Antigua,Managua,EMEA,13,13.63929030,-86.31189830,Ciudad Antigua;Dipilto;El Jícaro,"Ciudad Antigua|(13.63929030,-86.31189830);Dipilto|(13.72225520,-86.51366060);El Jícaro|(13.72222480,-86.14115420)"
+Nicaragua,NI,Río San Juan,El Almendro,Managua,EMEA,13,11.67859000,-84.70269000,El Almendro;Greytown;Morrito,"El Almendro|(11.67859000,-84.70269000);Greytown|(10.94684000,-83.73467000);Morrito|(11.62118000,-85.08052000)"
+Nicaragua,NI,Rivas,Rivas,Managua,EMEA,13,11.43716000,-85.82632000,Altagracia;Belén;Buenos Aires,"Altagracia|(11.56615000,-85.57840000);Belén|(11.50299000,-85.88935000);Buenos Aires|(11.46916000,-85.81661000)"
+Nicaragua,NI,South Caribbean Coast,Bluefields,Managua,EMEA,13,12.01366000,-83.76353000,Bluefields;Bocana de Paiwas;Corn Island,"Bluefields|(12.01366000,-83.76353000);Bocana de Paiwas|(12.78571000,-85.12269000);Corn Island|(12.17575000,-83.06145000)"
+Niger,NE,Agadez,Agadez,Niamey,EMEA,11,16.97333000,7.99111000,Agadez;Alaghsas;Arlit,"Agadez|(16.97333000,7.99111000);Alaghsas|(17.01870000,8.01680000);Arlit|(18.83409000,7.43327000)"
+Niger,NE,Diffa,Diffa,Niamey,EMEA,11,13.31536000,12.61135000,Département de Diffa;Département de Maïné-Soroa;Département de Nguigmi,"Département de Diffa|(13.66667000,12.50000000);Département de Maïné-Soroa|(13.31206000,12.08321000);Département de Nguigmi|(14.20753000,13.12177000)"
+Niger,NE,Dosso,Dosso,Niamey,EMEA,11,13.04900000,3.19370000,Boboye Department;Département de Dogondoutchi;Département de Dosso,"Boboye Department|(13.08167000,2.91083000);Département de Dogondoutchi|(13.50000000,4.00000000);Département de Dosso|(12.83333000,3.33333000)"
+Niger,NE,Maradi,Maradi,Niamey,EMEA,11,13.50000000,7.10174000,Aguié;Dakoro;Département d’Aguié,"Aguié|(13.50601000,7.77863000);Dakoro|(14.51056000,6.76500000);Département d’Aguié|(13.46976000,7.74219000)"
+Niger,NE,Tahoua,Tahoua,Niamey,EMEA,11,14.88880000,5.26920000,Abalak;Birni N Konni;Bouza,"Abalak|(15.41618000,6.16975000);Birni N Konni|(13.79599000,5.25026000);Bouza|(14.42293000,6.04278000)"
+Niger,NE,Tillabéri,Tillabéri,Niamey,EMEA,11,14.20711000,1.45418000,Ayorou;Balleyara;Département de Filingué,"Ayorou|(14.73075000,0.91739000);Balleyara|(13.72848000,2.87503000);Département de Filingué|(14.31645000,3.23611000)"
+Niger,NE,Zinder,Zinder,Niamey,EMEA,11,13.80716000,8.98810000,Département de Gouré;Département de Kantché;Département de Tânout,"Département de Gouré|(14.01618000,10.14722000);Département de Kantché|(13.40000000,8.60000000);Département de Tânout|(14.75000000,8.33333000)"
+Panama,PA,Bocas del Toro,Bocas del Toro,Panama City,EMEA,13,9.34031000,-82.24204000,Almirante;Barranco;Barranco Adentro,"Almirante|(9.30091000,-82.40180000);Barranco|(9.51984000,-82.70424000);Barranco Adentro|(9.52757000,-82.73344000)"
+Panama,PA,Chiriquí Province,Alanje,Panama City,EMEA,13,8.39791000,-82.55947000,Alanje;Algarrobos Arriba;Alto Boquete,"Alanje|(8.39791000,-82.55947000);Algarrobos Arriba|(8.51550000,-82.42263000);Alto Boquete|(8.73458000,-82.43213000)"
+Panama,PA,Coclé,Coclé,Panama City,EMEA,13,8.45601000,-80.42899000,Aguadulce;Aguas Blancas;Alto de La Estancia,"Aguadulce|(8.24183000,-80.54609000);Aguas Blancas|(8.50351000,-80.31169000);Alto de La Estancia|(8.58792000,-80.18443000)"
+Panama,PA,Colón,Colón,Panama City,EMEA,13,9.35451000,-79.90011000,Buena Vista;Cativá;Coclé del Norte,"Buena Vista|(9.27356000,-79.69551000);Cativá|(9.36218000,-79.83232000);Coclé del Norte|(9.07540000,-80.57177000)"
+Panama,PA,Darién,Boca de Cupé,Panama City,EMEA,13,8.03003000,-77.58978000,Boca de Cupé;Camogantí;Cucunatí,"Boca de Cupé|(8.03003000,-77.58978000);Camogantí|(8.04171000,-77.88682000);Cucunatí|(8.57508000,-78.25671000)"
+Panama,PA,Emberá-Wounaan Comarca,Bayamón,Panama City,EMEA,13,7.96817000,-78.21648000,Bayamón;Cémaco;Corozal,"Bayamón|(7.96817000,-78.21648000);Cémaco|(8.08285000,-77.54210000);Corozal|(8.20108000,-77.59637000)"
+Panama,PA,Guna,Achutupo,Panama City,EMEA,13,9.19827000,-77.98729000,Achutupo;Ailigandí;Cartí Sugdup,"Achutupo|(9.19827000,-77.98729000);Ailigandí|(9.22810000,-78.02778000);Cartí Sugdup|(9.46460000,-78.95931000)"
+Panama,PA,Herrera,Boca de Parita,Panama City,EMEA,13,8.00796000,-80.45320000,Boca de Parita;Cabuya;Cerro Largo,"Boca de Parita|(8.00796000,-80.45320000);Cabuya|(8.03138000,-80.63227000);Cerro Largo|(7.83377000,-80.83168000)"
+Panama,PA,Los Santos,Los Santos,Panama City,EMEA,13,7.93333000,-80.41667000,Agua Buena;Ave María;Bahía Honda,"Agua Buena|(7.83465000,-80.39405000);Ave María|(7.32481000,-80.45361000);Bahía Honda|(7.70517000,-80.45342000)"
+Panama,PA,Ngöbe-Buglé Comarca,Bahía Azul,Panama City,EMEA,13,9.14176000,-81.89425000,Bahía Azul;Besiko;Bisira,"Bahía Azul|(9.14176000,-81.89425000);Besiko|(8.54863000,-82.08980000);Bisira|(8.89553000,-81.85352000)"
+Panama,PA,Panamá,Panamá,Panama City,EMEA,13,8.99360000,-79.51973000,Alcalde Díaz;Ancón;Brujas,"Alcalde Díaz|(9.12016000,-79.55641000);Ancón|(8.96015000,-79.55140000);Brujas|(8.58536000,-78.53008000)"
+Panama,PA,Panamá Oeste,Alto del Espino,Panama City,EMEA,13,8.84213000,-79.84551000,Alto del Espino;Altos de San Francisco;Arenosa,"Alto del Espino|(8.84213000,-79.84551000);Altos de San Francisco|(8.86167000,-79.79000000);Arenosa|(9.03978000,-79.95128000)"
+Panama,PA,Veraguas,Alto de Jesús,Panama City,EMEA,13,8.26152000,-81.48412000,Alto de Jesús;Arenas;Atalaya,"Alto de Jesús|(8.26152000,-81.48412000);Arenas|(7.36865000,-80.86268000);Atalaya|(8.04213000,-80.92528000)"
+Paraguay,PY,Alto Paraguay,Capitán Pablo Lagerenza,Asuncion,EMEA,5,-19.91667000,-60.78333000,Capitán Pablo Lagerenza;Fuerte Olimpo,"Capitán Pablo Lagerenza|(-19.91667000,-60.78333000);Fuerte Olimpo|(-21.04153000,-57.87377000)"
+Paraguay,PY,Alto Paraná,Cedrales,Asuncion,EMEA,5,-25.65668000,-54.72272000,Cedrales;Ciudad del Este;Colonia Minga Porá,"Cedrales|(-25.65668000,-54.72272000);Ciudad del Este|(-25.50972000,-54.61111000);Colonia Minga Porá|(-24.86667000,-54.90000000)"
+Paraguay,PY,Amambay,Bella Vista,Asuncion,EMEA,5,-22.13333000,-56.51667000,Bella Vista;Capitán Bado;Pedro Juan Caballero,"Bella Vista|(-22.13333000,-56.51667000);Capitán Bado|(-23.26667000,-55.53333000);Pedro Juan Caballero|(-22.54722000,-55.73333000)"
+Paraguay,PY,Asuncion,,Asuncion,EMEA,5,,,,
+Paraguay,PY,Boquerón,Colonia Menno,Asuncion,EMEA,5,-22.36667000,-59.81667000,Colonia Menno;Colonia Neuland;Filadelfia,"Colonia Menno|(-22.36667000,-59.81667000);Colonia Neuland|(-22.66667000,-60.11667000);Filadelfia|(-22.33936000,-60.03157000)"
+Paraguay,PY,Caaguazú,Caaguazú,Asuncion,EMEA,5,-25.47104000,-56.01603000,Caaguazú;Carayaó;Cecilio Baez,"Caaguazú|(-25.47104000,-56.01603000);Carayaó|(-25.19750000,-56.39878000);Cecilio Baez|(-25.07158000,-56.24386000)"
+Paraguay,PY,Caazapá,Caazapá,Asuncion,EMEA,5,-26.19583000,-56.36806000,Abaí;Buena Vista;Caazapá,"Abaí|(-26.03333000,-55.93333000);Buena Vista|(-26.18387000,-56.08171000);Caazapá|(-26.19583000,-56.36806000)"
+Paraguay,PY,Canindeyú,Colonia Catuete,Asuncion,EMEA,5,-24.13333000,-54.61667000,Colonia Catuete;Corpus Christi;La Paloma,"Colonia Catuete|(-24.13333000,-54.61667000);Corpus Christi|(-24.08040000,-54.93933000);La Paloma|(-24.12957000,-54.61376000)"
+Paraguay,PY,Central,Areguá,Asuncion,EMEA,5,-25.31250000,-57.38472000,Areguá;Capiatá;Fernando de la Mora,"Areguá|(-25.31250000,-57.38472000);Capiatá|(-25.35520000,-57.44545000);Fernando de la Mora|(-25.33860000,-57.52167000)"
+Paraguay,PY,Concepción,Concepción,Asuncion,EMEA,5,-23.39985000,-57.43236000,Belén;Concepción;Horqueta,"Belén|(-23.46611000,-57.26194000);Concepción|(-23.39985000,-57.43236000);Horqueta|(-23.34278000,-57.05972000)"
+Paraguay,PY,Cordillera,Altos,Asuncion,EMEA,5,-25.26263000,-57.25443000,Altos;Arroyos y Esteros;Atyrá,"Altos|(-25.26263000,-57.25443000);Arroyos y Esteros|(-25.05478000,-57.09873000);Atyrá|(-25.27876000,-57.17192000)"
+Paraguay,PY,Guairá,Colonia Mauricio José Troche,Asuncion,EMEA,5,-25.56667000,-56.28333000,Colonia Mauricio José Troche;Coronel Martínez;Independencia,"Colonia Mauricio José Troche|(-25.56667000,-56.28333000);Coronel Martínez|(-25.75862000,-56.61677000);Independencia|(-25.69100000,-56.26781000)"
+Paraguay,PY,Itapúa,Arquitecto Tomás Romero Pereira,Asuncion,EMEA,5,-26.48333000,-55.25000000,Arquitecto Tomás Romero Pereira;Bella Vista;Capitán Miranda,"Arquitecto Tomás Romero Pereira|(-26.48333000,-55.25000000);Bella Vista|(-27.05000000,-55.55000000);Capitán Miranda|(-27.20000000,-55.80000000)"
+Paraguay,PY,Misiones,Juan de Ayolas,Asuncion,EMEA,5,-27.38662000,-56.84724000,Juan de Ayolas;San Juan Bautista;San Miguel,"Juan de Ayolas|(-27.38662000,-56.84724000);San Juan Bautista|(-26.66944000,-57.14583000);San Miguel|(-26.50000000,-57.05000000)"
+Paraguay,PY,Ñeembucú,Cerrito,Asuncion,EMEA,5,-27.34215000,-57.64119000,Cerrito;General José Eduvigis Díaz;Pilar,"Cerrito|(-27.34215000,-57.64119000);General José Eduvigis Díaz|(-27.20136000,-58.36740000);Pilar|(-26.85874000,-58.30639000)"
+Paraguay,PY,Paraguarí,Paraguarí,Asuncion,EMEA,5,-25.62083000,-57.14722000,Acahay;Caapucú;Carapeguá,"Acahay|(-25.91667000,-57.15000000);Caapucú|(-26.23523000,-57.18212000);Carapeguá|(-25.80000000,-57.23333000)"
+Paraguay,PY,Presidente Hayes,Benjamín Aceval,Asuncion,EMEA,5,-24.96667000,-57.56667000,Benjamín Aceval;Nanawua;Villa Hayes,"Benjamín Aceval|(-24.96667000,-57.56667000);Nanawua|(-25.27930000,-57.70307000);Villa Hayes|(-25.09306000,-57.52361000)"
+Paraguay,PY,San Pedro,Antequera,Asuncion,EMEA,5,-24.08526000,-57.20221000,Antequera;Capiíbary;Colonia Nueva Germania,"Antequera|(-24.08526000,-57.20221000);Capiíbary|(-24.80000000,-56.03333000);Colonia Nueva Germania|(-23.91137000,-56.70091000)"
+Rwanda,RW,Eastern,Kibungo,Kigali,EMEA,14,-2.15970000,30.54270000,Kibungo;Rwamagana,"Kibungo|(-2.15970000,30.54270000);Rwamagana|(-1.94870000,30.43470000)"
+Rwanda,RW,Kigali,Kigali,Kigali,EMEA,14,-1.94995000,30.05885000,Kigali,"Kigali|(-1.94995000,30.05885000)"
+Rwanda,RW,Northern,Byumba,Kigali,EMEA,14,-1.57630000,30.06750000,Byumba;Musanze,"Byumba|(-1.57630000,30.06750000);Musanze|(-1.49984000,29.63497000)"
+Rwanda,RW,Southern,Butare,Kigali,EMEA,14,-2.59667000,29.73944000,Butare;Eglise Catholique Centrale GIKO;Gitarama,"Butare|(-2.59667000,29.73944000);Eglise Catholique Centrale GIKO|(-1.93653000,29.80610000);Gitarama|(-2.07444000,29.75667000)"
+Rwanda,RW,Western,Cyangugu,Kigali,EMEA,14,-2.48460000,28.90750000,Cyangugu;Gisenyi;Kibuye,"Cyangugu|(-2.48460000,28.90750000);Gisenyi|(-1.70278000,29.25639000);Kibuye|(-2.06028000,29.34778000)"
+Seychelles,SC,Anse Boileau,Anse Boileau,Victoria,EMEA,14,-4.71667000,55.48333000,Anse Boileau,"Anse Boileau|(-4.71667000,55.48333000)"
+Seychelles,SC,Anse Royale,Anse Royale,Victoria,EMEA,14,-4.73333000,55.51667000,Anse Royale,"Anse Royale|(-4.73333000,55.51667000)"
+Seychelles,SC,Anse-aux-Pins,,Victoria,EMEA,14,,,,
+Seychelles,SC,Au Cap,,Victoria,EMEA,14,,,,
+Seychelles,SC,Baie Lazare,,Victoria,EMEA,14,,,,
+Seychelles,SC,Baie Sainte Anne,,Victoria,EMEA,14,,,,
+Seychelles,SC,Beau Vallon,Beau Vallon,Victoria,EMEA,14,-4.62091000,55.43015000,Beau Vallon,"Beau Vallon|(-4.62091000,55.43015000)"
+Seychelles,SC,Bel Air,,Victoria,EMEA,14,,,,
+Seychelles,SC,Bel Ombre,Bel Ombre,Victoria,EMEA,14,-4.61667000,55.41667000,Bel Ombre,"Bel Ombre|(-4.61667000,55.41667000)"
+Seychelles,SC,Cascade,Cascade,Victoria,EMEA,14,-4.66667000,55.50000000,Cascade,"Cascade|(-4.66667000,55.50000000)"
+Seychelles,SC,Glacis,,Victoria,EMEA,14,,,,
+Seychelles,SC,Grand'Anse Mahé,,Victoria,EMEA,14,,,,
+Seychelles,SC,Grand'Anse Praslin,,Victoria,EMEA,14,,,,
+Seychelles,SC,La Digue,,Victoria,EMEA,14,,,,
+Seychelles,SC,La Rivière Anglaise,Victoria,Victoria,EMEA,14,-4.62001000,55.45501000,Victoria,"Victoria|(-4.62001000,55.45501000)"
+Seychelles,SC,Les Mamelles,,Victoria,EMEA,14,,,,
+Seychelles,SC,Mont Buxton,,Victoria,EMEA,14,,,,
+Seychelles,SC,Mont Fleuri,,Victoria,EMEA,14,,,,
+Seychelles,SC,Plaisance,,Victoria,EMEA,14,,,,
+Seychelles,SC,Pointe La Rue,,Victoria,EMEA,14,,,,
+Seychelles,SC,Port Glaud,Port Glaud,Victoria,EMEA,14,-4.66667000,55.41667000,Port Glaud,"Port Glaud|(-4.66667000,55.41667000)"
+Seychelles,SC,Roche Caiman,,Victoria,EMEA,14,,,,
+Seychelles,SC,Saint Louis,,Victoria,EMEA,14,,,,
+Seychelles,SC,Takamaka,Takamaka,Victoria,EMEA,14,-4.76667000,55.50000000,Takamaka,"Takamaka|(-4.76667000,55.50000000)"
+Sierra Leone,SL,Eastern,Barma,Freetown,EMEA,11,8.34959000,-11.33059000,Barma;Blama;Boajibu,"Barma|(8.34959000,-11.33059000);Blama|(7.87481000,-11.34548000);Boajibu|(8.18763000,-11.34026000)"
+Sierra Leone,SL,Northern,Alikalia,Freetown,EMEA,11,9.15356000,-11.38712000,Alikalia;Bindi;Binkolo,"Alikalia|(9.15356000,-11.38712000);Bindi|(9.91376000,-11.44669000);Binkolo|(8.95225000,-11.98029000)"
+Sierra Leone,SL,Southern,Baiima,Freetown,EMEA,11,8.10826000,-11.84772000,Baiima;Baoma;Bo,"Baiima|(8.10826000,-11.84772000);Baoma|(7.99344000,-11.71468000);Bo|(7.96472000,-11.73833000)"
+Sierra Leone,SL,Western,Freetown,Freetown,EMEA,11,8.48714000,-13.23560000,Freetown;Hastings;Kent,"Freetown|(8.48714000,-13.23560000);Hastings|(8.37994000,-13.13693000);Kent|(8.33333000,-13.06667000)"
+Suriname,SR,Brokopondo,Brokopondo,Paramaribo,EMEA,5,5.05594000,-54.98043000,Brokopondo;Brownsweg,"Brokopondo|(5.05594000,-54.98043000);Brownsweg|(5.00435000,-55.15333000)"
+Suriname,SR,Commewijne,Mariënburg,Paramaribo,EMEA,5,5.87722000,-55.04322000,Mariënburg;Nieuw Amsterdam,"Mariënburg|(5.87722000,-55.04322000);Nieuw Amsterdam|(5.88573000,-55.08871000)"
+Suriname,SR,Coronie,Totness,Paramaribo,EMEA,5,5.87618000,-56.32572000,Totness,"Totness|(5.87618000,-56.32572000)"
+Suriname,SR,Marowijne,Albina,Paramaribo,EMEA,5,5.49788000,-54.05522000,Albina;Moengo,"Albina|(5.49788000,-54.05522000);Moengo|(5.61411000,-54.40121000)"
+Suriname,SR,Nickerie,Nieuw Nickerie,Paramaribo,EMEA,5,5.92606000,-56.97297000,Nieuw Nickerie;Wageningen,"Nieuw Nickerie|(5.92606000,-56.97297000);Wageningen|(5.76010000,-56.66523000)"
+Suriname,SR,Para,Onverwacht,Paramaribo,EMEA,5,5.58983000,-55.19462000,Onverwacht,"Onverwacht|(5.58983000,-55.19462000)"
+Suriname,SR,Paramaribo,Paramaribo,Paramaribo,EMEA,5,5.86638000,-55.16682000,Paramaribo,"Paramaribo|(5.86638000,-55.16682000)"
+Suriname,SR,Saramacca,Groningen,Paramaribo,EMEA,5,5.80000000,-55.46667000,Groningen,"Groningen|(5.80000000,-55.46667000)"
+Suriname,SR,Sipaliwini,,Paramaribo,EMEA,5,,,,
+Suriname,SR,Wanica,Lelydorp,Paramaribo,EMEA,5,5.70000000,-55.23333000,Lelydorp,"Lelydorp|(5.70000000,-55.23333000)"
+Togo,TG,Centrale,Sokodé,Lome,EMEA,11,8.98333000,1.13333000,Sokodé;Sotouboua;Tchamba,"Sokodé|(8.98333000,1.13333000);Sotouboua|(8.56340000,0.98399000);Tchamba|(9.03333000,1.41667000)"
+Togo,TG,Kara,Kara,Lome,EMEA,11,9.55111000,1.18611000,Bafilo;Bassar;Kandé,"Bafilo|(9.35000000,1.26667000);Bassar|(9.25025000,0.78213000);Kandé|(9.95778000,1.04472000)"
+Togo,TG,Maritime,Aného,Lome,EMEA,11,6.22798000,1.59190000,Aného;Lomé;Tabligbo,"Aného|(6.22798000,1.59190000);Lomé|(6.12874000,1.22154000);Tabligbo|(6.58333000,1.50000000)"
+Togo,TG,Plateaux,Amlamé,Lome,EMEA,11,7.46667000,0.90000000,Amlamé;Atakpamé;Badou,"Amlamé|(7.46667000,0.90000000);Atakpamé|(7.53333000,1.13333000);Badou|(7.58333000,0.60000000)"
+Togo,TG,Savanes,Dapaong,Lome,EMEA,11,10.86225000,0.20762000,Dapaong;Sansanné-Mango,"Dapaong|(10.86225000,0.20762000);Sansanné-Mango|(10.35917000,0.47083000)"
+Uruguay,UY,Artigas,Artigas,Montevideo,EMEA,5,-30.40000000,-56.46667000,Artigas;Baltasar Brum;Bella Unión,"Artigas|(-30.40000000,-56.46667000);Baltasar Brum|(-30.71905000,-57.32596000);Bella Unión|(-30.25966000,-57.59919000)"
+Uruguay,UY,Canelones,Canelones,Montevideo,EMEA,5,-34.52278000,-56.27778000,Aguas Corrientes;Atlántida;Barra de Carrasco,"Aguas Corrientes|(-34.52194000,-56.39361000);Atlántida|(-34.77190000,-55.75840000);Barra de Carrasco|(-34.87722000,-56.02972000)"
+Uruguay,UY,Cerro Largo,Aceguá,Montevideo,EMEA,5,-31.87178000,-54.16351000,Aceguá;Isidoro Noblía;Melo,"Aceguá|(-31.87178000,-54.16351000);Isidoro Noblía|(-31.96218000,-54.12309000);Melo|(-32.37028000,-54.16750000)"
+Uruguay,UY,Colonia,Carmelo,Montevideo,EMEA,5,-34.00023000,-58.28402000,Carmelo;Colonia del Sacramento;Florencio Sánchez,"Carmelo|(-34.00023000,-58.28402000);Colonia del Sacramento|(-34.46262000,-57.83976000);Florencio Sánchez|(-33.87785000,-57.37166000)"
+Uruguay,UY,Durazno,Durazno,Montevideo,EMEA,5,-33.38056000,-56.52361000,Blanquillo;Carlos Reyles;Durazno,"Blanquillo|(-32.76667000,-55.63333000);Carlos Reyles|(-33.05658000,-56.47652000);Durazno|(-33.38056000,-56.52361000)"
+Uruguay,UY,Flores,Trinidad,Montevideo,EMEA,5,-33.51650000,-56.89957000,Trinidad,"Trinidad|(-33.51650000,-56.89957000)"
+Uruguay,UY,Florida,Florida,Montevideo,EMEA,5,-34.09556000,-56.21417000,25 de Agosto;25 de Mayo;Alejandro Gallinal,"25 de Agosto|(-34.41167000,-56.40222000);25 de Mayo|(-34.18917000,-56.33944000);Alejandro Gallinal|(-33.86252000,-55.54264000)"
+Uruguay,UY,Lavalleja,José Batlle y Ordóñez,Montevideo,EMEA,5,-33.46667000,-55.11667000,José Batlle y Ordóñez;José Pedro Varela;Mariscala,"José Batlle y Ordóñez|(-33.46667000,-55.11667000);José Pedro Varela|(-33.45451000,-54.53586000);Mariscala|(-34.04085000,-54.77732000)"
+Uruguay,UY,Maldonado,Maldonado,Montevideo,EMEA,5,-34.90000000,-54.95000000,Aiguá;Maldonado;Pan de Azúcar,"Aiguá|(-34.20498000,-54.75665000);Maldonado|(-34.90000000,-54.95000000);Pan de Azúcar|(-34.77870000,-55.23582000)"
+Uruguay,UY,Montevideo,Montevideo,Montevideo,EMEA,5,-34.90328000,-56.18816000,Aires Puros;Arroyo Seco;Atahualpa,"Aires Puros|(-34.85200000,-56.18300000);Arroyo Seco|(-34.80400000,-56.27700000);Atahualpa|(-34.80900000,-56.23000000)"
+Uruguay,UY,Paysandú,Paysandú,Montevideo,EMEA,5,-32.31710000,-58.08072000,Estación Porvenir;Guichón;Paysandú,"Estación Porvenir|(-32.37085000,-57.85371000);Guichón|(-32.35846000,-57.19778000);Paysandú|(-32.31710000,-58.08072000)"
+Uruguay,UY,Río Negro,Fray Bentos,Montevideo,EMEA,5,-33.11651000,-58.31067000,Fray Bentos;Nuevo Berlín;San Javier,"Fray Bentos|(-33.11651000,-58.31067000);Nuevo Berlín|(-32.97974000,-58.05858000);San Javier|(-32.66523000,-58.13320000)"
+Uruguay,UY,Rivera,Rivera,Montevideo,EMEA,5,-30.90534000,-55.55076000,Minas de Corrales;Rivera;Tranqueras,"Minas de Corrales|(-31.57375000,-55.47075000);Rivera|(-30.90534000,-55.55076000);Tranqueras|(-31.20000000,-55.75000000)"
+Uruguay,UY,Rocha,Rocha,Montevideo,EMEA,5,-34.48333000,-54.33333000,Castillos;Cebollatí;Chui,"Castillos|(-34.19871000,-53.85919000);Cebollatí|(-33.26703000,-53.79425000);Chui|(-33.69792000,-53.45926000)"
+Uruguay,UY,Salto,Salto,Montevideo,EMEA,5,-31.38333000,-57.96667000,Belén;Salto;Villa Constitución,"Belén|(-30.78716000,-57.77577000);Salto|(-31.38333000,-57.96667000);Villa Constitución|(-31.06913000,-57.84946000)"
+Uruguay,UY,San José,Delta del Tigre,Montevideo,EMEA,5,-34.76488000,-56.36450000,Delta del Tigre;Ecilda Paullier;Libertad,"Delta del Tigre|(-34.76488000,-56.36450000);Ecilda Paullier|(-34.35778000,-57.04883000);Libertad|(-34.63459000,-56.61739000)"
+Uruguay,UY,Soriano,Cardona,Montevideo,EMEA,5,-33.87049000,-57.36954000,Cardona;Dolores;José Enrique Rodó,"Cardona|(-33.87049000,-57.36954000);Dolores|(-33.53009000,-58.21701000);José Enrique Rodó|(-33.69618000,-57.53153000)"
+Uruguay,UY,Tacuarembó,Tacuarembó,Montevideo,EMEA,5,-31.71694000,-55.98111000,Curtina;Paso de los Toros;Tacuarembó,"Curtina|(-32.15000000,-56.11667000);Paso de los Toros|(-32.81667000,-56.51667000);Tacuarembó|(-31.71694000,-55.98111000)"
+Uruguay,UY,Treinta y Tres,Treinta y Tres,Montevideo,EMEA,5,-33.23333000,-54.38333000,Santa Clara de Olimar;Treinta y Tres;Vergara,"Santa Clara de Olimar|(-32.92254000,-54.94447000);Treinta y Tres|(-33.23333000,-54.38333000);Vergara|(-32.94419000,-53.93810000)"
+Zimbabwe,ZW,Bulawayo,Bulawayo,Harare,EMEA,14,-20.15000000,28.58333000,Bulawayo,"Bulawayo|(-20.15000000,28.58333000)"
+Zimbabwe,ZW,Harare,Harare,Harare,EMEA,14,-17.82772000,31.05337000,Chitungwiza;Epworth;Harare,"Chitungwiza|(-18.01274000,31.07555000);Epworth|(-17.89000000,31.14750000);Harare|(-17.82772000,31.05337000)"
+Zimbabwe,ZW,Manicaland,Buhera District,Harare,EMEA,14,-19.45658000,31.93156000,Buhera District;Chimanimani;Chimanimani District,"Buhera District|(-19.45658000,31.93156000);Chimanimani|(-19.80000000,32.86667000);Chimanimani District|(-19.78295000,32.73338000)"
+Zimbabwe,ZW,Mashonaland Central,Bindura,Harare,EMEA,14,-17.30192000,31.33056000,Bindura;Bindura District;Centenary,"Bindura|(-17.30192000,31.33056000);Bindura District|(-17.21230000,31.30300000);Centenary|(-16.72289000,31.11462000)"
+Zimbabwe,ZW,Mashonaland East,Beatrice,Harare,EMEA,14,-18.25283000,30.84730000,Beatrice;Chivhu;Goromonzi District,"Beatrice|(-18.25283000,30.84730000);Chivhu|(-19.02112000,30.89218000);Goromonzi District|(-17.80695000,31.36372000)"
+Zimbabwe,ZW,Mashonaland West,Banket,Harare,EMEA,14,-17.38333000,30.40000000,Banket;Chakari;Chegutu,"Banket|(-17.38333000,30.40000000);Chakari|(-18.06294000,29.89246000);Chegutu|(-18.13021000,30.14074000)"
+Zimbabwe,ZW,Masvingo,Masvingo,Harare,EMEA,14,-20.06373000,30.82766000,Bikita District;Chiredzi;Chiredzi District,"Bikita District|(-20.13752000,31.93156000);Chiredzi|(-21.05000000,31.66667000);Chiredzi District|(-21.28585000,31.77039000)"
+Zimbabwe,ZW,Matabeleland North,Binga,Harare,EMEA,14,-17.62027000,27.34139000,Binga;Binga District;Bubi District,"Binga|(-17.62027000,27.34139000);Binga District|(-17.80460000,27.70088000);Bubi District|(-19.52508000,28.67998000)"
+Zimbabwe,ZW,Matabeleland South,Beitbridge,Harare,EMEA,14,-22.21667000,30.00000000,Beitbridge;Beitbridge District;Esigodini,"Beitbridge|(-22.21667000,30.00000000);Beitbridge District|(-21.89829000,30.07409000);Esigodini|(-20.28979000,28.92261000)"
+Zimbabwe,ZW,Midlands,Gokwe,Harare,EMEA,14,-18.20476000,28.93490000,Gokwe;Gweru;Gweru District,"Gokwe|(-18.20476000,28.93490000);Gweru|(-19.45000000,29.81667000);Gweru District|(-19.45665000,29.64495000)"

--- a/world_provincial_capitals_geo_regions.csv
+++ b/world_provincial_capitals_geo_regions.csv
@@ -1,0 +1,5100 @@
+Country,Country_Code,State_or_Province,Province_Capital,Country_Capital,Business_Region,UN_Sub_Region,Latitude,Longitude,Major_Cities,Major_Cities_LatLon
+Afghanistan,AF,Badakhshan,Ashkāsham,Kabul,,,36.68333000,71.53333000,Ashkāsham;Fayzabad;Jurm,"Ashkāsham|(36.68333000,71.53333000);Fayzabad|(37.11664000,70.58002000);Jurm|(36.86477000,70.83421000)"
+Afghanistan,AF,Badghis,Ghormach,Kabul,,,35.73062000,63.78264000,Ghormach;Qala i Naw,"Ghormach|(35.73062000,63.78264000);Qala i Naw|(34.98735000,63.12891000)"
+Afghanistan,AF,Baghlan,Baghlān,Kabul,,,36.13068000,68.70829000,Baghlān;Ḩukūmatī Dahanah-ye Ghōrī;Nahrīn,"Baghlān|(36.13068000,68.70829000);Ḩukūmatī Dahanah-ye Ghōrī|(35.90617000,68.48869000);Nahrīn|(36.06490000,69.13343000)"
+Afghanistan,AF,Balkh,Balkh,Kabul,,,36.75635000,66.89720000,Balkh;Dowlatābād;Khulm,"Balkh|(36.75635000,66.89720000);Dowlatābād|(36.98821000,66.82069000);Khulm|(36.69736000,67.69826000)"
+Afghanistan,AF,Bamyan,Bāmyān,Kabul,,,34.82156000,67.82734000,Bāmyān;Panjāb,"Bāmyān|(34.82156000,67.82734000);Panjāb|(34.38795000,67.02327000)"
+Afghanistan,AF,Daykundi,Nīlī,Kabul,,,33.76329000,66.07617000,Nīlī,"Nīlī|(33.76329000,66.07617000)"
+Afghanistan,AF,Farah,Farah,Kabul,,,32.37451000,62.11638000,Farah,"Farah|(32.37451000,62.11638000)"
+Afghanistan,AF,Faryab,Andkhoy,Kabul,,,36.95293000,65.12376000,Andkhoy;Maymana,"Andkhoy|(36.95293000,65.12376000);Maymana|(35.92139000,64.78361000)"
+Afghanistan,AF,Ghazni,Ghazni,Kabul,,,33.55391000,68.42096000,Ghazni,"Ghazni|(33.55391000,68.42096000)"
+Afghanistan,AF,Ghōr,Fayrōz Kōh,Kabul,,,34.51952000,65.25093000,Fayrōz Kōh;Shahrak,"Fayrōz Kōh|(34.51952000,65.25093000);Shahrak|(34.10737000,64.30520000)"
+Afghanistan,AF,Helmand,‘Alāqahdārī Dīshū,Kabul,,,30.43206000,63.29802000,‘Alāqahdārī Dīshū;Gereshk;Lashkar Gāh,"‘Alāqahdārī Dīshū|(30.43206000,63.29802000);Gereshk|(31.82089000,64.57005000);Lashkar Gāh|(31.59382000,64.37161000)"
+Afghanistan,AF,Herat,Chahār Burj,Kabul,,,34.24475000,62.19165000,Chahār Burj;Ghōriyān;Herāt,"Chahār Burj|(34.24475000,62.19165000);Ghōriyān|(34.34480000,61.49321000);Herāt|(34.34817000,62.19967000)"
+Afghanistan,AF,Jowzjan,Āqchah,Kabul,,,36.90500000,66.18341000,Āqchah;Darzāb;Qarqīn,"Āqchah|(36.90500000,66.18341000);Darzāb|(35.97744000,65.37828000);Qarqīn|(37.41853000,66.04358000)"
+Afghanistan,AF,Kabul,Kabul,Kabul,,,34.52813000,69.17233000,Kabul;Mīr Bachah Kōṯ;Paghmān,"Kabul|(34.52813000,69.17233000);Mīr Bachah Kōṯ|(34.74999000,69.11899000);Paghmān|(34.58787000,68.95091000)"
+Afghanistan,AF,Kandahar,Kandahār,Kabul,,,31.61332000,65.71013000,Kandahār,"Kandahār|(31.61332000,65.71013000)"
+Afghanistan,AF,Kapisa,Sidqābād,Kabul,,,35.02298000,69.35112000,Sidqābād,"Sidqābād|(35.02298000,69.35112000)"
+Afghanistan,AF,Khost,Khōst,Kabul,,,33.33951000,69.92041000,Khōst,"Khōst|(33.33951000,69.92041000)"
+Afghanistan,AF,Kunar,Asadabad,Kabul,,,34.87311000,71.14697000,Asadabad;Āsmār,"Asadabad|(34.87311000,71.14697000);Āsmār|(35.03333000,71.35809000)"
+Afghanistan,AF,Kunduz Province,Dasht-e Archī,Kabul,,,37.13333000,69.16667000,Dasht-e Archī;Imām Şāḩib;Khanabad,"Dasht-e Archī|(37.13333000,69.16667000);Imām Şāḩib|(37.18897000,68.93644000);Khanabad|(36.68250000,69.11556000)"
+Afghanistan,AF,Laghman,Mehtar Lām,Kabul,,,34.67139000,70.20944000,Mehtar Lām,"Mehtar Lām|(34.67139000,70.20944000)"
+Afghanistan,AF,Logar,Baraki Barak,Kabul,,,33.96744000,68.94920000,Baraki Barak;Ḩukūmatī Azrah;Pul-e ‘Alam,"Baraki Barak|(33.96744000,68.94920000);Ḩukūmatī Azrah|(34.17355000,69.64573000);Pul-e ‘Alam|(33.99529000,69.02274000)"
+Afghanistan,AF,Nangarhar,Bāsawul,Kabul,,,34.24749000,70.87218000,Bāsawul;Jalālābād,"Bāsawul|(34.24749000,70.87218000);Jalālābād|(34.42647000,70.45153000)"
+Afghanistan,AF,Nimruz,Khāsh,Kabul,,,31.52919000,62.79055000,Khāsh;Mīrābād;Rūdbār,"Khāsh|(31.52919000,62.79055000);Mīrābād|(30.43624000,61.83830000);Rūdbār|(30.15000000,62.60000000)"
+Afghanistan,AF,Nuristan,Pārūn,Kabul,,,35.42064000,70.92261000,Pārūn,"Pārūn|(35.42064000,70.92261000)"
+Afghanistan,AF,Paktia,Gardez,Kabul,,,33.59744000,69.22592000,Gardez,"Gardez|(33.59744000,69.22592000)"
+Afghanistan,AF,Paktika,Saṟōbī,Kabul,,,32.75221000,69.04587000,Saṟōbī;Zaṟah Sharan;Zarghūn Shahr,"Saṟōbī|(32.75221000,69.04587000);Zaṟah Sharan|(33.14641000,68.79213000);Zarghūn Shahr|(32.84734000,68.44573000)"
+Afghanistan,AF,Panjshir,Bāzārak,Kabul,,,35.31292000,69.51519000,Bāzārak,"Bāzārak|(35.31292000,69.51519000)"
+Afghanistan,AF,Parwan,Charikar,Kabul,,,35.01361000,69.17139000,Charikar;Jabal os Saraj,"Charikar|(35.01361000,69.17139000);Jabal os Saraj|(35.11833000,69.23778000)"
+Afghanistan,AF,Samangan,Aībak,Kabul,,,36.26468000,68.01551000,Aībak,"Aībak|(36.26468000,68.01551000)"
+Afghanistan,AF,Sar-e Pol,Chīras,Kabul,,,35.41674000,65.98234000,Chīras;Larkird;Qal‘ah-ye Shahr,"Chīras|(35.41674000,65.98234000);Larkird|(35.48936000,66.66409000);Qal‘ah-ye Shahr|(35.54729000,65.56760000)"
+Afghanistan,AF,Takhar,Ārt Khwājah,Kabul,,,37.08571000,69.47958000,Ārt Khwājah;Taloqan,"Ārt Khwājah|(37.08571000,69.47958000);Taloqan|(36.73605000,69.53451000)"
+Afghanistan,AF,Urozgan,Tarinkot,Kabul,,,32.62998000,65.87806000,Tarinkot;Uruzgān,"Tarinkot|(32.62998000,65.87806000);Uruzgān|(32.92775000,66.63253000)"
+Afghanistan,AF,Zabul,Qalāt,Kabul,,,32.10575000,66.90833000,Qalāt,"Qalāt|(32.10575000,66.90833000)"
+Aland Islands,AX,Brändö,,Mariehamn,,,,,,
+Aland Islands,AX,Eckerö,,Mariehamn,,,,,,
+Aland Islands,AX,Finström,,Mariehamn,,,,,,
+Aland Islands,AX,Föglö,,Mariehamn,,,,,,
+Aland Islands,AX,Geta,,Mariehamn,,,,,,
+Aland Islands,AX,Hammarland,,Mariehamn,,,,,,
+Aland Islands,AX,Jomala,,Mariehamn,,,,,,
+Aland Islands,AX,Kökar,,Mariehamn,,,,,,
+Aland Islands,AX,Kumlinge,,Mariehamn,,,,,,
+Aland Islands,AX,Lemland,,Mariehamn,,,,,,
+Aland Islands,AX,Lumparland,,Mariehamn,,,,,,
+Aland Islands,AX,Mariehamn,,Mariehamn,,,,,,
+Aland Islands,AX,Saltvik,,Mariehamn,,,,,,
+Aland Islands,AX,Sottunga,,Mariehamn,,,,,,
+Aland Islands,AX,Sund,,Mariehamn,,,,,,
+Aland Islands,AX,Vårdö,,Mariehamn,,,,,,
+Albania,AL,Berat,Berat,Tirana,,,40.70583000,19.95222000,Banaj;Bashkia Berat;Bashkia Kuçovë,"Banaj|(40.82492000,19.84074000);Bashkia Berat|(40.69997000,19.94983000);Bashkia Kuçovë|(40.82489000,19.95350000)"
+Albania,AL,Berat,,Tirana,,,,,,
+Albania,AL,Bulqizë,,Tirana,,,,,,
+Albania,AL,Delvinë,,Tirana,,,,,,
+Albania,AL,Devoll,,Tirana,,,,,,
+Albania,AL,Dibër,Bashkia Bulqizë,Tirana,,,41.47152000,20.33192000,Bashkia Bulqizë;Bashkia Klos;Bashkia Mat,"Bashkia Bulqizë|(41.47152000,20.33192000);Bashkia Klos|(41.50826000,20.07107000);Bashkia Mat|(41.63317000,20.01228000)"
+Albania,AL,Dibër,,Tirana,,,,,,
+Albania,AL,Durrës,Durrës,Tirana,,,41.32355000,19.45469000,Bashkia Durrës;Bashkia Krujë;Bashkia Shijak,"Bashkia Durrës|(41.42743000,19.48690000);Bashkia Krujë|(41.50091000,19.72571000);Bashkia Shijak|(41.33558000,19.58977000)"
+Albania,AL,Durrës,,Tirana,,,,,,
+Albania,AL,Elbasan,,Tirana,,,,,,
+Albania,AL,Fier,,Tirana,,,,,,
+Albania,AL,Fier,Fier,Tirana,,,40.72389000,19.55611000,Ballsh;Bashkia Divjakë;Bashkia Fier,"Ballsh|(40.59889000,19.73472000);Bashkia Divjakë|(40.95716000,19.52364000);Bashkia Fier|(40.72937000,19.48690000)"
+Albania,AL,Gjirokastër,Gjirokastër,Tirana,,,40.07583000,20.13889000,Bashkia Dropull;Bashkia Kelcyrë;Bashkia Libohovë,"Bashkia Dropull|(39.98584000,20.30529000);Bashkia Kelcyrë|(40.36196000,20.16476000);Bashkia Libohovë|(40.10754000,20.25753000)"
+Albania,AL,Gjirokastër,,Tirana,,,,,,
+Albania,AL,Gramsh,,Tirana,,,,,,
+Albania,AL,Has,,Tirana,,,,,,
+Albania,AL,Kavajë,,Tirana,,,,,,
+Albania,AL,Kolonjë,,Tirana,,,,,,
+Albania,AL,Korçë,Korçë,Tirana,,,40.61861000,20.78083000,Bashkia Devoll;Bashkia Kolonjë;Bashkia Maliq,"Bashkia Devoll|(40.60078000,20.93814000);Bashkia Kolonjë|(40.31420000,20.61482000);Bashkia Maliq|(40.75508000,20.60748000)"
+Albania,AL,Korçë,,Tirana,,,,,,
+Albania,AL,Krujë,,Tirana,,,,,,
+Albania,AL,Kuçovë,,Tirana,,,,,,
+Albania,AL,Kukës,Kukës,Tirana,,,42.07694000,20.42194000,Bajram Curri;Krumë;Kukës,"Bajram Curri|(42.35734000,20.07679000);Krumë|(42.19694000,20.41333000);Kukës|(42.07694000,20.42194000)"
+Albania,AL,Kukës,,Tirana,,,,,,
+Albania,AL,Kurbin,,Tirana,,,,,,
+Albania,AL,Lezhë,Lezhë,Tirana,,,41.78361000,19.64361000,Bashkia Kurbin;Bashkia Lezhë;Bashkia Mirditë,"Bashkia Kurbin|(41.62215000,19.70734000);Bashkia Lezhë|(41.81320000,19.64121000);Bashkia Mirditë|(41.80953000,19.99024000)"
+Albania,AL,Lezhë,,Tirana,,,,,,
+Albania,AL,Librazhd,,Tirana,,,,,,
+Albania,AL,Lushnjë,,Tirana,,,,,,
+Albania,AL,Malësi e Madhe,,Tirana,,,,,,
+Albania,AL,Mallakastër,,Tirana,,,,,,
+Albania,AL,Mat,,Tirana,,,,,,
+Albania,AL,Mirditë,,Tirana,,,,,,
+Albania,AL,Peqin,,Tirana,,,,,,
+Albania,AL,Përmet,,Tirana,,,,,,
+Albania,AL,Pogradec,,Tirana,,,,,,
+Albania,AL,Pukë,,Tirana,,,,,,
+Albania,AL,Sarandë,,Tirana,,,,,,
+Albania,AL,Shkodër,,Tirana,,,,,,
+Albania,AL,Shkodër,Shkodër,Tirana,,,42.06828000,19.51258000,Bashkia Malësi e Madhe;Bashkia Pukë;Bashkia Vau i Dejës,"Bashkia Malësi e Madhe|(42.36798000,19.58977000);Bashkia Pukë|(42.02997000,19.92778000);Bashkia Vau i Dejës|(42.04834000,19.69999000)"
+Albania,AL,Skrapar,,Tirana,,,,,,
+Albania,AL,Tepelenë,,Tirana,,,,,,
+Albania,AL,Tirana,Tirana,Tirana,,,41.32750000,19.81889000,Bashkia Kavajë;Bashkia Vorë;Kamëz,"Bashkia Kavajë|(41.18127000,19.55579000);Bashkia Vorë|(41.39804000,19.67703000);Kamëz|(41.38167000,19.76028000)"
+Albania,AL,Tirana,,Tirana,,,,,,
+Albania,AL,Tropojë,,Tirana,,,,,,
+Albania,AL,Vlorë,Vlorë,Tirana,,,40.46860000,19.48318000,Bashkia Finiq;Bashkia Himarë;Bashkia Konispol,"Bashkia Finiq|(39.84393000,20.16659000);Bashkia Himarë|(40.11581000,19.81389000);Bashkia Konispol|(39.70064000,20.13353000)"
+Albania,AL,Vlorë,,Tirana,,,,,,
+Algeria,DZ,Adrar,Adrar,Algiers,,,27.87429000,-0.29388000,Adrar;Aoulef;Reggane,"Adrar|(27.87429000,-0.29388000);Aoulef|(26.96667000,1.08333000);Reggane|(26.71576000,0.17140000)"
+Algeria,DZ,Aïn Defla,Aïn Defla,Algiers,,,36.26405000,1.96790000,Aïn Defla;El Abadia;El Attaf,"Aïn Defla|(36.26405000,1.96790000);El Abadia|(36.26951000,1.68609000);El Attaf|(36.22393000,1.67187000)"
+Algeria,DZ,Aïn Témouchent,Aïn Temouchent,Algiers,,,35.29749000,-1.14037000,Aïn Temouchent;Beni Saf;El Amria,"Aïn Temouchent|(35.29749000,-1.14037000);Beni Saf|(35.30099000,-1.38226000);El Amria|(35.52439000,-1.01577000)"
+Algeria,DZ,Algiers,Algiers,Algiers,,,36.73225000,3.08746000,Aïn Taya;Algiers;Bab Ezzouar,"Aïn Taya|(36.79333000,3.28694000);Algiers|(36.73225000,3.08746000);Bab Ezzouar|(36.72615000,3.18291000)"
+Algeria,DZ,Annaba,Annaba,Algiers,,,36.90000000,7.76667000,Annaba;Berrahal;Drean,"Annaba|(36.90000000,7.76667000);Berrahal|(36.83528000,7.45333000);Drean|(36.68482000,7.75111000)"
+Algeria,DZ,Batna,Batna,Algiers,,,35.55597000,6.17414000,Aïn Touta;Arris;Barika,"Aïn Touta|(35.37675000,5.90001000);Arris|(35.25881000,6.34706000);Barika|(35.38901000,5.36584000)"
+Algeria,DZ,Béchar,Béchar,Algiers,,,31.61667000,-2.21667000,Béchar,"Béchar|(31.61667000,-2.21667000)"
+Algeria,DZ,Béjaïa,Akbou,Algiers,,,36.45750000,4.53494000,Akbou;Amizour;Barbacha,"Akbou|(36.45750000,4.53494000);Amizour|(36.64022000,4.90131000);Barbacha|(36.56667000,4.96667000)"
+Algeria,DZ,Béni Abbès,,Algiers,,,,,,
+Algeria,DZ,Biskra,Biskra,Algiers,,,34.85038000,5.72805000,Biskra;Oumache;Sidi Khaled,"Biskra|(34.85038000,5.72805000);Oumache|(34.69292000,5.68092000);Sidi Khaled|(34.38700000,4.98785000)"
+Algeria,DZ,Blida,Blida,Algiers,,,36.47004000,2.82770000,Beni Mered;Blida;Boû Arfa,"Beni Mered|(36.52389000,2.86131000);Blida|(36.47004000,2.82770000);Boû Arfa|(36.46298000,2.81464000)"
+Algeria,DZ,Bordj Baji Mokhtar,,Algiers,,,,,,
+Algeria,DZ,Bordj Bou Arréridj,Bordj Bou Arreridj,Algiers,,,36.07321000,4.76108000,Bordj Bou Arreridj;Bordj Ghdir;Bordj Zemoura,"Bordj Bou Arreridj|(36.07321000,4.76108000);Bordj Ghdir|(35.90111000,4.89806000);Bordj Zemoura|(36.27462000,4.85668000)"
+Algeria,DZ,Bouïra,Bouïra,Algiers,,,36.37489000,3.90200000,Aïn Bessem;Bouïra;Chorfa,"Aïn Bessem|(36.29333000,3.67319000);Bouïra|(36.37489000,3.90200000);Chorfa|(36.36505000,4.32636000)"
+Algeria,DZ,Boumerdès,Arbatache,Algiers,,,36.63773000,3.37127000,Arbatache;Beni Amrane;Boudouaou,"Arbatache|(36.63773000,3.37127000);Beni Amrane|(36.66774000,3.59115000);Boudouaou|(36.72735000,3.40995000)"
+Algeria,DZ,Chlef,Chlef,Algiers,,,36.16525000,1.33452000,Abou el Hassan;Boukadir;Chlef,"Abou el Hassan|(36.41657000,1.19616000);Boukadir|(36.06629000,1.12602000);Chlef|(36.16525000,1.33452000)"
+Algeria,DZ,Constantine,Constantine,Algiers,,,36.36500000,6.61472000,’Aïn Abid;Aïn Smara;Constantine,"’Aïn Abid|(36.23194000,6.94333000);Aïn Smara|(36.26740000,6.50135000);Constantine|(36.36500000,6.61472000)"
+Algeria,DZ,Djanet,,Algiers,,,,,,
+Algeria,DZ,Djelfa,Djelfa,Algiers,,,34.67279000,3.26300000,’Aïn el Bell;Aïn Oussera;Birine,"’Aïn el Bell|(34.34381000,3.22475000);Aïn Oussera|(35.45139000,2.90583000);Birine|(35.63500000,3.22500000)"
+Algeria,DZ,El Bayadh,El Bayadh,Algiers,,,33.68318000,1.01927000,Brezina;El Abiodh Sidi Cheikh;El Bayadh,"Brezina|(33.09892000,1.26082000);El Abiodh Sidi Cheikh|(32.89300000,0.54839000);El Bayadh|(33.68318000,1.01927000)"
+Algeria,DZ,El M'ghair,,Algiers,,,,,,
+Algeria,DZ,El Menia,,Algiers,,,,,,
+Algeria,DZ,El Oued,El Oued,Algiers,,,33.35608000,6.86319000,Debila;El Oued;Reguiba,"Debila|(33.51667000,6.95000000);El Oued|(33.35608000,6.86319000);Reguiba|(33.56391000,6.70326000)"
+Algeria,DZ,El Tarf,El Tarf,Algiers,,,36.76720000,8.31377000,Ben Mehidi;Besbes;El Kala,"Ben Mehidi|(36.76967000,7.90641000);Besbes|(36.70222000,7.84722000);El Kala|(36.89556000,8.44333000)"
+Algeria,DZ,Ghardaïa,Ghardaïa,Algiers,,,32.49094000,3.67347000,Berriane;Ghardaïa;Metlili Chaamba,"Berriane|(32.82648000,3.76689000);Ghardaïa|(32.49094000,3.67347000);Metlili Chaamba|(32.26667000,3.63333000)"
+Algeria,DZ,Guelma,Guelma,Algiers,,,36.46214000,7.42608000,Boumahra Ahmed;Guelma;Héliopolis,"Boumahra Ahmed|(36.45833000,7.51389000);Guelma|(36.46214000,7.42608000);Héliopolis|(36.50361000,7.44278000)"
+Algeria,DZ,Illizi,Illizi,Algiers,,,26.48333000,8.46667000,Illizi,"Illizi|(26.48333000,8.46667000)"
+Algeria,DZ,In Guezzam,,Algiers,,,,,,
+Algeria,DZ,In Salah,,Algiers,,,,,,
+Algeria,DZ,Jijel,Jijel,Algiers,,,36.82055000,5.76671000,Jijel,"Jijel|(36.82055000,5.76671000)"
+Algeria,DZ,Khenchela,Khenchela,Algiers,,,35.43583000,7.14333000,Khenchela,"Khenchela|(35.43583000,7.14333000)"
+Algeria,DZ,Laghouat,Laghouat,Algiers,,,33.80000000,2.86514000,Aflou;Laghouat,"Aflou|(34.11279000,2.10228000);Laghouat|(33.80000000,2.86514000)"
+Algeria,DZ,M'Sila,‘Aïn el Hadjel,Algiers,,,35.67003000,3.88153000,‘Aïn el Hadjel;’Aïn el Melh;M’Sila,"‘Aïn el Hadjel|(35.67003000,3.88153000);’Aïn el Melh|(34.84146000,4.16383000);M’Sila|(35.70583000,4.54194000)"
+Algeria,DZ,Mascara,Mascara,Algiers,,,35.39664000,0.14027000,Bou Hanifia el Hamamat;Mascara;Oued el Abtal,"Bou Hanifia el Hamamat|(35.31473000,-0.05037000);Mascara|(35.39664000,0.14027000);Oued el Abtal|(35.45595000,0.68778000)"
+Algeria,DZ,Médéa,Médéa,Algiers,,,36.26417000,2.75393000,’Aïn Boucif;Berrouaghia;Ksar el Boukhari,"’Aïn Boucif|(35.89123000,3.15850000);Berrouaghia|(36.13516000,2.91085000);Ksar el Boukhari|(35.88889000,2.74905000)"
+Algeria,DZ,Mila,Mila,Algiers,,,36.45028000,6.26444000,Chelghoum el Aïd;Mila;Rouached,"Chelghoum el Aïd|(36.16286000,6.16651000);Mila|(36.45028000,6.26444000);Rouached|(36.45774000,6.04267000)"
+Algeria,DZ,Mostaganem,Mostaganem,Algiers,,,35.93115000,0.08918000,Mostaganem,"Mostaganem|(35.93115000,0.08918000)"
+Algeria,DZ,Naama,Naama,Algiers,,,33.26667000,-0.31667000,Aïn Sefra;Naama,"Aïn Sefra|(32.75000000,-0.58333000);Naama|(33.26667000,-0.31667000)"
+Algeria,DZ,Oran,Oran,Algiers,,,35.69906000,-0.63588000,’Aïn el Turk;Aïn el Bya;Bir el Djir,"’Aïn el Turk|(35.74381000,-0.76930000);Aïn el Bya|(35.80389000,-0.30178000);Bir el Djir|(35.72000000,-0.54500000)"
+Algeria,DZ,Ouargla,Ouargla,Algiers,,,31.94932000,5.32502000,Djamaa;El Hadjira;Hassi Messaoud,"Djamaa|(33.53388000,5.99306000);El Hadjira|(32.61336000,5.51259000);Hassi Messaoud|(31.68041000,6.07286000)"
+Algeria,DZ,Ouled Djellal,,Algiers,,,,,,
+Algeria,DZ,Oum El Bouaghi,Oum el Bouaghi,Algiers,,,35.87541000,7.11353000,Aïn Beïda;Aïn Fakroun;Aïn Kercha,"Aïn Beïda|(35.79639000,7.39278000);Aïn Fakroun|(35.97108000,6.87374000);Aïn Kercha|(35.92472000,6.69528000)"
+Algeria,DZ,Relizane,Relizane,Algiers,,,35.73734000,0.55599000,’Aïn Merane;Ammi Moussa;Djidiouia,"’Aïn Merane|(36.16277000,0.97037000);Ammi Moussa|(35.86781000,1.11143000);Djidiouia|(35.92989000,0.82871000)"
+Algeria,DZ,Saïda,Saïda,Algiers,,,34.83033000,0.15171000,’Aïn el Hadjar;Saïda,"’Aïn el Hadjar|(34.75846000,0.14528000);Saïda|(34.83033000,0.15171000)"
+Algeria,DZ,Sétif,Sétif,Algiers,,,36.19112000,5.41373000,Aïn Arnat;BABOR - VILLE;Bougaa,"Aïn Arnat|(36.18683000,5.31347000);BABOR - VILLE|(36.48994000,5.53930000);Bougaa|(36.33293000,5.08843000)"
+Algeria,DZ,Sidi Bel Abbès,Sidi Bel Abbès,Algiers,,,35.20000000,-0.63333333,Aïn El Berd District;Balidat Ameur;Belarbi,"Aïn El Berd District|(35.35000000,-0.51667000);Balidat Ameur|(32.95138900,5.98055600);Belarbi|(35.15149480,-0.45679090)"
+Algeria,DZ,Skikda,Skikda,Algiers,,,36.87617000,6.90921000,Azzaba;Karkira;Skikda,"Azzaba|(36.73944000,7.10528000);Karkira|(36.92917000,6.58556000);Skikda|(36.87617000,6.90921000)"
+Algeria,DZ,Souk Ahras,Souk Ahras,Algiers,,,36.28639000,7.95111000,Sedrata;Souk Ahras,"Sedrata|(36.12868000,7.53376000);Souk Ahras|(36.28639000,7.95111000)"
+Algeria,DZ,Tamanghasset,I-n-Salah,Algiers,,,27.19351000,2.46069000,I-n-Salah;Tamanrasset,"I-n-Salah|(27.19351000,2.46069000);Tamanrasset|(22.78500000,5.52278000)"
+Algeria,DZ,Tébessa,Tébessa,Algiers,,,35.40417000,8.12417000,Bir el Ater;Cheria;Hammamet,"Bir el Ater|(34.74488000,8.06024000);Cheria|(35.27306000,7.75194000);Hammamet|(35.44862000,7.95184000)"
+Algeria,DZ,Tiaret,Tiaret,Algiers,,,35.37103000,1.31699000,’Aïn Deheb;Djebilet Rosfa;Frenda,"’Aïn Deheb|(34.84218000,1.54697000);Djebilet Rosfa|(34.86375000,0.83496000);Frenda|(35.06544000,1.04945000)"
+Algeria,DZ,Timimoun,,Algiers,,,,,,
+Algeria,DZ,Tindouf,Tindouf,Algiers,,,27.67111000,-8.14743000,Tindouf,"Tindouf|(27.67111000,-8.14743000)"
+Algeria,DZ,Tipasa,Tipasa,Algiers,,,36.58972000,2.44750000,’Aïn Benian;Baraki;Bou Ismaïl,"’Aïn Benian|(36.80277000,2.92185000);Baraki|(36.66655000,3.09606000);Bou Ismaïl|(36.64262000,2.69007000)"
+Algeria,DZ,Tissemsilt,Tissemsilt,Algiers,,,35.60722000,1.81081000,Lardjem;Tissemsilt,"Lardjem|(35.74922000,1.54778000);Tissemsilt|(35.60722000,1.81081000)"
+Algeria,DZ,Tizi Ouzou,Tizi Ouzou,Algiers,,,36.71182000,4.04591000,’Aïn el Hammam;Arhribs;Azazga,"’Aïn el Hammam|(36.56471000,4.30619000);Arhribs|(36.79361000,4.31158000);Azazga|(36.74472000,4.37222000)"
+Algeria,DZ,Tlemcen,Tlemcen,Algiers,,,34.87833000,-1.31500000,Beni Mester;Bensekrane;Chetouane,"Beni Mester|(34.87045000,-1.42319000);Bensekrane|(35.07465000,-1.22431000);Chetouane|(34.92129000,-1.29512000)"
+Algeria,DZ,Touggourt,,Algiers,,,,,,
+American Samoa,AS,Eastern,Ituʻau,Pago Pago,,,-14.30616430,-170.80691440,Ituʻau;Maʻoputasi;Saʻole,"Ituʻau|(-14.30616430,-170.80691440);Maʻoputasi|(-14.25216850,-170.74187670);Saʻole|(-14.29995700,-170.61763370)"
+American Samoa,AS,Manuʻa,Faleasao,Pago Pago,,,-14.20385490,-169.54907370,Faleasao;Fitiuta;Ofu,"Faleasao|(-14.20385490,-169.54907370);Fitiuta|(-14.20386340,-169.51690440);Ofu|(-14.17135950,-169.71939120)"
+American Samoa,AS,Rose,,Pago Pago,,,,,,
+American Samoa,AS,Swains,,Pago Pago,,,,,,
+American Samoa,AS,Western,Lealataua,Pago Pago,,,-14.32261520,-170.90849930,Lealataua;Leasina;Tualatai,"Lealataua|(-14.32261520,-170.90849930);Leasina|(-14.29581640,-170.80459320);Tualatai|(-14.37923540,-170.81033120)"
+Andorra,AD,Andorra la Vella,Andorra la Vella,Andorra la Vella,,,42.50779000,1.52109000,Andorra la Vella,"Andorra la Vella|(42.50779000,1.52109000)"
+Andorra,AD,Canillo,Canillo,Andorra la Vella,,,42.56760000,1.59756000,Canillo;El Tarter,"Canillo|(42.56760000,1.59756000);El Tarter|(42.57952000,1.65362000)"
+Andorra,AD,Encamp,Encamp,Andorra la Vella,,,42.53474000,1.58014000,Encamp;Pas de la Casa,"Encamp|(42.53474000,1.58014000);Pas de la Casa|(42.54277000,1.73361000)"
+Andorra,AD,Escaldes-Engordany,les Escaldes,Andorra la Vella,,,42.50729000,1.53414000,les Escaldes,"les Escaldes|(42.50729000,1.53414000)"
+Andorra,AD,La Massana,la Massana,Andorra la Vella,,,42.54499000,1.51483000,Arinsal;la Massana,"Arinsal|(42.57205000,1.48453000);la Massana|(42.54499000,1.51483000)"
+Andorra,AD,Ordino,Ordino,Andorra la Vella,,,42.55623000,1.53319000,Ordino,"Ordino|(42.55623000,1.53319000)"
+Andorra,AD,Sant Julià de Lòria,Sant Julià de Lòria,Andorra la Vella,,,42.46372000,1.49129000,Sant Julià de Lòria,"Sant Julià de Lòria|(42.46372000,1.49129000)"
+Angola,AO,Bengo,Ambriz,Luanda,EMEA,17,-7.85740000,13.12510000,Ambriz;Bula Atumba;Caxito,"Ambriz|(-7.85740000,13.12510000);Bula Atumba|(-7.31170000,14.31470000);Caxito|(-8.57848000,13.66425000)"
+Angola,AO,Benguela,Benguela,Luanda,EMEA,17,-12.57626000,13.40547000,Baía Farta;Balombo;Benguela,"Baía Farta|(-12.57660000,13.47760000);Balombo|(-12.90460000,13.59590000);Benguela|(-12.57626000,13.40547000)"
+Angola,AO,Bié,Camacupa,Luanda,EMEA,17,-12.01667000,17.48333000,Camacupa;Catabola;Chissamba,"Camacupa|(-12.01667000,17.48333000);Catabola|(-12.15000000,17.28333000);Chissamba|(-12.16667000,17.33333000)"
+Angola,AO,Cabinda,Cabinda,Luanda,EMEA,17,-5.55000000,12.20000000,Cabinda,"Cabinda|(-5.55000000,12.20000000)"
+Angola,AO,Cuando Cubango,Menongue,Luanda,EMEA,17,-14.65850000,17.69099000,Menongue,"Menongue|(-14.65850000,17.69099000)"
+Angola,AO,Cuanza,Quibala,Luanda,EMEA,17,-10.73366000,14.97995000,Quibala;Sumbe;Uacu Cungo,"Quibala|(-10.73366000,14.97995000);Sumbe|(-11.20605000,13.84371000);Uacu Cungo|(-11.35669000,15.11719000)"
+Angola,AO,Cuanza Norte,Camabatela,Luanda,EMEA,17,-8.18812000,15.37495000,Camabatela;N’dalatando,"Camabatela|(-8.18812000,15.37495000);N’dalatando|(-9.29782000,14.91162000)"
+Angola,AO,Cunene,Ondjiva,Luanda,EMEA,17,-17.06667000,15.73333000,Ondjiva,"Ondjiva|(-17.06667000,15.73333000)"
+Angola,AO,Huambo,Huambo,Luanda,EMEA,17,-12.77611000,15.73917000,Caála;Chela;Huambo,"Caála|(-12.85250000,15.56056000);Chela|(-12.30261000,15.43358000);Huambo|(-12.77611000,15.73917000)"
+Angola,AO,Huíla,Caconda,Luanda,EMEA,17,-13.73333000,15.06667000,Caconda;Caluquembe;Chibia,"Caconda|(-13.73333000,15.06667000);Caluquembe|(-13.92093000,14.53476000);Chibia|(-15.23657000,13.88468000)"
+Angola,AO,Luanda,Luanda,Luanda,EMEA,17,-8.83682000,13.23432000,Belas;Cacuaco;Cazenga,"Belas|(-9.06875000,13.16072000);Cacuaco|(-8.82960000,13.29730000);Cazenga|(-8.82860000,13.26650000)"
+Angola,AO,Lunda Norte,Lucapa,Luanda,EMEA,17,-8.68337000,20.27045000,Lucapa,"Lucapa|(-8.68337000,20.27045000)"
+Angola,AO,Lunda Sul,Cazaji,Luanda,EMEA,17,-11.06715000,20.70148000,Cazaji;Saurimo,"Cazaji|(-11.06715000,20.70148000);Saurimo|(-9.66078000,20.39155000)"
+Angola,AO,Malanje,Malanje,Luanda,EMEA,17,-9.54015000,16.34096000,Malanje,"Malanje|(-9.54015000,16.34096000)"
+Angola,AO,Moxico,Léua,Luanda,EMEA,17,-11.65000000,20.45000000,Léua;Luau;Luena,"Léua|(-11.65000000,20.45000000);Luau|(-10.70727000,22.22466000);Luena|(-11.78333000,19.91667000)"
+Angola,AO,Uíge,Uíge,Luanda,EMEA,17,-7.60874000,15.06131000,Uíge,"Uíge|(-7.60874000,15.06131000)"
+Angola,AO,Zaire,Mbanza Congo,Luanda,EMEA,17,-6.26703000,14.24010000,Mbanza Congo;N'zeto;Soio,"Mbanza Congo|(-6.26703000,14.24010000);N'zeto|(-7.23116000,12.86660000);Soio|(-6.13490000,12.36894000)"
+Anguilla,AI,Blowing Point,,The Valley,EMEA,29,,,,
+Anguilla,AI,East End,,The Valley,EMEA,29,,,,
+Anguilla,AI,George Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,Island Harbour,,The Valley,EMEA,29,,,,
+Anguilla,AI,North Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,North Side,,The Valley,EMEA,29,,,,
+Anguilla,AI,Sandy Ground,,The Valley,EMEA,29,,,,
+Anguilla,AI,Sandy Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,South Hill,,The Valley,EMEA,29,,,,
+Anguilla,AI,Stoney Ground,,The Valley,EMEA,29,,,,
+Anguilla,AI,The Farrington,,The Valley,EMEA,29,,,,
+Anguilla,AI,The Quarter,,The Valley,EMEA,29,,,,
+Anguilla,AI,The Valley,,The Valley,EMEA,29,,,,
+Anguilla,AI,West End,,The Valley,EMEA,29,,,,
+Antigua and Barbuda,AG,Barbuda,Codrington,St. John's,,,17.63333000,-61.83333000,Codrington,"Codrington|(17.63333000,-61.83333000)"
+Antigua and Barbuda,AG,Redonda,,St. John's,,,,,,
+Antigua and Barbuda,AG,Saint George,Piggotts,St. John's,,,17.11667000,-61.80000000,Piggotts,"Piggotts|(17.11667000,-61.80000000)"
+Antigua and Barbuda,AG,Saint John,Potters Village,St. John's,,,17.11337000,-61.81962000,Potters Village;Saint John’s,"Potters Village|(17.11337000,-61.81962000);Saint John’s|(17.12096000,-61.84329000)"
+Antigua and Barbuda,AG,Saint Mary,Bolands,St. John's,,,17.06565000,-61.87466000,Bolands,"Bolands|(17.06565000,-61.87466000)"
+Antigua and Barbuda,AG,Saint Paul,Falmouth,St. John's,,,17.02741000,-61.78136000,Falmouth;Liberta,"Falmouth|(17.02741000,-61.78136000);Liberta|(17.04141000,-61.79052000)"
+Antigua and Barbuda,AG,Saint Peter,All Saints,St. John's,,,17.06671000,-61.79303000,All Saints;Parham,"All Saints|(17.06671000,-61.79303000);Parham|(17.09682000,-61.77046000)"
+Antigua and Barbuda,AG,Saint Philip,,St. John's,,,,,,
+Argentina,AR,Autonomous City of Buenos Aires,Agronomía,Buenos Aires,,,-34.59222640,-58.49997640,Agronomía;Almagro;Balvanera,"Agronomía|(-34.59222640,-58.49997640);Almagro|(-34.60985140,-58.44322610);Balvanera|(-34.60928550,-58.42375890)"
+Argentina,AR,Buenos Aires,Adolfo Alsina,Buenos Aires,,,-37.16054780,-64.22506020,Adolfo Alsina;Adolfo Gonzáles Chaves;Alberti,"Adolfo Alsina|(-37.16054780,-64.22506020);Adolfo Gonzáles Chaves|(-37.93801600,-60.90296530);Alberti|(-35.02768320,-60.58411980)"
+Argentina,AR,Catamarca,Ancasti,Buenos Aires,,,-28.81247000,-65.50145000,Ancasti;Andalgalá;Antofagasta de la Sierra,"Ancasti|(-28.81247000,-65.50145000);Andalgalá|(-27.58185000,-66.31626000);Antofagasta de la Sierra|(-26.05940000,-67.40636000)"
+Argentina,AR,Chaco,Aviá Terai,Buenos Aires,,,-26.68532000,-60.72920000,Aviá Terai;Barranqueras;Basail,"Aviá Terai|(-26.68532000,-60.72920000);Barranqueras|(-27.48132000,-58.93925000);Basail|(-27.88539000,-59.28245000)"
+Argentina,AR,Chubut,Alto Río Senguer,Buenos Aires,,,-45.04105000,-70.81982000,Alto Río Senguer;Camarones;Comodoro Rivadavia,"Alto Río Senguer|(-45.04105000,-70.81982000);Camarones|(-44.79709000,-65.70994000);Comodoro Rivadavia|(-45.86413000,-67.49656000)"
+Argentina,AR,Córdoba,Córdoba,Buenos Aires,,,-31.41350000,-64.18105000,Achiras;Adelia María;Agua de Oro,"Achiras|(-33.17538000,-64.99331000);Adelia María|(-33.63152000,-64.02097000);Agua de Oro|(-31.06661000,-64.30017000)"
+Argentina,AR,Corrientes,Corrientes,Buenos Aires,,,-27.46784000,-58.83440000,Alvear;Berón de Astrada;Bonpland,"Alvear|(-29.09683000,-56.55043000);Berón de Astrada|(-27.55067000,-57.53460000);Bonpland|(-29.81708000,-57.42974000)"
+Argentina,AR,Entre Ríos,Aldea San Antonio,Buenos Aires,,,-32.62317000,-58.70512000,Aldea San Antonio;Aranguren;Bovril,"Aldea San Antonio|(-32.62317000,-58.70512000);Aranguren|(-32.24252000,-60.16107000);Bovril|(-31.34311000,-59.44512000)"
+Argentina,AR,Formosa,Formosa,Buenos Aires,,,-26.18489000,-58.17313000,Clorinda;Comandante Fontana;Departamento de Pilcomayo,"Clorinda|(-25.28481000,-57.71851000);Comandante Fontana|(-25.33453000,-59.68212000);Departamento de Pilcomayo|(-25.50000000,-58.08333000)"
+Argentina,AR,Jujuy,Abra Pampa,Buenos Aires,,,-22.72049000,-65.69697000,Abra Pampa;Caimancito;Calilegua,"Abra Pampa|(-22.72049000,-65.69697000);Caimancito|(-23.74069000,-64.59370000);Calilegua|(-23.77368000,-64.77002000)"
+Argentina,AR,La Pampa,Alpachiri,Buenos Aires,,,-37.37704000,-63.77445000,Alpachiri;Alta Italia;Anguil,"Alpachiri|(-37.37704000,-63.77445000);Alta Italia|(-35.33350000,-64.11496000);Anguil|(-36.52567000,-64.01025000)"
+Argentina,AR,La Rioja,La Rioja,Buenos Aires,,,-29.41105000,-66.85067000,Arauco;Castro Barros;Chamical,"Arauco|(-28.58071000,-66.79250000);Castro Barros|(-30.57952000,-65.72696000);Chamical|(-30.36002000,-66.31399000)"
+Argentina,AR,Mendoza,Mendoza,Buenos Aires,,,-32.89084000,-68.82717000,Departamento de Capital;Departamento de General Alvear;Departamento de Godoy Cruz,"Departamento de Capital|(-32.88469000,-68.85826000);Departamento de General Alvear|(-35.16667000,-67.33333000);Departamento de Godoy Cruz|(-32.93333000,-68.86667000)"
+Argentina,AR,Misiones,Alba Posse,Buenos Aires,,,-27.56978000,-54.68262000,Alba Posse;Almafuerte;Aristóbulo del Valle,"Alba Posse|(-27.56978000,-54.68262000);Almafuerte|(-27.50825000,-55.40258000);Aristóbulo del Valle|(-27.09625000,-54.89626000)"
+Argentina,AR,Neuquén,Neuquén,Buenos Aires,,,-38.95161000,-68.05910000,Aluminé;Andacollo;Añelo,"Aluminé|(-39.23686000,-70.91970000);Andacollo|(-37.17945000,-70.66912000);Añelo|(-38.35441000,-68.78840000)"
+Argentina,AR,Río Negro,Allen,Buenos Aires,,,-38.97736000,-67.82714000,Allen;Catriel;Cervantes,"Allen|(-38.97736000,-67.82714000);Catriel|(-37.87907000,-67.79560000);Cervantes|(-39.05444000,-67.39426000)"
+Argentina,AR,Salta,Salta,Buenos Aires,,,-24.78590000,-65.41166000,Apolinario Saravia;Cachí;Cafayate,"Apolinario Saravia|(-24.43276000,-63.99535000);Cachí|(-25.12033000,-66.16519000);Cafayate|(-26.08333000,-65.83333000)"
+Argentina,AR,San Juan,San Juan,Buenos Aires,,,-31.53750000,-68.53639000,Albardón;Calingasta;Caucete,"Albardón|(-31.43722000,-68.52556000);Calingasta|(-31.33394000,-69.42080000);Caucete|(-31.65179000,-68.28105000)"
+Argentina,AR,San Luis,San Luis,Buenos Aires,,,-33.29501000,-66.33563000,Buena Esperanza;Candelaria;Concarán,"Buena Esperanza|(-34.75647000,-65.25379000);Candelaria|(-32.06036000,-65.82477000);Concarán|(-32.56009000,-65.24270000)"
+Argentina,AR,Santa Cruz,28 de Noviembre,Buenos Aires,,,-51.58390000,-72.21382000,28 de Noviembre;Caleta Olivia;Comandante Luis Piedra Buena,"28 de Noviembre|(-51.58390000,-72.21382000);Caleta Olivia|(-46.43929000,-67.52814000);Comandante Luis Piedra Buena|(-49.98513000,-68.91467000)"
+Argentina,AR,Santa Fe,Santa Fe,Buenos Aires,,,-31.64881000,-60.70868000,Armstrong;Arroyo Seco;Arrufó,"Armstrong|(-32.78215000,-61.60222000);Arroyo Seco|(-33.15489000,-60.50863000);Arrufó|(-30.23281000,-61.72862000)"
+Argentina,AR,Santiago del Estero,Santiago del Estero,Buenos Aires,,,-27.79511000,-64.26149000,Añatuya;Beltrán;Campo Gallo,"Añatuya|(-28.46064000,-62.83472000);Beltrán|(-27.82913000,-64.06098000);Campo Gallo|(-26.58333000,-62.85000000)"
+Argentina,AR,Tierra del Fuego,Río Grande,Buenos Aires,,,-53.78769000,-67.70946000,Río Grande;Tolhuin;Ushuaia,"Río Grande|(-53.78769000,-67.70946000);Tolhuin|(-54.51083000,-67.19550000);Ushuaia|(-54.81084000,-68.31591000)"
+Argentina,AR,Tucumán,Aguilares,Buenos Aires,,,-27.43380000,-65.61427000,Aguilares;Alderetes;Bella Vista,"Aguilares|(-27.43380000,-65.61427000);Alderetes|(-26.81667000,-65.13333000);Bella Vista|(-27.03424000,-65.30196000)"
+Armenia,AM,Aragatsotn,Agarakavan,Yerevan,,,40.33069000,44.07233000,Agarakavan;Aparan;Aragats,"Agarakavan|(40.33069000,44.07233000);Aparan|(40.59323000,44.35890000);Aragats|(40.48889000,44.35290000)"
+Armenia,AM,Ararat,Ararat,Yerevan,,,39.83069000,44.70569000,Abovyan;Aralez;Ararat,"Abovyan|(40.04851000,44.54742000);Aralez|(39.90008000,44.65570000);Ararat|(39.83069000,44.70569000)"
+Armenia,AM,Armavir,Armavir,Yerevan,,,40.15446000,44.03815000,Aghavnatun;Aknalich;Aknashen,"Aghavnatun|(40.23330000,44.25295000);Aknalich|(40.14728000,44.16669000);Aknashen|(40.09551000,44.28604000)"
+Armenia,AM,Gegharkunik,Akunk’,Yerevan,,,40.15886000,45.72568000,Akunk’;Astghadzor;Chambarak,"Akunk’|(40.15886000,45.72568000);Astghadzor|(40.12231000,45.35553000);Chambarak|(40.59655000,45.35498000)"
+Armenia,AM,Kotayk,Abovyan,Yerevan,,,40.27368000,44.63348000,Abovyan;Aghavnadzor;Akunk’,"Abovyan|(40.27368000,44.63348000);Aghavnadzor|(40.58195000,44.69581000);Akunk’|(40.26672000,44.68610000)"
+Armenia,AM,Lori,Agarak,Yerevan,,,41.01072000,44.46845000,Agarak;Akht’ala;Alaverdi,"Agarak|(41.01072000,44.46845000);Akht’ala|(41.16838000,44.75811000);Alaverdi|(41.09766000,44.67316000)"
+Armenia,AM,Shirak,Shirak,Yerevan,,,40.84042000,43.91582000,Akhuryan;Amasia;Anushavan,"Akhuryan|(40.78003000,43.90027000);Amasia|(40.95442000,43.78720000);Anushavan|(40.65008000,43.98053000)"
+Armenia,AM,Syunik,Agarak,Yerevan,,,39.20684000,46.54460000,Agarak;Akner;Angeghakot’,"Agarak|(39.20684000,46.54460000);Akner|(39.53491000,46.30732000);Angeghakot’|(39.56952000,45.94452000)"
+Armenia,AM,Tavush,Archis,Yerevan,,,41.16351000,44.87631000,Archis;Artsvaberd;Aygehovit,"Archis|(41.16351000,44.87631000);Artsvaberd|(40.83947000,45.47033000);Aygehovit|(40.97951000,45.25033000)"
+Armenia,AM,Vayots Dzor,Agarakadzor,Yerevan,,,39.73608000,45.35553000,Agarakadzor;Aghavnadzor;Areni,"Agarakadzor|(39.73608000,45.35553000);Aghavnadzor|(39.78607000,45.22790000);Areni|(39.71668000,45.18329000)"
+Armenia,AM,Yerevan,Yerevan,Yerevan,,,40.18111000,44.51361000,Arabkir;Argavand;Jrashen,"Arabkir|(40.20549000,44.50699000);Argavand|(40.15289000,44.43890000);Jrashen|(40.05275000,44.51259000)"
+Aruba,AW,Noord,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Oranjestad,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Oranjestad East,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Oranjestad West,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Paradera,,Oranjestad,EMEA,29,,,,
+Aruba,AW,San Nicolaas Noord,,Oranjestad,EMEA,29,,,,
+Aruba,AW,San Nicolaas Zuid,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Santa Cruz,,Oranjestad,EMEA,29,,,,
+Aruba,AW,Savaneta,,Oranjestad,EMEA,29,,,,
+Australia,AU,Australian Capital Territory,Acton,Canberra,,,-35.27767000,149.11829000,Acton;Ainslie;Amaroo,"Acton|(-35.27767000,149.11829000);Ainslie|(-35.26255000,149.14370000);Amaroo|(-35.16959000,149.12802000)"
+Australia,AU,New South Wales,Abbotsbury,Canberra,,,-33.87010000,150.86119000,Abbotsbury;Abbotsford;Abercrombie,"Abbotsbury|(-33.87010000,150.86119000);Abbotsford|(-33.84889000,151.12801000);Abercrombie|(-33.38867000,149.54580000)"
+Australia,AU,Northern Territory,Alawa,Canberra,,,-12.37954000,130.87320000,Alawa;Alice Springs;Alyangula,"Alawa|(-12.37954000,130.87320000);Alice Springs|(-23.69748000,133.88362000);Alyangula|(-13.85413000,136.42129000)"
+Australia,AU,Queensland,Acacia Ridge,Canberra,,,-27.58333000,153.03333000,Acacia Ridge;Agnes Water;Airlie Beach,"Acacia Ridge|(-27.58333000,153.03333000);Agnes Water|(-24.21190000,151.90350000);Airlie Beach|(-20.26751000,148.71471000)"
+Australia,AU,South Australia,Aberfoyle Park,Canberra,,,-35.07680000,138.59163000,Aberfoyle Park;Adelaide;Adelaide city centre,"Aberfoyle Park|(-35.07680000,138.59163000);Adelaide|(-34.92866000,138.59863000);Adelaide city centre|(-34.92873000,138.60334000)"
+Australia,AU,Tasmania,Acton Park,Canberra,,,-42.87932000,147.48459000,Acton Park;Austins Ferry;Bagdad,"Acton Park|(-42.87932000,147.48459000);Austins Ferry|(-42.76667000,147.25000000);Bagdad|(-42.62968000,147.22339000)"
+Australia,AU,Victoria,Abbotsford,Canberra,,,-37.80000000,145.00000000,Abbotsford;Aberfeldie;Airport West,"Abbotsford|(-37.80000000,145.00000000);Aberfeldie|(-37.75959000,144.89740000);Airport West|(-37.72470000,144.88126000)"
+Australia,AU,Western Australia,Abbey,Canberra,,,-33.66364000,115.25635000,Abbey;Albany;Albany city centre,"Abbey|(-33.66364000,115.25635000);Albany|(-34.70990000,118.12345000);Albany city centre|(-35.02479000,117.88472000)"
+Austria,AT,Burgenland,Andau,Vienna,,,47.77441000,17.03293000,Andau;Antau;Apetlon,"Andau|(47.77441000,17.03293000);Antau|(47.77377000,16.47984000);Apetlon|(47.74394000,16.83020000)"
+Austria,AT,Carinthia,Albeck,Vienna,,,46.81666667,14.10000000,Albeck;Althofen;Annabichl,"Albeck|(46.81666667,14.10000000);Althofen|(46.87298000,14.47449000);Annabichl|(46.65000000,14.31667000)"
+Austria,AT,Lower Austria,Absdorf,Vienna,,,48.40021000,15.97874000,Absdorf;Achau;Aderklaa,"Absdorf|(48.40021000,15.97874000);Achau|(48.08026000,16.38611000);Aderklaa|(48.28333000,16.53333000)"
+Austria,AT,Salzburg,Salzburg,Vienna,,,47.79941000,13.04399000,Abtenau;Adnet;Altenmarkt im Pongau,"Abtenau|(47.56373000,13.34599000);Adnet|(47.69746000,13.13115000);Altenmarkt im Pongau|(47.38333000,13.41667000)"
+Austria,AT,Styria,Abtissendorf,Vienna,,,46.99583000,15.45639000,Abtissendorf;Admont;Aflenz Kurort,"Abtissendorf|(46.99583000,15.45639000);Admont|(47.57537000,14.46075000);Aflenz Kurort|(47.54211000,15.23898000)"
+Austria,AT,Tyrol,Abfaltersbach,Vienna,,,46.75715000,12.52828000,Abfaltersbach;Absam;Achenkirch,"Abfaltersbach|(46.75715000,12.52828000);Absam|(47.29572000,11.50593000);Achenkirch|(47.52659000,11.70559000)"
+Austria,AT,Upper Austria,Abwinden,Vienna,,,48.25903000,14.42625000,Abwinden;Adlwang;Afiesl,"Abwinden|(48.25903000,14.42625000);Adlwang|(47.99245000,14.21742000);Afiesl|(48.58229000,14.12777000)"
+Austria,AT,Vienna,Vienna,Vienna,,,48.20849000,16.37208000,Donaustadt;Favoriten;Floridsdorf,"Donaustadt|(48.23330000,16.46002000);Favoriten|(48.16116000,16.38233000);Floridsdorf|(48.25000000,16.40000000)"
+Austria,AT,Vorarlberg,Alberschwende,Vienna,,,47.45025000,9.83152000,Alberschwende;Altach;Andelsbuch,"Alberschwende|(47.45025000,9.83152000);Altach|(47.35000000,9.65000000);Andelsbuch|(47.41167000,9.89326000)"
+Azerbaijan,AZ,Absheron,Ceyranbatan,Baku,,,40.54194000,49.66073000,Ceyranbatan;Digah;Gyuzdek,"Ceyranbatan|(40.54194000,49.66073000);Digah|(40.49257000,49.87477000);Gyuzdek|(40.37444000,49.68194000)"
+Azerbaijan,AZ,Agdam,Ağdam,Baku,,,39.99096000,46.92736000,Ağdam,"Ağdam|(39.99096000,46.92736000)"
+Azerbaijan,AZ,Agdash,Ağdaş,Baku,,,40.64699000,47.47380000,Ağdaş,"Ağdaş|(40.64699000,47.47380000)"
+Azerbaijan,AZ,Aghjabadi,Agdzhabedy,Baku,,,40.05015000,47.45937000,Agdzhabedy;Avşar,"Agdzhabedy|(40.05015000,47.45937000);Avşar|(39.97389000,47.42389000)"
+Azerbaijan,AZ,Agstafa,Aghstafa,Baku,,,41.11889000,45.45389000,Aghstafa;Saloğlu;Vurğun,"Aghstafa|(41.11889000,45.45389000);Saloğlu|(41.27524000,45.35293000);Vurğun|(41.09524000,45.47111000)"
+Azerbaijan,AZ,Agsu,Aghsu,Baku,,,40.57028000,48.40087000,Aghsu,"Aghsu|(40.57028000,48.40087000)"
+Azerbaijan,AZ,Astara,Astara,Baku,,,38.45598000,48.87498000,Astara;Kizhaba,"Astara|(38.45598000,48.87498000);Kizhaba|(38.53461000,48.80546000)"
+Azerbaijan,AZ,Babek,,Baku,,,,,,
+Azerbaijan,AZ,Baku,Baku,Baku,,,40.37767000,49.89201000,Amirdzhan;Badamdar;Bakıxanov,"Amirdzhan|(40.42639000,49.98361000);Badamdar|(40.34024000,49.80450000);Bakıxanov|(40.41894000,49.96693000)"
+Azerbaijan,AZ,Balakan,Belokany,Baku,,,41.72626000,46.40478000,Belokany;Qabaqçöl,"Belokany|(41.72626000,46.40478000);Qabaqçöl|(41.75259000,46.27052000)"
+Azerbaijan,AZ,Barda,Barda,Baku,,,40.37577000,47.12619000,Barda;Samuxlu,"Barda|(40.37577000,47.12619000);Samuxlu|(40.50833000,47.16917000)"
+Azerbaijan,AZ,Beylagan,Beylagan,Baku,,,39.77556000,47.61861000,Beylagan;Birinci Aşıqlı;Dünyamalılar,"Beylagan|(39.77556000,47.61861000);Birinci Aşıqlı|(39.81917000,47.67944000);Dünyamalılar|(39.77278000,47.75889000)"
+Azerbaijan,AZ,Bilasuvar,Pushkino,Baku,,,39.45833000,48.54500000,Pushkino,"Pushkino|(39.45833000,48.54500000)"
+Azerbaijan,AZ,Dashkasan,Verkhniy Dashkesan,Baku,,,40.49357000,46.07175000,Verkhniy Dashkesan;Yukhary-Dashkesan,"Verkhniy Dashkesan|(40.49357000,46.07175000);Yukhary-Dashkesan|(40.52393000,46.08186000)"
+Azerbaijan,AZ,Fizuli,Fizuli,Baku,,,39.60094000,47.14529000,Fizuli;Horadiz,"Fizuli|(39.60094000,47.14529000);Horadiz|(39.45015000,47.33496000)"
+Azerbaijan,AZ,Ganja,Ganja,Baku,,,40.68278000,46.36056000,Ganja,"Ganja|(40.68278000,46.36056000)"
+Azerbaijan,AZ,Gədəbəy,Arıqdam,Baku,,,40.59313000,45.79900000,Arıqdam;Arıqıran;Böyük Qaramurad,"Arıqdam|(40.59313000,45.79900000);Arıqıran|(40.53971000,45.61414000);Böyük Qaramurad|(40.57626000,45.63727000)"
+Azerbaijan,AZ,Gobustan,Qobustan,Baku,,,40.53360000,48.92819000,Qobustan,"Qobustan|(40.53360000,48.92819000)"
+Azerbaijan,AZ,Goranboy,Goranboy,Baku,,,40.61028000,46.78972000,Goranboy;Qızılhacılı,"Goranboy|(40.61028000,46.78972000);Qızılhacılı|(40.57362000,46.84900000)"
+Azerbaijan,AZ,Goychay,Geoktschai,Baku,,,40.65055000,47.74219000,Geoktschai,"Geoktschai|(40.65055000,47.74219000)"
+Azerbaijan,AZ,Goygol,Yelenendorf,Baku,,,40.58584000,46.31890000,Yelenendorf,"Yelenendorf|(40.58584000,46.31890000)"
+Azerbaijan,AZ,Hajigabul,Hacıqabul,Baku,,,40.03874000,48.94286000,Hacıqabul;Mughan,"Hacıqabul|(40.03874000,48.94286000);Mughan|(40.09902000,48.81886000)"
+Azerbaijan,AZ,Imishli,Imishli,Baku,,,39.87095000,48.05995000,Imishli,"Imishli|(39.87095000,48.05995000)"
+Azerbaijan,AZ,Ismailli,Basqal,Baku,,,40.75520000,48.39104000,Basqal;İsmayıllı,"Basqal|(40.75520000,48.39104000);İsmayıllı|(40.78485000,48.15141000)"
+Azerbaijan,AZ,Jabrayil,Jebrail,Baku,,,39.39917000,47.02835000,Jebrail,"Jebrail|(39.39917000,47.02835000)"
+Azerbaijan,AZ,Jalilabad,Jalilabad,Baku,,,39.20963000,48.49186000,Jalilabad;Prishibinskoye,"Jalilabad|(39.20963000,48.49186000);Prishibinskoye|(39.11998000,48.59383000)"
+Azerbaijan,AZ,Julfa,,Baku,,,,,,
+Azerbaijan,AZ,Kalbajar,Kerbakhiar,Baku,,,40.10984000,46.04446000,Kerbakhiar;Vank,"Kerbakhiar|(40.10984000,46.04446000);Vank|(40.05275000,46.54419000)"
+Azerbaijan,AZ,Kangarli,,Baku,,,,,,
+Azerbaijan,AZ,Khachmaz,Xaçmaz,Baku,,,41.46426000,48.80565000,Xaçmaz;Xudat,"Xaçmaz|(41.46426000,48.80565000);Xudat|(41.63052000,48.68161000)"
+Azerbaijan,AZ,Khizi,Altıağac,Baku,,,40.85785000,48.93540000,Altıağac;Khyzy;Kilyazi,"Altıağac|(40.85785000,48.93540000);Khyzy|(40.90847000,49.07481000);Kilyazi|(40.87392000,49.34376000)"
+Azerbaijan,AZ,Khojali,Askyaran,Baku,,,39.93910000,46.83161000,Askyaran;Xocalı,"Askyaran|(39.93910000,46.83161000);Xocalı|(39.91297000,46.79028000)"
+Azerbaijan,AZ,Kurdamir,Kyurdarmir,Baku,,,40.34257000,48.15649000,Kyurdarmir,"Kyurdarmir|(40.34257000,48.15649000)"
+Azerbaijan,AZ,Lachin,Laçın,Baku,,,39.59881000,46.55045000,Laçın,"Laçın|(39.59881000,46.55045000)"
+Azerbaijan,AZ,Lankaran,,Baku,,,,,,
+Azerbaijan,AZ,Lankaran,Lankaran,Baku,,,38.75428000,48.85062000,Haftoni;Lankaran,"Haftoni|(38.76325000,48.76223000);Lankaran|(38.75428000,48.85062000)"
+Azerbaijan,AZ,Lerik,Lerik,Baku,,,38.77388000,48.41497000,Lerik,"Lerik|(38.77388000,48.41497000)"
+Azerbaijan,AZ,Martuni,Hadrut,Baku,,,39.52003000,47.03190000,Hadrut;Novyy Karanlug;Qırmızı Bazar,"Hadrut|(39.52003000,47.03190000);Novyy Karanlug|(39.79496000,47.11170000);Qırmızı Bazar|(39.67669000,46.95123000)"
+Azerbaijan,AZ,Masally,Masally,Baku,,,39.03532000,48.66540000,Boradigah;Masally,"Boradigah|(38.93013000,48.70920000);Masally|(39.03532000,48.66540000)"
+Azerbaijan,AZ,Mingachevir,Mingelchaur,Baku,,,40.76395000,47.05953000,Mingelchaur,"Mingelchaur|(40.76395000,47.05953000)"
+Azerbaijan,AZ,Nakhchivan,Nakhchivan,Baku,,,39.20889000,45.41222000,Cahri;Çalxanqala;Culfa,"Cahri|(39.34837000,45.41557000);Çalxanqala|(39.44167000,45.28333000);Culfa|(38.95397000,45.62961000)"
+Azerbaijan,AZ,Neftchala,Neftçala,Baku,,,39.37680000,49.24700000,Neftçala;Severo-Vostotchnyi Bank;Sovetabad,"Neftçala|(39.37680000,49.24700000);Severo-Vostotchnyi Bank|(39.41117000,49.24792000);Sovetabad|(39.33667000,49.21414000)"
+Azerbaijan,AZ,Oghuz,Oğuz,Baku,,,41.07128000,47.46528000,Oğuz,"Oğuz|(41.07128000,47.46528000)"
+Azerbaijan,AZ,Ordubad,,Baku,,,,,,
+Azerbaijan,AZ,Qabala,Qutqashen,Baku,,,40.98247000,47.84909000,Qutqashen,"Qutqashen|(40.98247000,47.84909000)"
+Azerbaijan,AZ,Qakh,Çinarlı,Baku,,,41.46965000,46.91582000,Çinarlı;Qax;Qax İngiloy,"Çinarlı|(41.46965000,46.91582000);Qax|(41.41826000,46.92043000);Qax İngiloy|(41.42412000,46.93859000)"
+Azerbaijan,AZ,Qazakh,Qazax,Baku,,,41.09246000,45.36561000,Qazax,"Qazax|(41.09246000,45.36561000)"
+Azerbaijan,AZ,Quba,Quba,Baku,,,41.36108000,48.51341000,Hacıhüseynli;Quba,"Hacıhüseynli|(41.45639000,48.64889000);Quba|(41.36108000,48.51341000)"
+Azerbaijan,AZ,Qubadli,Qubadlı,Baku,,,39.34441000,46.58183000,Qubadlı,"Qubadlı|(39.34441000,46.58183000)"
+Azerbaijan,AZ,Qusar,Qusar,Baku,,,41.42750000,48.43020000,Qusar;Samur,"Qusar|(41.42750000,48.43020000);Samur|(41.63671000,48.43028000)"
+Azerbaijan,AZ,Saatly,Əhmədbəyli,Baku,,,39.88074000,48.39158000,Əhmədbəyli;Saatlı,"Əhmədbəyli|(39.88074000,48.39158000);Saatlı|(39.93214000,48.36892000)"
+Azerbaijan,AZ,Sabirabad,Sabirabad,Baku,,,40.00869000,48.47701000,Sabirabad,"Sabirabad|(40.00869000,48.47701000)"
+Azerbaijan,AZ,Sadarak,,Baku,,,,,,
+Azerbaijan,AZ,Salyan,Salyan,Baku,,,39.59621000,48.98479000,Qaraçala;Salyan,"Qaraçala|(39.81614000,48.93792000);Salyan|(39.59621000,48.98479000)"
+Azerbaijan,AZ,Samukh,Qarayeri,Baku,,,40.78674000,46.31365000,Qarayeri;Qırmızı Samux;Samux,"Qarayeri|(40.78674000,46.31365000);Qırmızı Samux|(40.93972000,46.37889000);Samux|(40.76485000,46.40868000)"
+Azerbaijan,AZ,Shabran,Divichibazar,Baku,,,41.20117000,48.98712000,Divichibazar,"Divichibazar|(41.20117000,48.98712000)"
+Azerbaijan,AZ,Shahbuz,,Baku,,,,,,
+Azerbaijan,AZ,Shaki,Sheki,Baku,,,41.19194000,47.17056000,Sheki,"Sheki|(41.19194000,47.17056000)"
+Azerbaijan,AZ,Shaki,Baş Göynük,Baku,,,41.32582000,47.11357000,Baş Göynük,"Baş Göynük|(41.32582000,47.11357000)"
+Azerbaijan,AZ,Shamakhi,Shamakhi,Baku,,,40.63141000,48.64137000,Shamakhi,"Shamakhi|(40.63141000,48.64137000)"
+Azerbaijan,AZ,Shamkir,Dolyar,Baku,,,40.86278000,46.03493000,Dolyar;Dzagam;Qasım İsmayılov,"Dolyar|(40.86278000,46.03493000);Dzagam|(40.90330000,45.88564000);Qasım İsmayılov|(40.81243000,46.25938000)"
+Azerbaijan,AZ,Sharur,,Baku,,,,,,
+Azerbaijan,AZ,Shirvan,Şirvan,Baku,,,39.93778000,48.92900000,Şirvan,"Şirvan|(39.93778000,48.92900000)"
+Azerbaijan,AZ,Shusha,Shushi,Baku,,,39.76006000,46.74989000,Shushi,"Shushi|(39.76006000,46.74989000)"
+Azerbaijan,AZ,Siazan,Gilgilçay,Baku,,,41.13932000,49.09038000,Gilgilçay;Kyzyl-Burun,"Gilgilçay|(41.13932000,49.09038000);Kyzyl-Burun|(41.07811000,49.11564000)"
+Azerbaijan,AZ,Sumqayit,Corat,Baku,,,40.57176000,49.70509000,Corat;Hacı Zeynalabdin;Sumqayıt,"Corat|(40.57176000,49.70509000);Hacı Zeynalabdin|(40.62333000,49.55861000);Sumqayıt|(40.58972000,49.66861000)"
+Azerbaijan,AZ,Tartar,Martakert,Baku,,,40.21127000,46.82135000,Martakert;Terter,"Martakert|(40.21127000,46.82135000);Terter|(40.34201000,46.93161000)"
+Azerbaijan,AZ,Tovuz,Tovuz,Baku,,,40.99249000,45.62838000,Çatax;Çobansığnaq;Dondar Quşçu,"Çatax|(40.72622000,45.55919000);Çobansığnaq|(40.75244000,45.70645000);Dondar Quşçu|(40.95390000,45.61942000)"
+Azerbaijan,AZ,Ujar,Ujar,Baku,,,40.51902000,47.65423000,Ujar,"Ujar|(40.51902000,47.65423000)"
+Azerbaijan,AZ,Yardymli,Yardımlı,Baku,,,38.90771000,48.24052000,Yardımlı,"Yardımlı|(38.90771000,48.24052000)"
+Azerbaijan,AZ,Yevlakh,Yevlakh,Baku,,,40.61832000,47.15014000,Yevlakh,"Yevlakh|(40.61832000,47.15014000)"
+Azerbaijan,AZ,Yevlakh,Aran,Baku,,,40.62528000,46.97556000,Aran;Qaramanlı,"Aran|(40.62528000,46.97556000);Qaramanlı|(40.48135000,46.99339000)"
+Azerbaijan,AZ,Zangilan,Zangilan,Baku,,,39.08371000,46.65988000,Mincivan;Zangilan,"Mincivan|(39.03023000,46.72329000);Zangilan|(39.08371000,46.65988000)"
+Azerbaijan,AZ,Zaqatala,Zaqatala,Baku,,,41.63160000,46.64479000,Aliabad;Faldarlı;Mamrux,"Aliabad|(41.48290000,46.63483000);Faldarlı|(41.46868000,46.51579000);Mamrux|(41.54243000,46.76700000)"
+Azerbaijan,AZ,Zardab,Zardob,Baku,,,40.21840000,47.71214000,Zardob,"Zardob|(40.21840000,47.71214000)"
+Bahrain,BH,Capital,Jidd Ḩafş,Manama,,,26.21861000,50.54778000,Jidd Ḩafş;Manama;Sitrah,"Jidd Ḩafş|(26.21861000,50.54778000);Manama|(26.22787000,50.58565000);Sitrah|(26.15472000,50.62056000)"
+Bahrain,BH,Central,Madīnat Ḩamad,Manama,,,26.11528000,50.50694000,Madīnat Ḩamad,"Madīnat Ḩamad|(26.11528000,50.50694000)"
+Bahrain,BH,Muharraq,Al Ḩadd,Manama,,,26.24556000,50.65417000,Al Ḩadd;Al Muharraq,"Al Ḩadd|(26.24556000,50.65417000);Al Muharraq|(26.25722000,50.61194000)"
+Bahrain,BH,Northern,,Manama,,,,,,
+Bahrain,BH,Southern,Ar Rifā‘,Manama,,,26.13000000,50.55500000,Ar Rifā‘;Dār Kulayb;Madīnat ‘Īsá,"Ar Rifā‘|(26.13000000,50.55500000);Dār Kulayb|(26.06861000,50.50389000);Madīnat ‘Īsá|(26.17361000,50.54778000)"
+Bangladesh,BD,Barisal ,Barisal ,Dhaka,,,22.42035790,89.78250340,Barguna;Barisal;Bhola,"Barguna|(22.17167870,89.79740240);Barisal|(22.42035790,89.78250340);Bhola|(22.32452480,90.10568470)"
+Bangladesh,BD,Chittagong ,Chittagong,Dhaka,,,22.48750000,91.96333000,Bandarban;Brahmanbaria;Chandpur,"Bandarban|(22.00000000,92.33333000);Brahmanbaria|(23.98333000,91.16667000);Chandpur|(23.25000000,90.83333000)"
+Bangladesh,BD,Dhaka ,Dhaka ,Dhaka,,,23.78417980,89.92859830,Dhaka;Faridpur;Gazipur,"Dhaka|(23.78417980,89.92859830);Faridpur|(23.45115240,89.52820380);Gazipur|(24.10914520,90.09596140)"
+Bangladesh,BD,Khulna ,Khulna ,Dhaka,,,22.35351390,88.83407090,Bagerhat;Chuadanga;Jessore,"Bagerhat|(22.34880590,89.07470250);Chuadanga|(23.60352730,88.48732400);Jessore|(23.08473560,88.87480080)"
+Bangladesh,BD,Mymensingh ,Mymensingh ,Dhaka,,,24.72309850,89.78411730,Jamalpur;Mymensingh;Netrokona,"Jamalpur|(25.00108250,89.26050130);Mymensingh|(24.72309850,89.78411730);Netrokona|(24.87204810,90.52293810)"
+Bangladesh,BD,Rajshahi ,Rajshahi ,Dhaka,,,24.42073360,88.29602140,Bogra;Chapai Nawabganj;Joypurhat,"Bogra|(24.82966450,89.02598570);Chapai Nawabganj|(24.59988690,88.28504660);Joypurhat|(25.06567070,88.76832650)"
+Bangladesh,BD,Rangpur ,Rangpur ,Dhaka,,,25.62390240,88.90094980,Dinajpur;Gaibandha;Kurigram,"Dinajpur|(25.64261030,88.18344620);Gaibandha|(25.34315570,89.13978570);Kurigram|(25.80827220,89.00915030)"
+Bangladesh,BD,Sylhet ,Sylhet ,Dhaka,,,24.89189110,91.73554950,Habiganj;Moulvibazar;Sunamganj,"Habiganj|(24.33481970,90.74899010);Moulvibazar|(24.48617710,91.28742410);Sunamganj|(24.88905540,91.00248270)"
+Barbados,BB,Christ Church,Oistins,Bridgetown,,,13.07067000,-59.54637000,Oistins,"Oistins|(13.07067000,-59.54637000)"
+Barbados,BB,Saint Andrew,Greenland,Bridgetown,,,13.25808000,-59.57763000,Greenland,"Greenland|(13.25808000,-59.57763000)"
+Barbados,BB,Saint George,,Bridgetown,,,,,,
+Barbados,BB,Saint James,Holetown,Bridgetown,,,13.18672000,-59.63808000,Holetown,"Holetown|(13.18672000,-59.63808000)"
+Barbados,BB,Saint John,,Bridgetown,,,,,,
+Barbados,BB,Saint Joseph,Bathsheba,Bridgetown,,,13.21133000,-59.52596000,Bathsheba,"Bathsheba|(13.21133000,-59.52596000)"
+Barbados,BB,Saint Lucy,,Bridgetown,,,,,,
+Barbados,BB,Saint Michael,Bridgetown,Bridgetown,,,13.10732000,-59.62021000,Bridgetown,"Bridgetown|(13.10732000,-59.62021000)"
+Barbados,BB,Saint Peter,Speightstown,Bridgetown,,,13.25072000,-59.64396000,Speightstown,"Speightstown|(13.25072000,-59.64396000)"
+Barbados,BB,Saint Philip,Crane,Bridgetown,,,13.10487000,-59.44861000,Crane,"Crane|(13.10487000,-59.44861000)"
+Barbados,BB,Saint Thomas,,Bridgetown,,,,,,
+Belarus,BY,Brest,Brest,Minsk,,,52.09755000,23.68775000,Antopal’;Asnyezhytsy;Baranovichi,"Antopal’|(52.20380000,24.78630000);Asnyezhytsy|(52.18910000,26.12990000);Baranovichi|(53.13270000,26.01390000)"
+Belarus,BY,Gomel,Aktsyabrski,Minsk,,,52.64400000,28.88010000,Aktsyabrski;Brahin;Brahinski Rayon,"Aktsyabrski|(52.64400000,28.88010000);Brahin|(51.78700000,30.26770000);Brahinski Rayon|(51.66667000,30.33333000)"
+Belarus,BY,Grodno,Ashmyanski Rayon,Minsk,,,54.41667000,25.91667000,Ashmyanski Rayon;Ashmyany;Astravyets,"Ashmyanski Rayon|(54.41667000,25.91667000);Ashmyany|(54.42100000,25.93600000);Astravyets|(54.61378000,25.95537000)"
+Belarus,BY,Minsk,Astrashytski Haradok,Minsk,,,54.06510000,27.69500000,Astrashytski Haradok;Atolina;Azyartso,"Astrashytski Haradok|(54.06510000,27.69500000);Atolina|(53.78170000,27.43460000);Azyartso|(53.83970000,27.39170000)"
+Belarus,BY,Minsk,Minsk,Minsk,,,53.90000000,27.56667000,Frunzyenski Rayon;Kastrychnitski Rayon;Lyeninski Rayon,"Frunzyenski Rayon|(53.90056000,27.49500000);Kastrychnitski Rayon|(53.85667000,27.54139000);Lyeninski Rayon|(53.85944000,27.58778000)"
+Belarus,BY,Mogilev,Asipovichy,Minsk,,,53.30110000,28.63860000,Asipovichy;Asipovitski Rayon;Babruysk,"Asipovichy|(53.30110000,28.63860000);Asipovitski Rayon|(53.33333000,28.75000000);Babruysk|(53.13840000,29.22140000)"
+Belarus,BY,Vitebsk,Vitebsk,Minsk,,,55.19040000,30.20490000,Balbasava;Baran’;Braslaw,"Balbasava|(54.42070000,30.29090000);Baran’|(54.47840000,30.31590000);Braslaw|(55.64130000,27.04180000)"
+Belgium,BE,Antwerp,,Brussels,,,,,,
+Belgium,BE,Brussels-Capital ,Brussels,Brussels,,,50.85045000,4.34878000,Brussels,"Brussels|(50.85045000,4.34878000)"
+Belgium,BE,East Flanders,,Brussels,,,,,,
+Belgium,BE,Flanders,Aalst,Brussels,,,50.93604000,4.03550000,Aalst;Aalter;Aarschot,"Aalst|(50.93604000,4.03550000);Aalter|(51.09017000,3.44693000);Aarschot|(50.98715000,4.83695000)"
+Belgium,BE,Flemish Brabant,,Brussels,,,,,,
+Belgium,BE,Hainaut,,Brussels,,,,,,
+Belgium,BE,Liège,,Brussels,,,,,,
+Belgium,BE,Limburg,,Brussels,,,,,,
+Belgium,BE,Luxembourg,,Brussels,,,,,,
+Belgium,BE,Namur,,Brussels,,,,,,
+Belgium,BE,Wallonia,Aiseau,Brussels,,,50.41158000,4.58671000,Aiseau;Amay;Amblève,"Aiseau|(50.41158000,4.58671000);Amay|(50.54829000,5.30974000);Amblève|(50.35357000,6.17002000)"
+Belgium,BE,Walloon Brabant,,Brussels,,,,,,
+Belgium,BE,West Flanders,,Brussels,,,,,,
+Belize,BZ,Belize,Belize City,Belmopan,EMEA,13,17.49952000,-88.19756000,Belize City;San Pedro,"Belize City|(17.49952000,-88.19756000);San Pedro|(17.91598000,-87.96590000)"
+Belize,BZ,Cayo,Belmopan,Belmopan,EMEA,13,17.25000000,-88.76667000,Belmopan;Benque Viejo el Carmen;San Ignacio,"Belmopan|(17.25000000,-88.76667000);Benque Viejo el Carmen|(17.07500000,-89.13917000);San Ignacio|(17.15880000,-89.06960000)"
+Belize,BZ,Corozal,Corozal,Belmopan,EMEA,13,18.39375000,-88.38849000,Corozal,"Corozal|(18.39375000,-88.38849000)"
+Belize,BZ,Orange Walk,Orange Walk,Belmopan,EMEA,13,18.08124000,-88.56328000,Hopelchén;Orange Walk;Shipyard,"Hopelchén|(17.80000000,-89.10000000);Orange Walk|(18.08124000,-88.56328000);Shipyard|(17.89382000,-88.65452000)"
+Belize,BZ,Stann Creek,Dangriga,Belmopan,EMEA,13,16.96970000,-88.23313000,Dangriga;Placencia,"Dangriga|(16.96970000,-88.23313000);Placencia|(16.51419000,-88.36647000)"
+Belize,BZ,Toledo,Punta Gorda,Belmopan,EMEA,13,16.09835000,-88.80970000,Punta Gorda,"Punta Gorda|(16.09835000,-88.80970000)"
+Benin,BJ,Alibori,Banikoara,Porto-Novo,,,11.29845000,2.43856000,Banikoara;Kandi;Malanville,"Banikoara|(11.29845000,2.43856000);Kandi|(11.13417000,2.93861000);Malanville|(11.86819000,3.38327000)"
+Benin,BJ,Atakora,Guilmaro,Porto-Novo,,,10.56583000,1.72444000,Guilmaro;Natitingou;Tanguieta,"Guilmaro|(10.56583000,1.72444000);Natitingou|(10.30416000,1.37962000);Tanguieta|(11.03621000,1.41757000)"
+Benin,BJ,Atlantique,Abomey-Calavi,Porto-Novo,,,6.44852000,2.35566000,Abomey-Calavi;Allada;Hévié,"Abomey-Calavi|(6.44852000,2.35566000);Allada|(6.66547000,2.15138000);Hévié|(6.41667000,2.25000000)"
+Benin,BJ,Borgou,Bembèrèkè,Porto-Novo,,,10.22827000,2.66335000,Bembèrèkè;Bétérou;Nikki,"Bembèrèkè|(10.22827000,2.66335000);Bétérou|(9.19916000,2.25855000);Nikki|(9.94009000,3.21075000)"
+Benin,BJ,Collines,Comé,Porto-Novo,,,6.40764000,1.88198000,Comé;Dassa-Zoumé;Savalou,"Comé|(6.40764000,1.88198000);Dassa-Zoumé|(7.75000000,2.18333000);Savalou|(7.92807000,1.97558000)"
+Benin,BJ,Donga,Bassila,Porto-Novo,,,9.00814000,1.66540000,Bassila;Commune of Djougou;Djougou,"Bassila|(9.00814000,1.66540000);Commune of Djougou|(9.64300000,1.89600000);Djougou|(9.70853000,1.66598000)"
+Benin,BJ,Kouffo,Djakotomey,Porto-Novo,,,6.90000000,1.71667000,Djakotomey;Dogbo,"Djakotomey|(6.90000000,1.71667000);Dogbo|(6.79911000,1.78073000)"
+Benin,BJ,Littoral,Cotonou,Porto-Novo,,,6.36536000,2.41833000,Cotonou,"Cotonou|(6.36536000,2.41833000)"
+Benin,BJ,Mono,Commune of Athieme,Porto-Novo,,,6.56924000,1.70259000,Commune of Athieme;Lokossa,"Commune of Athieme|(6.56924000,1.70259000);Lokossa|(6.63869000,1.71674000)"
+Benin,BJ,Ouémé,Porto-Novo,Porto-Novo,,,6.49646000,2.60359000,Porto-Novo,"Porto-Novo|(6.49646000,2.60359000)"
+Benin,BJ,Plateau,Kétou,Porto-Novo,,,7.36332000,2.59978000,Kétou;Pobé;Sakété,"Kétou|(7.36332000,2.59978000);Pobé|(6.98008000,2.66490000);Sakété|(6.73618000,2.65866000)"
+Benin,BJ,Zou,Abomey,Porto-Novo,,,7.18286000,1.99119000,Abomey;Bohicon;Commune of Agbangnizoun,"Abomey|(7.18286000,1.99119000);Bohicon|(7.17826000,2.06670000);Commune of Agbangnizoun|(7.07600000,1.96100000)"
+Bermuda,BM,Devonshire,Devonshire,Hamilton,,,32.29300000,-64.80000000,Devonshire,"Devonshire|(32.29300000,-64.80000000)"
+Bermuda,BM,Hamilton,Hamilton,Hamilton,,,32.29400000,-64.78300000,Hamilton,"Hamilton|(32.29400000,-64.78300000)"
+Bermuda,BM,Paget,Paget,Hamilton,,,32.27800000,-64.76900000,Paget,"Paget|(32.27800000,-64.76900000)"
+Bermuda,BM,Pembroke,,Hamilton,,,,,,
+Bermuda,BM,Saint George's,St. George's,Hamilton,,,32.38100000,-64.67400000,St. George's;Tucker’s Town,"St. George's|(32.38100000,-64.67400000);Tucker’s Town|(32.33280000,64.68810000)"
+Bermuda,BM,Sandys,Somerset,Hamilton,,,32.28200000,-64.84400000,Somerset,"Somerset|(32.28200000,-64.84400000)"
+Bermuda,BM,Smith's,Flatts,Hamilton,,,32.32800000,-64.73600000,Flatts,"Flatts|(32.32800000,-64.73600000)"
+Bermuda,BM,Southampton,Southampton,Hamilton,,,32.24900000,-64.86100000,Southampton,"Southampton|(32.24900000,-64.86100000)"
+Bermuda,BM,Warwick,Warwick,Hamilton,,,32.26700000,-64.80600000,Warwick,"Warwick|(32.26700000,-64.80600000)"
+Bhutan,BT,Bumthang ,Jakar,Thimphu,,,27.54918000,90.75250000,Jakar;Tang Valley,"Jakar|(27.54918000,90.75250000);Tang Valley|(27.50252420,90.74495440)"
+Bhutan,BT,Chukha ,Chapchha,Thimphu,,,27.20000000,89.55000000,Chapchha;Daphu;Khitokha,"Chapchha|(27.20000000,89.55000000);Daphu|(26.96670000,89.38330000);Khitokha|(26.90000000,89.61670000)"
+Bhutan,BT,Dagana ,Daga,Thimphu,,,27.07529000,89.87688000,Daga;Sibsu;Thumgaon,"Daga|(27.07529000,89.87688000);Sibsu|(27.00000000,88.90000000);Thumgaon|(26.98330000,89.96670000)"
+Bhutan,BT,Gasa ,Gasa,Thimphu,,,27.90372000,89.72689000,Gasa,"Gasa|(27.90372000,89.72689000)"
+Bhutan,BT,Haa ,Ha,Thimphu,,,27.38747000,89.28074000,Ha;Naktsang;Sangkari,"Ha|(27.38747000,89.28074000);Naktsang|(27.38330000,89.26670000);Sangkari|(27.30000000,89.31670000)"
+Bhutan,BT,Lhuntse ,Lhuentse,Thimphu,,,27.66787000,91.18393000,Lhuentse,"Lhuentse|(27.66787000,91.18393000)"
+Bhutan,BT,Mongar ,Mongar,Thimphu,,,27.27471000,91.23963000,Kengkhar;Mongar;Thebong,"Kengkhar|(27.10000000,91.25000000);Mongar|(27.27471000,91.23963000);Thebong|(27.26670000,91.26670000)"
+Bhutan,BT,Paro ,Paro,Thimphu,,,27.43050000,89.41334000,Paro;Suchha;Tshalunang,"Paro|(27.43050000,89.41334000);Suchha|(27.23330000,89.45000000);Tshalunang|(27.43330000,89.65000000)"
+Bhutan,BT,Pemagatshel ,Pemagatshel,Thimphu,,,27.03795000,91.40305000,Nganglam;Pemagatshel,"Nganglam|(26.84181100,91.24248490);Pemagatshel|(27.03795000,91.40305000)"
+Bhutan,BT,Punakha ,Pajo,Thimphu,,,27.53333000,89.88333000,Pajo;Punākha,"Pajo|(27.53333000,89.88333000);Punākha|(27.59137000,89.87743000)"
+Bhutan,BT,Samdrup Jongkhar ,Samdrup Jongkhar,Thimphu,,,26.80069000,91.50519000,Samdrup Jongkhar,"Samdrup Jongkhar|(26.80069000,91.50519000)"
+Bhutan,BT,Samtse ,Samtse,Thimphu,,,26.89903000,89.09951000,Denchukha;Dorokha;Samtse,"Denchukha|(27.01670000,89.25000000);Dorokha|(27.01670000,89.21670000);Samtse|(26.89903000,89.09951000)"
+Bhutan,BT,Sarpang ,Sarpang,Thimphu,,,26.86395000,90.26745000,Bhurgaon;Galechugaon;Geylegphug,"Bhurgaon|(26.90000000,90.43330000);Galechugaon|(27.00000000,90.53330000);Geylegphug|(26.87060000,90.48560000)"
+Bhutan,BT,Thimphu ,Thimphu,Thimphu,,,27.46609000,89.64191000,Thimphu,"Thimphu|(27.46609000,89.64191000)"
+Bhutan,BT,Trashi Yangtse	,Trashi Yangtse,Thimphu,,,27.58330000,91.46670000,Shali;Trashi Yangtse;Yalang,"Shali|(27.48330000,91.56670000);Trashi Yangtse|(27.58330000,91.46670000);Yalang|(27.43330000,91.63330000)"
+Bhutan,BT,Trashigang ,Trashigang,Thimphu,,,27.33310000,91.55424000,Balfai;Ghunkarah;Ngalangkang,"Balfai|(27.21670320,91.47940030);Ghunkarah|(27.40000000,91.56670000);Ngalangkang|(27.45282330,91.56477710)"
+Bhutan,BT,Trongsa ,Trongsa,Thimphu,,,27.49940000,90.50470000,Trongsa,"Trongsa|(27.49940000,90.50470000)"
+Bhutan,BT,Tsirang ,Tsirang,Thimphu,,,27.02190000,90.12291000,Beteni;Dagapela;Damphu,"Beteni|(27.03330000,90.23330000);Dagapela|(26.93330000,89.95000000);Damphu|(27.01670000,90.10000000)"
+Bhutan,BT,Wangdue Phodrang ,Wangdue Phodrang,Thimphu,,,27.48330000,89.90000000,Manikyangsa;Ritang;Wangdue Phodrang,"Manikyangsa|(27.53330000,90.10000000);Ritang|(27.55000000,90.16670000);Wangdue Phodrang|(27.48330000,89.90000000)"
+Bhutan,BT,Zhemgang ,Zhemgang,Thimphu,,,27.21689000,90.65793000,Panbang;Zhemgang,"Panbang|(26.86667000,90.98333000);Zhemgang|(27.21689000,90.65793000)"
+Bolivia,BO,Beni,Guayaramerín,Sucre,,,-10.82580000,-65.35810000,Guayaramerín;Provincia Cercado;Provincia General José Ballivián,"Guayaramerín|(-10.82580000,-65.35810000);Provincia Cercado|(-14.50000000,-64.33333000);Provincia General José Ballivián|(-14.00000000,-67.08333000)"
+Bolivia,BO,Chuquisaca,Camargo,Sucre,,,-20.64064000,-65.20893000,Camargo;Monteagudo;Padilla,"Camargo|(-20.64064000,-65.20893000);Monteagudo|(-19.79989000,-63.95461000);Padilla|(-19.30878000,-64.30273000)"
+Bolivia,BO,Cochabamba,Cochabamba,Sucre,,,-17.38950000,-66.15680000,Aiquile;Arani;Bolivar,"Aiquile|(-18.20408000,-65.18068000);Arani|(-17.56854000,-65.76883000);Bolivar|(-17.96667000,-66.53333000)"
+Bolivia,BO,La Paz,La Paz,Sucre,,,-16.50000000,-68.15000000,Achacachi;Amarete;Batallas,"Achacachi|(-16.05000000,-68.68333000);Amarete|(-15.23675000,-68.98462000);Batallas|(-16.30000000,-68.53333000)"
+Bolivia,BO,Oruro,Oruro,Sucre,,,-17.98333000,-67.15000000,Challapata;Huanuni;Litoral de Atacama,"Challapata|(-18.90208000,-66.77048000);Huanuni|(-18.28900000,-66.83583000);Litoral de Atacama|(-18.76071000,-68.24295000)"
+Bolivia,BO,Pando,Cobija,Sucre,,,-11.02671000,-68.76918000,Cobija;Provincia Abuná;Provincia General Federico Román,"Cobija|(-11.02671000,-68.76918000);Provincia Abuná|(-10.50000000,-66.50000000);Provincia General Federico Román|(-10.33333000,-65.88333000)"
+Bolivia,BO,Potosí,Potosí,Sucre,,,-19.58361000,-65.75306000,Atocha;Betanzos;Colchani,"Atocha|(-20.93515000,-66.22139000);Betanzos|(-19.55293000,-65.45395000);Colchani|(-20.30000000,-66.93333000)"
+Bolivia,BO,Santa Cruz,Abapó,Sucre,,,-18.88279000,-63.38026000,Abapó;Ascención de Guarayos;Ascensión,"Abapó|(-18.88279000,-63.38026000);Ascención de Guarayos|(-15.89299000,-63.18855000);Ascensión|(-15.70000000,-63.08333000)"
+Bolivia,BO,Tarija,Tarija,Sucre,,,-21.53549000,-64.72956000,Bermejo;Entre Ríos;Provincia Arce,"Bermejo|(-22.73206000,-64.33724000);Entre Ríos|(-21.52661000,-64.17299000);Provincia Arce|(-22.16667000,-64.33333000)"
+"Bonaire, Sint Eustatius and Saba",BQ,Bonaire,Boven Bolivia,Kralendijk,,,12.18190000,-68.21810000,Boven Bolivia;Dorp Tera Kora;Oranjestad,"Boven Bolivia|(12.18190000,-68.21810000);Dorp Tera Kora|(12.13333000,-68.26667000);Oranjestad|(17.48333333,-62.98333333)"
+"Bonaire, Sint Eustatius and Saba",BQ,Saba,,Kralendijk,,,,,,
+"Bonaire, Sint Eustatius and Saba",BQ,Sint Eustatius,,Kralendijk,,,,,,
+Bosnia and Herzegovina,BA,Bosnian Podrinje,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Brčko,Brčko,Sarajevo,,,44.86995000,18.81012000,Brčko;Brka,"Brčko|(44.86995000,18.81012000);Brka|(44.82837000,18.72420000)"
+Bosnia and Herzegovina,BA,Canton 10,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Central Bosnia,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Federation of Bosnia and Herzegovina,Banovići,Sarajevo,,,44.40596000,18.52648000,Banovići;Barice;Bihać,"Banovići|(44.40596000,18.52648000);Barice|(44.54065000,18.48069000);Bihać|(44.81694000,15.87083000)"
+Bosnia and Herzegovina,BA,Herzegovina-Neretva,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Posavina,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Republika Srpska,Balatun,Sarajevo,,,44.86332000,19.33931000,Balatun;Banja Luka;Bijeljina,"Balatun|(44.86332000,19.33931000);Banja Luka|(44.77842000,17.19386000);Bijeljina|(44.76583000,19.15083000)"
+Bosnia and Herzegovina,BA,Sarajevo,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Tuzla,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Una-Sana,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,West Herzegovina,,Sarajevo,,,,,,
+Bosnia and Herzegovina,BA,Zenica-Doboj,,Sarajevo,,,,,,
+Botswana,BW,Central,Gobojango,Gaborone,EMEA,18,-21.83270000,28.72882000,Gobojango;Gweta;Kalamare,"Gobojango|(-21.83270000,28.72882000);Gweta|(-20.18333000,25.23333000);Kalamare|(-22.93369000,26.57032000)"
+Botswana,BW,Ghanzi,Ghanzi,Gaborone,EMEA,18,-21.69785000,21.64581000,Dekar;Ghanzi,"Dekar|(-21.53333000,21.93333000);Ghanzi|(-21.69785000,21.64581000)"
+Botswana,BW,Kgalagadi,Hukuntsi,Gaborone,EMEA,18,-23.99880000,21.77962000,Hukuntsi;Kang;Lehututu,"Hukuntsi|(-23.99880000,21.77962000);Kang|(-23.67518000,22.78762000);Lehututu|(-23.96667000,21.86667000)"
+Botswana,BW,Kgatleng,Bokaa,Gaborone,EMEA,18,-24.45000000,26.01667000,Bokaa;Mmathubudukwane;Mochudi,"Bokaa|(-24.45000000,26.01667000);Mmathubudukwane|(-24.60000000,26.43333000);Mochudi|(-24.41667000,26.15000000)"
+Botswana,BW,Kweneng,Botlhapatlou,Gaborone,EMEA,18,-24.02591000,25.48976000,Botlhapatlou;Dutlwe;Gabane,"Botlhapatlou|(-24.02591000,25.48976000);Dutlwe|(-23.98333000,23.90000000);Gabane|(-24.66667000,25.78222000)"
+Botswana,BW,Ngamiland,,Gaborone,EMEA,18,,,,
+Botswana,BW,North-East,Dukwe,Gaborone,EMEA,18,-20.58333000,26.41667000,Dukwe;Makaleng;Masunga,"Dukwe|(-20.58333000,26.41667000);Makaleng|(-20.90000000,27.28333000);Masunga|(-20.62455000,27.44875000)"
+Botswana,BW,North-West,Maun,Gaborone,EMEA,18,-19.98333000,23.41667000,Maun;Nokaneng;Pandamatenga,"Maun|(-19.98333000,23.41667000);Nokaneng|(-19.66667000,22.26667000);Pandamatenga|(-18.52779000,25.62698000)"
+Botswana,BW,South-East,Gaborone,Gaborone,EMEA,18,-24.76234000,25.79950000,Gaborone;Janeng;Kopong,"Gaborone|(-24.76234000,25.79950000);Janeng|(-25.41667000,25.55000000);Kopong|(-24.48333000,25.88333000)"
+Botswana,BW,Southern,Kanye,Gaborone,EMEA,18,-24.96675000,25.33273000,Kanye;Khakhea;Mosopa,"Kanye|(-24.96675000,25.33273000);Khakhea|(-24.68954000,23.49403000);Mosopa|(-24.77180000,25.42156000)"
+Brazil,BR,Acre,Acrelândia,Brasilia,,,-9.98045000,-66.84388000,Acrelândia;Assis Brasil;Brasiléia,"Acrelândia|(-9.98045000,-66.84388000);Assis Brasil|(-10.88334000,-70.01314000);Brasiléia|(-11.01611000,-68.74806000)"
+Brazil,BR,Alagoas,Água Branca,Brasilia,,,-9.26988000,-37.91917000,Água Branca;Anadia;Arapiraca,"Água Branca|(-9.26988000,-37.91917000);Anadia|(-9.67495000,-36.33790000);Arapiraca|(-9.74380000,-36.59315000)"
+Brazil,BR,Amapá,Amapá,Brasilia,,,1.85706000,-50.84374000,Amapá;Calçoene;Cutias,"Amapá|(1.85706000,-50.84374000);Calçoene|(2.36098000,-51.45285000);Cutias|(0.99713000,-50.52041000)"
+Brazil,BR,Amazonas,Alvarães,Brasilia,,,-3.22083000,-64.80417000,Alvarães;Amaturá;Anamã,"Alvarães|(-3.22083000,-64.80417000);Amaturá|(-3.38926000,-68.22698000);Anamã|(-3.47990000,-61.71689000)"
+Brazil,BR,Bahia,Abaíra,Brasilia,,,-13.32129000,-41.69759000,Abaíra;Abaré;Acajutiba,"Abaíra|(-13.32129000,-41.69759000);Abaré|(-8.80961000,-39.27062000);Acajutiba|(-11.60682000,-38.03594000)"
+Brazil,BR,Ceará,Abaiara,Brasilia,,,-7.33642000,-39.06129000,Abaiara;Acarape;Acaraú,"Abaiara|(-7.33642000,-39.06129000);Acarape|(-4.20565000,-38.69160000);Acaraú|(-2.95424000,-40.08597000)"
+Brazil,BR,Distrito Federal,Brasília,Brasilia,,,-15.77972000,-47.92972000,Brasília;Planaltina,"Brasília|(-15.77972000,-47.92972000);Planaltina|(-15.61791000,-47.64874000)"
+Brazil,BR,Espírito Santo,Afonso Cláudio,Brasilia,,,-20.10512000,-41.12422000,Afonso Cláudio;Água Doce do Norte;Águia Branca,"Afonso Cláudio|(-20.10512000,-41.12422000);Água Doce do Norte|(-18.50646000,-40.99190000);Águia Branca|(-18.98306000,-40.74028000)"
+Brazil,BR,Goiás,Goiás,Brasilia,,,-15.93444000,-50.14028000,Abadia de Goiás;Abadiânia;Acreúna,"Abadia de Goiás|(-16.77762000,-49.46841000);Abadiânia|(-16.22632000,-48.62681000);Acreúna|(-17.43605000,-50.26696000)"
+Brazil,BR,Maranhão,Açailândia,Brasilia,,,-4.69214000,-47.34302000,Açailândia;Afonso Cunha;Água Doce do Maranhão,"Açailândia|(-4.69214000,-47.34302000);Afonso Cunha|(-4.21479000,-43.29743000);Água Doce do Maranhão|(-2.91251000,-42.14125000)"
+Brazil,BR,Mato Grosso,Acorizal,Brasilia,,,-15.17336000,-56.30434000,Acorizal;Água Boa;Alta Floresta,"Acorizal|(-15.17336000,-56.30434000);Água Boa|(-14.13584000,-52.49093000);Alta Floresta|(-9.87556000,-56.08611000)"
+Brazil,BR,Mato Grosso do Sul,Água Clara,Brasilia,,,-19.89787000,-52.95089000,Água Clara;Alcinópolis;Amambai,"Água Clara|(-19.89787000,-52.95089000);Alcinópolis|(-18.19955000,-53.75814000);Amambai|(-23.12710000,-54.95790000)"
+Brazil,BR,Minas Gerais,Abadia dos Dourados,Brasilia,,,-18.36347000,-47.46997000,Abadia dos Dourados;Abaeté;Abre Campo,"Abadia dos Dourados|(-18.36347000,-47.46997000);Abaeté|(-19.11099000,-45.43051000);Abre Campo|(-20.27265000,-42.43908000)"
+Brazil,BR,Pará,Abaetetuba,Brasilia,,,-1.71806000,-48.88250000,Abaetetuba;Abel Figueiredo;Acará,"Abaetetuba|(-1.71806000,-48.88250000);Abel Figueiredo|(-4.94378000,-48.42275000);Acará|(-1.96083000,-48.19667000)"
+Brazil,BR,Paraíba,Água Branca,Brasilia,,,-7.46957000,-37.66100000,Água Branca;Aguiar;Alagoa Grande,"Água Branca|(-7.46957000,-37.66100000);Aguiar|(-7.07620000,-38.24255000);Alagoa Grande|(-7.07831000,-35.59525000)"
+Brazil,BR,Paraná,Abatiá,Brasilia,,,-23.29903000,-50.32176000,Abatiá;Adrianópolis;Agudos do Sul,"Abatiá|(-23.29903000,-50.32176000);Adrianópolis|(-24.76632000,-48.79998000);Agudos do Sul|(-26.04616000,-49.31186000)"
+Brazil,BR,Pernambuco,Abreu e Lima,Brasilia,,,-7.86865000,-35.08171000,Abreu e Lima;Afogados da Ingazeira;Afrânio,"Abreu e Lima|(-7.86865000,-35.08171000);Afogados da Ingazeira|(-7.72298000,-37.61781000);Afrânio|(-8.62589000,-41.05768000)"
+Brazil,BR,Piauí,Acauã,Brasilia,,,-8.31552000,-40.91283000,Acauã;Agricolândia;Água Branca,"Acauã|(-8.31552000,-40.91283000);Agricolândia|(-5.74819000,-42.67458000);Água Branca|(-5.89222000,-42.63611000)"
+Brazil,BR,Rio de Janeiro,Rio de Janeiro,Brasilia,,,-22.92008000,-43.33069000,Angra dos Reis;Aperibé;Araruama,"Angra dos Reis|(-23.00667000,-44.31806000);Aperibé|(-21.64148000,-42.12753000);Araruama|(-22.87278000,-42.34306000)"
+Brazil,BR,Rio Grande do Norte,Acari,Brasilia,,,-6.38547000,-36.63908000,Acari;Açu;Afonso Bezerra,"Acari|(-6.38547000,-36.63908000);Açu|(-5.57667000,-36.90861000);Afonso Bezerra|(-5.43183000,-36.65619000)"
+Brazil,BR,Rio Grande do Sul,Aceguá,Brasilia,,,-31.64597000,-54.10715000,Aceguá;Água Santa;Agudo,"Aceguá|(-31.64597000,-54.10715000);Água Santa|(-28.18543000,-52.01286000);Agudo|(-29.62631000,-53.22404000)"
+Brazil,BR,Rondônia,Alta Floresta d'Oeste,Brasilia,,,-12.47107000,-62.13705000,Alta Floresta d'Oeste;Alto Alegre dos Parecis;Alto Paraíso,"Alta Floresta d'Oeste|(-12.47107000,-62.13705000);Alto Alegre dos Parecis|(-12.75601000,-61.97971000);Alto Paraíso|(-9.65996000,-63.58719000)"
+Brazil,BR,Roraima,Alto Alegre,Brasilia,,,2.98862450,-61.32004260,Alto Alegre;Amajari;Boa Vista,"Alto Alegre|(2.98862450,-61.32004260);Amajari|(3.65416667,-61.41694444);Boa Vista|(2.82000000,-60.67194444)"
+Brazil,BR,Santa Catarina,Abdon Batista,Brasilia,,,-27.58981000,-51.04023000,Abdon Batista;Abelardo Luz;Agrolândia,"Abdon Batista|(-27.58981000,-51.04023000);Abelardo Luz|(-26.59825000,-52.22321000);Agrolândia|(-27.46387000,-49.83759000)"
+Brazil,BR,São Paulo,São Paulo,Brasilia,,,-23.54750000,-46.63611000,Adamantina;Adolfo;Aguaí,"Adamantina|(-21.59136000,-51.06669000);Adolfo|(-21.28535000,-49.65497000);Aguaí|(-22.02590000,-47.06702000)"
+Brazil,BR,Sergipe,Amparo de São Francisco,Brasilia,,,-10.13736000,-36.92219000,Amparo de São Francisco;Aquidabã;Aracaju,"Amparo de São Francisco|(-10.13736000,-36.92219000);Aquidabã|(-10.31619000,-37.10451000);Aracaju|(-10.98232000,-37.10333000)"
+Brazil,BR,Tocantins,Abreulândia,Brasilia,,,-9.43672000,-49.31733000,Abreulândia;Aguiarnópolis;Aliança do Tocantins,"Abreulândia|(-9.43672000,-49.31733000);Aguiarnópolis|(-6.48176000,-47.51435000);Aliança do Tocantins|(-11.32864000,-48.95855000)"
+Brunei,BN,Belait,Kuala Belait,Bandar Seri Begawan,,,4.58361000,114.23120000,Kuala Belait;Seria,"Kuala Belait|(4.58361000,114.23120000);Seria|(4.60637000,114.32476000)"
+Brunei,BN,Brunei-Muara,Bandar Seri Begawan,Bandar Seri Begawan,,,4.89035000,114.94006000,Bandar Seri Begawan;Berakas A;Kapok,"Bandar Seri Begawan|(4.89035000,114.94006000);Berakas A|(4.97032000,114.92989000);Kapok|(5.02447000,115.04664000)"
+Brunei,BN,Temburong,Bangar,Bandar Seri Begawan,,,4.70861000,115.07167000,Bangar,"Bangar|(4.70861000,115.07167000)"
+Brunei,BN,Tutong,Tutong,Bandar Seri Begawan,,,4.80278000,114.64917000,Tutong,"Tutong|(4.80278000,114.64917000)"
+Bulgaria,BG,Blagoevgrad,Blagoevgrad,Sofia,,,42.01667000,23.10000000,Bansko;Belitsa;Blagoevgrad,"Bansko|(41.83830000,23.48851000);Belitsa|(41.95694000,23.57250000);Blagoevgrad|(42.01667000,23.10000000)"
+Bulgaria,BG,Burgas,Burgas,Sofia,,,42.50606000,27.46781000,Aheloy;Ahtopol;Aytos,"Aheloy|(42.64987000,27.64838000);Ahtopol|(42.09768000,27.93961000);Aytos|(42.70188650,27.25203860)"
+Bulgaria,BG,Dobrich,Dobrich,Sofia,,,43.56667000,27.83333000,Balchik;Dobrich;General Toshevo,"Balchik|(43.42166000,28.15848000);Dobrich|(43.56667000,27.83333000);General Toshevo|(43.70123000,28.03787000)"
+Bulgaria,BG,Gabrovo,Gabrovo,Sofia,,,42.87472000,25.33417000,Dryanovo;Gabrovo;Obshtina Dryanovo,"Dryanovo|(42.97897000,25.47850000);Gabrovo|(42.87472000,25.33417000);Obshtina Dryanovo|(43.00000000,25.46667000)"
+Bulgaria,BG,Haskovo,Haskovo,Sofia,,,41.93415000,25.55557000,Dimitrovgrad;Harmanli;Haskovo,"Dimitrovgrad|(42.05824930,25.59164660);Harmanli|(41.93333000,25.90000000);Haskovo|(41.93415000,25.55557000)"
+Bulgaria,BG,Kardzhali,Kardzhali,Sofia,,,41.65000000,25.36667000,Ardino;Dzhebel;Kardzhali,"Ardino|(41.58333000,25.13333000);Dzhebel|(41.49566000,25.30363000);Kardzhali|(41.65000000,25.36667000)"
+Bulgaria,BG,Kyustendil,Kyustendil,Sofia,,,42.28389000,22.69111000,Boboshevo;Bobov Dol;Dupnitsa,"Boboshevo|(42.15296000,23.00146000);Bobov Dol|(42.36256000,23.00324000);Dupnitsa|(42.26667000,23.11667000)"
+Bulgaria,BG,Lovech,Lovech,Sofia,,,43.13333000,24.71667000,Apriltsi;Letnitsa;Lovech,"Apriltsi|(42.84142000,24.91759000);Letnitsa|(43.31167000,25.07333000);Lovech|(43.13333000,24.71667000)"
+Bulgaria,BG,Montana,Montana,Sofia,,,43.41250000,23.22500000,Berkovitsa;Boychinovtsi;Brusartsi,"Berkovitsa|(43.23581000,23.12738000);Boychinovtsi|(43.47222000,23.33583000);Brusartsi|(43.66075000,23.06732000)"
+Bulgaria,BG,Pazardzhik,Pazardzhik,Sofia,,,42.18845490,24.33189930,Batak;Belovo;Bratsigovo,"Batak|(41.94225000,24.21843000);Belovo|(42.21239000,24.02081000);Bratsigovo|(42.01667000,24.36667000)"
+Bulgaria,BG,Pernik,Pernik,Sofia,,,42.60000000,23.03333000,Batanovtsi;Breznik;Obshtina Kovachevtsi,"Batanovtsi|(42.59692000,22.95634000);Breznik|(42.74085000,22.90723000);Obshtina Kovachevtsi|(42.55000000,22.83333000)"
+Bulgaria,BG,Pleven,Pleven,Sofia,,,43.41667000,24.61667000,Belene;Cherven Bryag;Dolna Mitropolia,"Belene|(43.64594000,25.12627000);Cherven Bryag|(43.26667000,24.10000000);Dolna Mitropolia|(43.46667000,24.53333000)"
+Bulgaria,BG,Plovdiv,Plovdiv,Sofia,,,42.14185410,24.74992970,Asenovgrad;Brezovo;Hisarya,"Asenovgrad|(42.01667000,24.86667000);Brezovo|(42.35000000,25.08333000);Hisarya|(42.50000000,24.70000000)"
+Bulgaria,BG,Razgrad,Razgrad,Sofia,,,43.52582110,26.52306030,Isperih;Kubrat;Loznitsa,"Isperih|(43.71687240,26.83014190);Kubrat|(43.79658000,26.50063000);Loznitsa|(43.36667000,26.60000000)"
+Bulgaria,BG,Ruse,Ruse,Sofia,,,43.84872000,25.95340000,Borovo;Dve Mogili;Ivanovo,"Borovo|(43.50086000,25.80992000);Dve Mogili|(43.59258000,25.87486000);Ivanovo|(43.68568000,25.95565000)"
+Bulgaria,BG,Shumen,Shumen,Sofia,,,43.28333300,26.93333300,Shumen,"Shumen|(43.28333300,26.93333300)"
+Bulgaria,BG,Silistra,Silistra,Sofia,,,44.11710000,27.26056000,Alfatar;Dulovo;Glavinitsa,"Alfatar|(43.94525000,27.28751000);Dulovo|(43.81667000,27.15000000);Glavinitsa|(43.91667000,26.83333000)"
+Bulgaria,BG,Sliven,Sliven,Sofia,,,42.68583000,26.32917000,Kermen;Kotel;Nova Zagora,"Kermen|(42.50000000,26.25000000);Kotel|(42.88737760,26.44915980);Nova Zagora|(42.48333000,26.01667000)"
+Bulgaria,BG,Smolyan,Smolyan,Sofia,,,41.57439000,24.71204000,Banite;Borino;Chepelare,"Banite|(41.61667000,25.01667000);Borino|(41.68408000,24.29300000);Chepelare|(41.73333000,24.68333000)"
+Bulgaria,BG,Sofia,Anton,Sofia,,,42.75000000,24.28333000,Anton;Botevgrad;Bozhurishte,"Anton|(42.75000000,24.28333000);Botevgrad|(42.90000000,23.78333000);Bozhurishte|(42.75000000,23.20000000)"
+Bulgaria,BG,Sofia City,Buhovo,Sofia,,,42.76667000,23.56667000,Buhovo;Sofia;Stolichna Obshtina,"Buhovo|(42.76667000,23.56667000);Sofia|(42.69751000,23.32415000);Stolichna Obshtina|(42.68647000,23.30561000)"
+Bulgaria,BG,Stara Zagora,Stara Zagora,Sofia,,,42.43278000,25.64194000,Asen;Chirpan;Gŭlŭbovo,"Asen|(42.65000000,25.20000000);Chirpan|(42.20000000,25.33333000);Gŭlŭbovo|(42.13333000,25.85000000)"
+Bulgaria,BG,Targovishte,Targovishte,Sofia,,,43.25120000,26.57215000,Antonovo;Obshtina Antonovo;Obshtina Omurtag,"Antonovo|(43.15000000,26.16667000);Obshtina Antonovo|(43.11667000,26.20000000);Obshtina Omurtag|(43.08333000,26.48333000)"
+Bulgaria,BG,Varna,Varna,Sofia,,,43.20738730,27.91666530,Aksakovo;Asparuhovo;Balgarevo,"Aksakovo|(43.25615000,27.82105000);Asparuhovo|(43.18067000,27.88823000);Balgarevo|(43.40296000,28.41189000)"
+Bulgaria,BG,Veliko Tarnovo,Byala Cherkva,Sofia,,,43.20000000,25.30000000,Byala Cherkva;Debelets;Elena,"Byala Cherkva|(43.20000000,25.30000000);Debelets|(43.03333000,25.61667000);Elena|(42.93333000,25.88333000)"
+Bulgaria,BG,Vidin,Vidin,Sofia,,,43.99159000,22.88236000,Belogradchik;Boynitsa;Bregovo,"Belogradchik|(43.62722000,22.68361000);Boynitsa|(43.95650000,22.53255000);Bregovo|(44.15167000,22.64250000)"
+Bulgaria,BG,Vratsa,Vratsa,Sofia,,,43.21000000,23.56250000,Borovan;Byala Slatina;Hayredin,"Borovan|(43.44635800,23.73543160);Byala Slatina|(43.46667000,23.93333000);Hayredin|(43.60193000,23.66135000)"
+Bulgaria,BG,Yambol,Yambol,Sofia,,,42.48393500,26.51055530,Bolyarovo;Elhovo;Obshtina Bolyarovo,"Bolyarovo|(42.14962000,26.81116000);Elhovo|(42.16667000,26.56667000);Obshtina Bolyarovo|(42.15000000,26.85000000)"
+Burkina Faso,BF,Balé,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Bam,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Banwa,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Bazèga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Boucle du Mouhoun,Barani,Ouagadougou,EMEA,11,13.16910000,-3.88990000,Barani;Boromo;Dédougou,"Barani|(13.16910000,-3.88990000);Boromo|(11.74542000,-2.93006000);Dédougou|(12.46338000,-3.46075000)"
+Burkina Faso,BF,Bougouriba,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Boulgou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Boulkiemde,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Cascades,Banfora,Ouagadougou,EMEA,11,10.63333000,-4.76667000,Banfora;Province de la Comoé;Province de la Léraba,"Banfora|(10.63333000,-4.76667000);Province de la Comoé|(10.33333000,-4.41667000);Province de la Léraba|(10.66667000,-5.20000000)"
+Burkina Faso,BF,Centre,Kadiogo Province,Ouagadougou,EMEA,11,12.33333000,-1.50000000,Kadiogo Province;Ouagadougou,"Kadiogo Province|(12.33333000,-1.50000000);Ouagadougou|(12.36566000,-1.53388000)"
+Burkina Faso,BF,Centre-Est,Garango,Ouagadougou,EMEA,11,11.80000000,-0.55056000,Garango;Koupéla;Kouritenga Province,"Garango|(11.80000000,-0.55056000);Koupéla|(12.17864000,-0.35103000);Kouritenga Province|(12.20000000,-0.30000000)"
+Burkina Faso,BF,Centre-Nord,Boulsa,Ouagadougou,EMEA,11,12.66664000,-0.57469000,Boulsa;Kaya;Kongoussi,"Boulsa|(12.66664000,-0.57469000);Kaya|(13.09167000,-1.08444000);Kongoussi|(13.32583000,-1.53472000)"
+Burkina Faso,BF,Centre-Ouest,Goulouré,Ouagadougou,EMEA,11,12.23484000,-1.93394000,Goulouré;Kokologo;Koudougou,"Goulouré|(12.23484000,-1.93394000);Kokologo|(12.19392000,-1.87687000);Koudougou|(12.25263000,-2.36272000)"
+Burkina Faso,BF,Centre-Sud,Bazega Province,Ouagadougou,EMEA,11,11.91667000,-1.50000000,Bazega Province;Kombissiri;Manga,"Bazega Province|(11.91667000,-1.50000000);Kombissiri|(12.06884000,-1.33644000);Manga|(11.66361000,-1.07306000)"
+Burkina Faso,BF,Comoé,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Est,Bogandé,Ouagadougou,EMEA,11,12.97040000,-0.14953000,Bogandé;Diapaga;Fada N'gourma,"Bogandé|(12.97040000,-0.14953000);Diapaga|(12.07305000,1.78838000);Fada N'gourma|(12.06157000,0.35843000)"
+Burkina Faso,BF,Ganzourgou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Gnagna,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Gourma,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Hauts-Bassins,Bobo-Dioulasso,Ouagadougou,EMEA,11,11.17715000,-4.29790000,Bobo-Dioulasso;Houndé;Province du Houet,"Bobo-Dioulasso|(11.17715000,-4.29790000);Houndé|(11.50000000,-3.51667000);Province du Houet|(11.33333000,-4.25000000)"
+Burkina Faso,BF,Houet,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Ioba,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kadiogo,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kénédougou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Komondjari,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kompienga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kossi,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Koulpélogo,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kouritenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Kourwéogo,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Léraba,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Loroum,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Mouhoun,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Nahouri,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Namentenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Nayala,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Nord,Gourcy,Ouagadougou,EMEA,11,13.20776000,-2.35893000,Gourcy;Ouahigouya;Province du Loroum,"Gourcy|(13.20776000,-2.35893000);Ouahigouya|(13.58278000,-2.42158000);Province du Loroum|(13.91667000,-2.16667000)"
+Burkina Faso,BF,Noumbiel,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Oubritenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Oudalan,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Passoré,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Plateau-Central,Boussé,Ouagadougou,EMEA,11,12.66121000,-1.89515000,Boussé;Oubritenga;Province du Ganzourgou,"Boussé|(12.66121000,-1.89515000);Oubritenga|(12.66667000,-1.33333000);Province du Ganzourgou|(12.26667000,-0.76667000)"
+Burkina Faso,BF,Poni,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sahel,Djibo,Ouagadougou,EMEA,11,14.09940000,-1.62554000,Djibo;Dori;Gorom-Gorom,"Djibo|(14.09940000,-1.62554000);Dori|(14.03540000,-0.03450000);Gorom-Gorom|(14.44290000,-0.23468000)"
+Burkina Faso,BF,Sanguié,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sanmatenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Séno,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sissili,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Soum,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sourou,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Sud-Ouest,Batié,Ouagadougou,EMEA,11,9.88333000,-2.91667000,Batié;Dano;Diébougou,"Batié|(9.88333000,-2.91667000);Dano|(11.14640000,-3.05784000);Diébougou|(10.96209000,-3.24967000)"
+Burkina Faso,BF,Tapoa,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Tuy,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Yagha,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Yatenga,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Ziro,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Zondoma,,Ouagadougou,EMEA,11,,,,
+Burkina Faso,BF,Zoundwéogo,,Ouagadougou,EMEA,11,,,,
+Burundi,BI,Bubanza,Bubanza,Bujumbura,EMEA,14,-3.08040000,29.39100000,Bubanza,"Bubanza|(-3.08040000,29.39100000)"
+Burundi,BI,Bujumbura Mairie,Bujumbura,Bujumbura,EMEA,14,-3.38193000,29.36142000,Bujumbura,"Bujumbura|(-3.38193000,29.36142000)"
+Burundi,BI,Bujumbura Rural,,Bujumbura,EMEA,14,,,,
+Burundi,BI,Bururi,Bururi,Bujumbura,EMEA,14,-3.94877000,29.62438000,Bururi,"Bururi|(-3.94877000,29.62438000)"
+Burundi,BI,Cankuzo,Cankuzo,Bujumbura,EMEA,14,-3.21860000,30.55280000,Cankuzo,"Cankuzo|(-3.21860000,30.55280000)"
+Burundi,BI,Cibitoke,Cibitoke,Bujumbura,EMEA,14,-2.88690000,29.12480000,Cibitoke,"Cibitoke|(-2.88690000,29.12480000)"
+Burundi,BI,Gitega,Gitega,Bujumbura,EMEA,14,-3.42708000,29.92463000,Gitega,"Gitega|(-3.42708000,29.92463000)"
+Burundi,BI,Karuzi,Karuzi,Bujumbura,EMEA,14,-3.10139000,30.16278000,Karuzi,"Karuzi|(-3.10139000,30.16278000)"
+Burundi,BI,Kayanza,Kayanza,Bujumbura,EMEA,14,-2.92210000,29.62930000,Kayanza,"Kayanza|(-2.92210000,29.62930000)"
+Burundi,BI,Kirundo,Kirundo,Bujumbura,EMEA,14,-2.58450000,30.09590000,Kirundo,"Kirundo|(-2.58450000,30.09590000)"
+Burundi,BI,Makamba,Makamba,Bujumbura,EMEA,14,-4.13480000,29.80400000,Makamba,"Makamba|(-4.13480000,29.80400000)"
+Burundi,BI,Muramvya,Muramvya,Bujumbura,EMEA,14,-3.26820000,29.60790000,Muramvya,"Muramvya|(-3.26820000,29.60790000)"
+Burundi,BI,Muyinga,Muyinga,Bujumbura,EMEA,14,-2.84510000,30.34140000,Muyinga,"Muyinga|(-2.84510000,30.34140000)"
+Burundi,BI,Mwaro,Mwaro,Bujumbura,EMEA,14,-3.51128000,29.70334000,Mwaro,"Mwaro|(-3.51128000,29.70334000)"
+Burundi,BI,Ngozi,Ngozi,Bujumbura,EMEA,14,-2.90750000,29.83060000,Ngozi,"Ngozi|(-2.90750000,29.83060000)"
+Burundi,BI,Rumonge,Rumonge,Bujumbura,EMEA,14,-3.97360000,29.43860000,Rumonge,"Rumonge|(-3.97360000,29.43860000)"
+Burundi,BI,Rutana,Rutana,Bujumbura,EMEA,14,-3.92790000,29.99200000,Rutana,"Rutana|(-3.92790000,29.99200000)"
+Burundi,BI,Ruyigi,Ruyigi,Bujumbura,EMEA,14,-3.47639000,30.24861000,Ruyigi,"Ruyigi|(-3.47639000,30.24861000)"
+Cambodia,KH,Banteay Meanchey,Mongkol Borei,Phnom Penh,,,13.45531000,102.99186000,Mongkol Borei;Paoy Paet;Sisophon,"Mongkol Borei|(13.45531000,102.99186000);Paoy Paet|(13.65805000,102.56365000);Sisophon|(13.58588000,102.97369000)"
+Cambodia,KH,Battambang,Battambang,Phnom Penh,,,13.10271000,103.19822000,Battambang;Srŏk Âk Phnŭm;Srŏk Banăn,"Battambang|(13.10271000,103.19822000);Srŏk Âk Phnŭm|(13.23621000,103.45894000);Srŏk Banăn|(12.97067000,103.04742000)"
+Cambodia,KH,Kampong Cham,Kampong Cham,Phnom Penh,,,11.98000000,105.44500000,Cheung Prey;Kampong Cham;Srŏk Bathéay,"Cheung Prey|(12.10000000,105.07000000);Kampong Cham|(11.98000000,105.44500000);Srŏk Bathéay|(12.02986000,104.93171000)"
+Cambodia,KH,Kampong Chhnang,Kampong Chhnang,Phnom Penh,,,12.26000000,104.67000000,Baribour;Kampong Chhnang;Rolea B'ier,"Baribour|(12.43000000,104.47000000);Kampong Chhnang|(12.26000000,104.67000000);Rolea B'ier|(12.21000000,104.61000000)"
+Cambodia,KH,Kampong Speu,Kampong Speu,Phnom Penh,,,11.45332000,104.52085000,Kampong Speu;Krŏng Chbar Mon;Srŏk Basedth,"Kampong Speu|(11.45332000,104.52085000);Krŏng Chbar Mon|(11.47091000,104.50655000);Srŏk Basedth|(11.18432000,104.53584000)"
+Cambodia,KH,Kampong Thom,,Phnom Penh,,,,,,
+Cambodia,KH,Kampot,Kampot,Phnom Penh,,,10.61041000,104.18145000,Angkor Chey;Banteay Meas;Chhouk District,"Angkor Chey|(10.76667000,104.65000000);Banteay Meas|(10.61667000,104.53333000);Chhouk District|(10.81667000,104.45000000)"
+Cambodia,KH,Kandal,Krŏng Ta Khmau,Phnom Penh,,,11.45474000,104.94350000,Krŏng Ta Khmau;Srŏk Khsăch Kândal;Ta Khmau,"Krŏng Ta Khmau|(11.45474000,104.94350000);Srŏk Khsăch Kândal|(11.69224000,105.03732000);Ta Khmau|(11.48333000,104.95000000)"
+Cambodia,KH,Kep,Krong Kep,Phnom Penh,,,10.48291000,104.31672000,Krong Kep;Srŏk Dâmnăk Châng’aeur,"Krong Kep|(10.48291000,104.31672000);Srŏk Dâmnăk Châng’aeur|(10.53394000,104.34855000)"
+Cambodia,KH,Koh Kong,Koh Kong,Phnom Penh,,,11.61531000,102.98380000,Koh Kong;Smach Mean Chey;Srae Ambel,"Koh Kong|(11.61531000,102.98380000);Smach Mean Chey|(11.54665000,103.03569000);Srae Ambel|(11.10968000,103.76226000)"
+Cambodia,KH,Kratie,Kracheh,Phnom Penh,,,12.57000000,106.20000000,Kracheh;Kratié;Snuol,"Kracheh|(12.57000000,106.20000000);Kratié|(12.48811000,106.01879000);Snuol|(12.19373000,106.47361000)"
+Cambodia,KH,Mondulkiri,Krŏng Sênmônoŭrôm,Phnom Penh,,,12.50480000,107.15525000,Krŏng Sênmônoŭrôm;Sen Monorom;Srŏk Kaev Seima,"Krŏng Sênmônoŭrôm|(12.50480000,107.15525000);Sen Monorom|(12.45583000,107.18811000);Srŏk Kaev Seima|(12.41722000,106.77025000)"
+Cambodia,KH,Oddar Meanchey,Samraong,Phnom Penh,,,14.18175000,103.51761000,Samraong;Srŏk Bântéay Âmpĭl;Srŏk Sâmraông,"Samraong|(14.18175000,103.51761000);Srŏk Bântéay Âmpĭl|(14.18590000,103.25925000);Srŏk Sâmraông|(14.25039000,103.62739000)"
+Cambodia,KH,Pailin,Pailin,Phnom Penh,,,12.84895000,102.60928000,Khan Sala Krau;Pailin,"Khan Sala Krau|(12.97984000,102.63957000);Pailin|(12.84895000,102.60928000)"
+Cambodia,KH,Phnom Penh,Phnom Penh,Phnom Penh,,,11.56245000,104.91601000,Khan 7 Makara;Khan Châmkar Mon;Khan Dângkaô,"Khan 7 Makara|(11.56254000,104.91405000);Khan Châmkar Mon|(11.54390000,104.92175000);Khan Dângkaô|(11.52457000,104.83944000)"
+Cambodia,KH,Preah Vihear,Sangkom Thmei,Phnom Penh,,,13.47395000,104.77051000,Sangkom Thmei;Srŏk Ch’êh Sên;Srŏk Chhêb,"Sangkom Thmei|(13.47395000,104.77051000);Srŏk Ch’êh Sên|(13.58215000,105.34533000);Srŏk Chhêb|(13.91077000,105.46180000)"
+Cambodia,KH,Prey Veng,Prey Veng,Phnom Penh,,,11.48682000,105.32533000,Prey Veng;Srŏk Kâmpóng Léav;Srŏk Mésang,"Prey Veng|(11.48682000,105.32533000);Srŏk Kâmpóng Léav|(11.50970000,105.30110000);Srŏk Mésang|(11.35528000,105.57235000)"
+Cambodia,KH,Pursat,Pursat,Phnom Penh,,,12.53878000,103.91920000,Bakan;Krakor;Pursat,"Bakan|(12.78000000,103.79000000);Krakor|(12.48000000,104.19000000);Pursat|(12.53878000,103.91920000)"
+Cambodia,KH,Ratanakiri,Banlung,Phnom Penh,,,13.73939000,106.98727000,Banlung;Lumphat;Srŏk Ândong Méas,"Banlung|(13.73939000,106.98727000);Lumphat|(13.49146000,106.98022000);Srŏk Ândong Méas|(13.93352000,107.31155000)"
+Cambodia,KH,Siem Reap,Siem Reap,Phnom Penh,,,13.36179000,103.86056000,Siem Reap;Srŏk Ângkôr Thum;Srŏk Prasat Bakong,"Siem Reap|(13.36179000,103.86056000);Srŏk Ângkôr Thum|(13.57881000,103.85645000);Srŏk Prasat Bakong|(13.21031000,103.97689000)"
+Cambodia,KH,Sihanoukville,Sihanoukville,Phnom Penh,,,10.60932000,103.52958000,Sihanoukville;Srok Stueng Hav,"Sihanoukville|(10.60932000,103.52958000);Srok Stueng Hav|(10.85249000,103.74016000)"
+Cambodia,KH,Stung Treng,Stung Treng,Phnom Penh,,,13.52586000,105.96830000,Srŏk Srêsén;Stueng Traeng;Stung Treng,"Srŏk Srêsén|(13.60530000,106.35819000);Stueng Traeng|(13.65000000,106.07000000);Stung Treng|(13.52586000,105.96830000)"
+Cambodia,KH,Svay Rieng,Svay Rieng,Phnom Penh,,,11.08785000,105.79935000,Srŏk Svay Chrŭm;Svay Rieng,"Srŏk Svay Chrŭm|(11.11160000,105.69814000);Svay Rieng|(11.08785000,105.79935000)"
+Cambodia,KH,Takeo,Takeo,Phnom Penh,,,10.99081000,104.78498000,Krŏng Doun Kaev;Phumĭ Véal Srê;Srŏk Ângkôr Borei,"Krŏng Doun Kaev|(10.99459000,104.79550000);Phumĭ Véal Srê|(10.98081000,104.77828000);Srŏk Ângkôr Borei|(10.99291000,104.95177000)"
+Cameroon,CM,Adamawa,Bankim,Yaounde,,,6.08303000,11.49050000,Bankim;Banyo;Bélel,"Bankim|(6.08303000,11.49050000);Banyo|(6.75000000,11.81667000);Bélel|(7.05000000,14.43333000)"
+Cameroon,CM,Centre,Akono,Yaounde,,,3.50000000,11.33333000,Akono;Akonolinga;Bafia,"Akono|(3.50000000,11.33333000);Akonolinga|(3.76667000,12.25000000);Bafia|(4.75000000,11.23333000)"
+Cameroon,CM,East,Abong Mbang,Yaounde,,,3.98333000,13.18333000,Abong Mbang;Batouri;Bélabo,"Abong Mbang|(3.98333000,13.18333000);Batouri|(4.43333000,14.36667000);Bélabo|(4.93333000,13.30000000)"
+Cameroon,CM,Far North,Bogo,Yaounde,,,10.73360000,14.60928000,Bogo;Kaélé;Kousséri,"Bogo|(10.73360000,14.60928000);Kaélé|(10.10917000,14.45083000);Kousséri|(12.07689000,15.03063000)"
+Cameroon,CM,Littoral,Bonabéri,Yaounde,,,4.07142000,9.68177000,Bonabéri;Diang;Dibombari,"Bonabéri|(4.07142000,9.68177000);Diang|(4.25000000,10.01667000);Dibombari|(4.17870000,9.65610000)"
+Cameroon,CM,North,Faro Department,Yaounde,,,8.25014000,12.87829000,Faro Department;Garoua;Guider,"Faro Department|(8.25014000,12.87829000);Garoua|(9.30143000,13.39771000);Guider|(9.93330000,13.94671000)"
+Cameroon,CM,Northwest,Babanki,Yaounde,,,6.11667000,10.25000000,Babanki;Bali;Bamenda,"Babanki|(6.11667000,10.25000000);Bali|(5.88737000,10.01176000);Bamenda|(5.95970000,10.14597000)"
+Cameroon,CM,South,Akom II,Yaounde,,,2.78333000,10.56667000,Akom II;Ambam;Ébolowa,"Akom II|(2.78333000,10.56667000);Ambam|(2.38333000,11.28333000);Ébolowa|(2.90000000,11.15000000)"
+Cameroon,CM,Southwest,Bamusso,Yaounde,,,4.45910000,8.90270000,Bamusso;Bekondo;Buea,"Bamusso|(4.45910000,8.90270000);Bekondo|(4.68190000,9.32140000);Buea|(4.15342000,9.24231000)"
+Cameroon,CM,West,Bafang,Yaounde,,,5.15705000,10.17710000,Bafang;Bafoussam;Bamendjou,"Bafang|(5.15705000,10.17710000);Bafoussam|(5.47775000,10.41759000);Bamendjou|(5.38988000,10.33014000)"
+Canada,CA,Alberta,Airdrie,Ottawa,,,51.30011000,-114.03528000,Airdrie;Athabasca;Banff,"Airdrie|(51.30011000,-114.03528000);Athabasca|(54.71687000,-113.28537000);Banff|(51.17622000,-115.56982000)"
+Canada,CA,British Columbia,Abbotsford,Ottawa,,,49.05798000,-122.25257000,Abbotsford;Agassiz;Aldergrove,"Abbotsford|(49.05798000,-122.25257000);Agassiz|(49.23298000,-121.76926000);Aldergrove|(49.05801000,-122.47087000)"
+Canada,CA,Manitoba,Altona,Ottawa,,,49.10469000,-97.55961000,Altona;Beausejour;Boissevain,"Altona|(49.10469000,-97.55961000);Beausejour|(50.06220000,-96.51669000);Boissevain|(49.23062000,-100.05586000)"
+Canada,CA,New Brunswick,Baie Ste. Anne,Ottawa,,,47.05231000,-64.95355000,Baie Ste. Anne;Bathurst;Bouctouche,"Baie Ste. Anne|(47.05231000,-64.95355000);Bathurst|(47.61814000,-65.65112000);Bouctouche|(46.46844000,-64.73905000)"
+Canada,CA,Newfoundland and Labrador,Bay Roberts,Ottawa,,,47.59989000,-53.26478000,Bay Roberts;Bay St. George South;Bonavista,"Bay Roberts|(47.59989000,-53.26478000);Bay St. George South|(48.22781000,-58.84162000);Bonavista|(48.64989000,-53.11474000)"
+Canada,CA,Northwest Territories,Behchokǫ̀,Ottawa,,,62.80250000,-116.04639000,Behchokǫ̀;Fort McPherson;Fort Smith,"Behchokǫ̀|(62.80250000,-116.04639000);Fort McPherson|(67.43863000,-134.88543000);Fort Smith|(60.00439000,-111.88871000)"
+Canada,CA,Nova Scotia,Amherst,Ottawa,,,45.83345000,-64.19874000,Amherst;Annapolis County;Antigonish,"Amherst|(45.83345000,-64.19874000);Annapolis County|(44.58345000,-65.16551000);Antigonish|(45.61685000,-61.99858000)"
+Canada,CA,Nunavut,Clyde River,Ottawa,,,70.47233000,-68.58987000,Clyde River;Gjoa Haven;Iqaluit,"Clyde River|(70.47233000,-68.58987000);Gjoa Haven|(68.62602000,-95.87836000);Iqaluit|(63.74697000,-68.51727000)"
+Canada,CA,Ontario,Ajax,Ottawa,,,43.85012000,-79.03288000,Ajax;Algoma;Alliston,"Ajax|(43.85012000,-79.03288000);Algoma|(47.88364000,-84.42406000);Alliston|(44.15011000,-79.86635000)"
+Canada,CA,Prince Edward Island,Alberton,Ottawa,,,46.81685000,-64.06542000,Alberton;Belfast;Charlottetown,"Alberton|(46.81685000,-64.06542000);Belfast|(46.08341000,-62.88197000);Charlottetown|(46.23899000,-63.13414000)"
+Canada,CA,Quebec,Abitibi-Témiscamingue,Ottawa,,,48.10018000,-77.78280000,Abitibi-Témiscamingue;Acton Vale;Adstock,"Abitibi-Témiscamingue|(48.10018000,-77.78280000);Acton Vale|(45.65007000,-72.56582000);Adstock|(46.05007000,-71.08235000)"
+Canada,CA,Saskatchewan,Assiniboia,Ottawa,,,49.63336000,-105.98446000,Assiniboia;Biggar;Canora,"Assiniboia|(49.63336000,-105.98446000);Biggar|(52.06680000,-108.00135000);Canora|(51.63328000,-102.43425000)"
+Canada,CA,Yukon,Dawson City,Ottawa,,,64.06013000,-139.43328000,Dawson City;Haines Junction;Watson Lake,"Dawson City|(64.06013000,-139.43328000);Haines Junction|(60.75216000,-137.51082000);Watson Lake|(60.06349000,-128.70893000)"
+Cape Verde,CV,Barlavento Islands,,Praia,,,,,,
+Cape Verde,CV,Boa Vista,Sal Rei,Praia,,,16.17611000,-22.91722000,Sal Rei,"Sal Rei|(16.17611000,-22.91722000)"
+Cape Verde,CV,Brava,Nova Sintra,Praia,,,14.87139000,-24.69556000,Nova Sintra,"Nova Sintra|(14.87139000,-24.69556000)"
+Cape Verde,CV,Maio,Vila do Maio,Praia,,,15.13823000,-23.21158000,Vila do Maio,"Vila do Maio|(15.13823000,-23.21158000)"
+Cape Verde,CV,Mosteiros,Igreja,Praia,,,15.03389000,-24.32500000,Igreja,"Igreja|(15.03389000,-24.32500000)"
+Cape Verde,CV,Paul,Pombas,Praia,,,17.15026000,-25.02007000,Pombas,"Pombas|(17.15026000,-25.02007000)"
+Cape Verde,CV,Porto Novo,Porto Novo,Praia,,,17.01969000,-25.06471000,Porto Novo,"Porto Novo|(17.01969000,-25.06471000)"
+Cape Verde,CV,Praia,Praia,Praia,,,14.93152000,-23.51254000,Praia,"Praia|(14.93152000,-23.51254000)"
+Cape Verde,CV,Ribeira Brava,Ribeira Brava,Praia,,,16.61583000,-24.29833000,Ribeira Brava,"Ribeira Brava|(16.61583000,-24.29833000)"
+Cape Verde,CV,Ribeira Grande,Ribeira Grande,Praia,,,17.18250000,-25.06500000,Ponta do Sol;Ribeira Grande,"Ponta do Sol|(17.20171000,-25.09217000);Ribeira Grande|(17.18250000,-25.06500000)"
+Cape Verde,CV,Ribeira Grande de Santiago,Cidade Velha,Praia,,,14.91531000,-23.60527000,Cidade Velha,"Cidade Velha|(14.91531000,-23.60527000)"
+Cape Verde,CV,Sal,Espargos,Praia,,,16.75524000,-22.94460000,Espargos;Santa Maria,"Espargos|(16.75524000,-22.94460000);Santa Maria|(16.59796000,-22.90509000)"
+Cape Verde,CV,Santa Catarina,Assomada,Praia,,,15.10000000,-23.68333000,Assomada,"Assomada|(15.10000000,-23.68333000)"
+Cape Verde,CV,Santa Catarina do Fogo,Cova Figueira,Praia,,,14.89054000,-24.29343000,Cova Figueira,"Cova Figueira|(14.89054000,-24.29343000)"
+Cape Verde,CV,Santa Cruz,Santa Cruz,Praia,,,15.13333000,-23.56667000,Pedra Badejo;Santa Cruz,"Pedra Badejo|(15.13750000,-23.53083000);Santa Cruz|(15.13333000,-23.56667000)"
+Cape Verde,CV,São Domingos,São Domingos,Praia,,,15.02438000,-23.56250000,São Domingos,"São Domingos|(15.02438000,-23.56250000)"
+Cape Verde,CV,São Filipe,São Filipe,Praia,,,14.89610000,-24.49556000,São Filipe,"São Filipe|(14.89610000,-24.49556000)"
+Cape Verde,CV,São Lourenço dos Órgãos,João Teves,Praia,,,15.06694000,-23.58917000,João Teves,"João Teves|(15.06694000,-23.58917000)"
+Cape Verde,CV,São Miguel,Calheta,Praia,,,15.18613000,-23.59228000,Calheta,"Calheta|(15.18613000,-23.59228000)"
+Cape Verde,CV,São Vicente,Mindelo,Praia,,,16.89014000,-24.98042000,Mindelo,"Mindelo|(16.89014000,-24.98042000)"
+Cape Verde,CV,Sotavento Islands,,Praia,,,,,,
+Cape Verde,CV,Tarrafal,Tarrafal,Praia,,,15.27881000,-23.75192000,Tarrafal,"Tarrafal|(15.27881000,-23.75192000)"
+Cape Verde,CV,Tarrafal de São Nicolau,Tarrafal de São Nicolau,Praia,,,16.56622000,-24.35793000,Tarrafal de São Nicolau,"Tarrafal de São Nicolau|(16.56622000,-24.35793000)"
+Cayman Islands,KY,Cayman Brac,Cayman Brac,George Town,,,19.71999700,-79.89072660,Cayman Brac,"Cayman Brac|(19.71999700,-79.89072660)"
+Cayman Islands,KY,Grand Cayman,Bodden Town,George Town,,,19.27966930,-81.27779990,Bodden Town;East End;George Town,"Bodden Town|(19.27966930,-81.27779990);East End|(19.29958980,-81.11961380);George Town|(19.29023260,-81.44333720)"
+Cayman Islands,KY,Little Cayman,Little Cayman,George Town,,,19.68567390,-80.11830190,Little Cayman,"Little Cayman|(19.68567390,-80.11830190)"
+Central African Republic,CF,Bamingui-Bangoran,Bamingui,Bangui,,,7.88897000,20.04875000,Bamingui;Ndélé,"Bamingui|(7.88897000,20.04875000);Ndélé|(8.74287000,20.89108000)"
+Central African Republic,CF,Bangui,Bangui,Bangui,,,4.36122000,18.55496000,Bangui,"Bangui|(4.36122000,18.55496000)"
+Central African Republic,CF,Basse-Kotto,Alindao,Bangui,,,5.02667000,21.20876000,Alindao;Kembé;Mobaye,"Alindao|(5.02667000,21.20876000);Kembé|(4.62275000,21.88645000);Mobaye|(4.31902000,21.17861000)"
+Central African Republic,CF,Haut-Mbomou,Obo,Bangui,,,5.39586000,26.49211000,Obo;Zemio,"Obo|(5.39586000,26.49211000);Zemio|(5.03144000,25.13614000)"
+Central African Republic,CF,Haute-Kotto,Bria,Bangui,,,6.54233000,21.98633000,Bria;Ouadda,"Bria|(6.54233000,21.98633000);Ouadda|(8.07771000,22.40075000)"
+Central African Republic,CF,Kémo,Sibut,Bangui,,,5.71801000,19.07389000,Sibut,"Sibut|(5.71801000,19.07389000)"
+Central African Republic,CF,Lobaye,Boda,Bangui,,,4.31887000,17.46953000,Boda;Boganangone;Mbaiki,"Boda|(4.31887000,17.46953000);Boganangone|(4.73558000,17.14047000);Mbaiki|(3.97145000,17.93352000)"
+Central African Republic,CF,Mambéré-Kadéï,Berberati,Bangui,,,4.31211000,15.88948000,Berberati;Carnot;Gamboula,"Berberati|(4.31211000,15.88948000);Carnot|(4.94273000,15.87735000);Gamboula|(4.11775000,15.13926000)"
+Central African Republic,CF,Mbomou,Bangassou,Bangui,,,4.74132000,22.81838000,Bangassou;Gambo;Ouango,"Bangassou|(4.74132000,22.81838000);Gambo|(4.64816000,22.26331000);Ouango|(4.31325000,22.55524000)"
+Central African Republic,CF,Nana-Grébizi,Kaga Bandoro,Bangui,,,6.98961000,19.18744000,Kaga Bandoro,"Kaga Bandoro|(6.98961000,19.18744000)"
+Central African Republic,CF,Nana-Mambéré,Baoro,Bangui,,,5.66667000,15.96667000,Baoro;Bouar,"Baoro|(5.66667000,15.96667000);Bouar|(5.93404000,15.59599000)"
+Central African Republic,CF,Ombella-M'Poko,Bimbo,Bangui,,,4.25671000,18.41583000,Bimbo;Boali;Damara,"Bimbo|(4.25671000,18.41583000);Boali|(4.80048000,18.12747000);Damara|(4.96075000,18.70350000)"
+Central African Republic,CF,Ouaka,Bambari,Bangui,,,5.76795000,20.67565000,Bambari;Grimari;Ippy,"Bambari|(5.76795000,20.67565000);Grimari|(5.73549000,19.91209000);Ippy|(6.26793000,21.22468000)"
+Central African Republic,CF,Ouham,Batangafo,Bangui,,,7.30082000,18.28330000,Batangafo;Bossangoa;Bouca,"Batangafo|(7.30082000,18.28330000);Bossangoa|(6.49263000,17.45518000);Bouca|(6.50734000,18.27670000)"
+Central African Republic,CF,Ouham-Pendé,Bocaranga,Bangui,,,6.76546000,15.77873000,Bocaranga;Bozoum;Paoua,"Bocaranga|(6.76546000,15.77873000);Bozoum|(6.31933000,16.37992000);Paoua|(7.24269000,16.44059000)"
+Central African Republic,CF,Sangha-Mbaéré,Nola,Bangui,,,3.52494000,16.04583000,Nola,"Nola|(3.52494000,16.04583000)"
+Central African Republic,CF,Vakaga,Birao,Bangui,,,10.28488000,22.78818000,Birao;Ouanda-Djallé,"Birao|(10.28488000,22.78818000);Ouanda-Djallé|(9.05877000,22.42741000)"
+Chad,TD,Bahr el Gazel,Moussoro,N'Djamena,,,13.64143000,16.48941000,Moussoro,"Moussoro|(13.64143000,16.48941000)"
+Chad,TD,Batha,Ati,N'Djamena,,,13.21540000,18.33530000,Ati;Oum Hadjer,"Ati|(13.21540000,18.33530000);Oum Hadjer|(13.29540000,19.69660000)"
+Chad,TD,Borkou,Faya-Largeau,N'Djamena,,,17.92570000,19.10428000,Faya-Largeau,"Faya-Largeau|(17.92570000,19.10428000)"
+Chad,TD,Chari-Baguirmi,Baguirmi Department,N'Djamena,,,11.39833333,16.16750000,Baguirmi Department;Bousso;Dababa,"Baguirmi Department|(11.39833333,16.16750000);Bousso|(10.48250000,16.71611111);Dababa|(12.38000000,17.06000000)"
+Chad,TD,Ennedi-Est,,N'Djamena,,,,,,
+Chad,TD,Ennedi-Ouest,Fada,N'Djamena,,,17.18535000,21.58114000,Fada,"Fada|(17.18535000,21.58114000)"
+Chad,TD,Guéra,Bitkine,N'Djamena,,,11.98010000,18.21380000,Bitkine;Melfi;Mongo,"Bitkine|(11.98010000,18.21380000);Melfi|(11.05980000,17.93550000);Mongo|(12.18441000,18.69303000)"
+Chad,TD,Hadjer-Lamis,Bokoro,N'Djamena,,,12.37813000,17.05876000,Bokoro;Massaguet;Massakory,"Bokoro|(12.37813000,17.05876000);Massaguet|(12.47554000,15.43647000);Massakory|(12.99600000,15.72927000)"
+Chad,TD,Kanem,Mao,N'Djamena,,,14.12116000,15.31030000,Mao,"Mao|(14.12116000,15.31030000)"
+Chad,TD,Lac,Bol,N'Djamena,,,13.46706000,14.71363000,Bol,"Bol|(13.46706000,14.71363000)"
+Chad,TD,Logone Occidental,Beïnamar,N'Djamena,,,8.66980000,15.38130000,Beïnamar;Benoy;Lac Wey,"Beïnamar|(8.66980000,15.38130000);Benoy|(8.98327000,16.31991000);Lac Wey|(8.70502000,15.98303000)"
+Chad,TD,Logone Oriental,Bébédja,N'Djamena,,,8.67610000,16.56600000,Bébédja;Béboto;Doba,"Bébédja|(8.67610000,16.56600000);Béboto|(8.26681000,16.93898000);Doba|(8.65000000,16.85000000)"
+Chad,TD,Mandoul,Goundi,N'Djamena,,,9.36267000,17.36597000,Goundi;Koumra;Moïssala,"Goundi|(9.36267000,17.36597000);Koumra|(8.91256000,17.55392000);Moïssala|(8.34040000,17.76630000)"
+Chad,TD,Mayo-Kebbi Est,Bongor,N'Djamena,,,10.28056000,15.37222000,Bongor;Gounou Gaya;Guelendeng,"Bongor|(10.28056000,15.37222000);Gounou Gaya|(9.62940000,15.51320000);Guelendeng|(10.91762000,15.55011000)"
+Chad,TD,Mayo-Kebbi Ouest,Mboursou Léré,N'Djamena,,,9.76390000,14.15390000,Mboursou Léré;Pala,"Mboursou Léré|(9.76390000,14.15390000);Pala|(9.36420000,14.90460000)"
+Chad,TD,Moyen-Chari,Kyabé,N'Djamena,,,9.45149000,18.94493000,Kyabé;Sarh,"Kyabé|(9.45149000,18.94493000);Sarh|(9.14290000,18.39230000)"
+Chad,TD,N'Djamena,N'Djamena,N'Djamena,,,12.11000000,15.05000000,N'Djamena,"N'Djamena|(12.11000000,15.05000000)"
+Chad,TD,Ouaddaï,Abéché,N'Djamena,,,13.82916000,20.83240000,Abéché;Adré;Goz Béïda,"Abéché|(13.82916000,20.83240000);Adré|(13.46648000,22.19875000);Goz Béïda|(13.94563000,20.54680000)"
+Chad,TD,Salamat,Am Timan,N'Djamena,,,11.02970000,20.28270000,Am Timan,"Am Timan|(11.02970000,20.28270000)"
+Chad,TD,Sila,Goz Beïda,N'Djamena,,,12.22484000,21.41034000,Goz Beïda,"Goz Beïda|(12.22484000,21.41034000)"
+Chad,TD,Tandjilé,Béré,N'Djamena,,,9.32020000,16.15520000,Béré;Kelo;Laï,"Béré|(9.32020000,16.15520000);Kelo|(9.30859000,15.80658000);Laï|(9.39720000,16.30066000)"
+Chad,TD,Tibesti,Aozou,N'Djamena,,,21.83750000,17.42750000,Aozou,"Aozou|(21.83750000,17.42750000)"
+Chad,TD,Wadi Fira,Biltine,N'Djamena,,,14.52791000,20.92749000,Biltine;Iriba,"Biltine|(14.52791000,20.92749000);Iriba|(15.11667000,22.25000000)"
+Chile,CL,Aisén del General Carlos Ibañez del Campo,Aysén,Santiago,,,-45.40303000,-72.69184000,Aysén;Chile Chico;Cisnes,"Aysén|(-45.40303000,-72.69184000);Chile Chico|(-46.53760000,-71.72930000);Cisnes|(-44.72750000,-72.68050000)"
+Chile,CL,Antofagasta,Antofagasta,Santiago,,,-23.65236000,-70.39540000,Antofagasta;Calama;María Elena,"Antofagasta|(-23.65236000,-70.39540000);Calama|(-22.45667000,-68.92371000);María Elena|(-22.35000000,-69.66666667)"
+Chile,CL,Arica y Parinacota,Arica,Santiago,,,-18.47460000,-70.29792000,Arica;Camarones;General Lagos,"Arica|(-18.47460000,-70.29792000);Camarones|(-19.01666667,-69.86666667);General Lagos|(-17.56666667,-69.50000000)"
+Chile,CL,Atacama,Alto del Carmen,Santiago,,,-28.93355556,-70.46227778,Alto del Carmen;Caldera;Chañaral,"Alto del Carmen|(-28.93355556,-70.46227778);Caldera|(-27.06666667,-70.81666667);Chañaral|(-26.34790000,-70.62240000)"
+Chile,CL,Biobío,Alto Biobío,Santiago,,,-38.05000000,-71.31666667,Alto Biobío;Antuco;Arauco,"Alto Biobío|(-38.05000000,-71.31666667);Antuco|(-37.33333333,-71.68333333);Arauco|(-37.24630000,-73.31752000)"
+Chile,CL,Coquimbo,Coquimbo,Santiago,,,-29.95332000,-71.33947000,Andacollo;Canela;Combarbalá,"Andacollo|(-30.21666667,-71.08333333);Canela|(-31.40000000,-71.45000000);Combarbalá|(-31.16666667,-71.05000000)"
+Chile,CL,La Araucanía,Angol,Santiago,,,-37.79519000,-72.71636000,Angol;Carahue;Cholchol,"Angol|(-37.79519000,-72.71636000);Carahue|(-38.71122000,-73.16101000);Cholchol|(-38.60000000,-72.85000000)"
+Chile,CL,Libertador General Bernardo O'Higgins,Chépica,Santiago,,,-34.73333333,-71.28333333,Chépica;Chimbarongo;Codegua,"Chépica|(-34.73333333,-71.28333333);Chimbarongo|(-34.71247000,-71.04340000);Codegua|(-34.03333333,-70.66666667)"
+Chile,CL,Los Lagos,Ancud,Santiago,,,-41.87070000,-73.81622000,Ancud;Calbuco;Castro,"Ancud|(-41.87070000,-73.81622000);Calbuco|(-41.77338000,-73.13049000);Castro|(-42.47210000,-73.77319000)"
+Chile,CL,Los Ríos,Corral,Santiago,,,-39.88730000,-73.43101000,Corral;Futrono;La Unión,"Corral|(-39.88730000,-73.43101000);Futrono|(-40.13333333,-72.40000000);La Unión|(-40.29313000,-73.08167000)"
+Chile,CL,Magallanes y de la Antártica Chilena,Antártica,Santiago,,,-53.14138970,-70.90576650,Antártica;Cabo de Hornos;Laguna Blanca,"Antártica|(-53.14138970,-70.90576650);Cabo de Hornos|(-54.93333333,-67.61666667);Laguna Blanca|(-52.25000000,-71.91666667)"
+Chile,CL,Maule,Maule,Santiago,,,-35.53333333,-71.70000000,Cauquenes;Chanco;Colbún,"Cauquenes|(-35.96710000,-72.32248000);Chanco|(-35.73333333,-72.53333333);Colbún|(-35.69494000,-71.40568000)"
+Chile,CL,Ñuble,Bulnes,Santiago,,,-36.74232000,-72.29854000,Bulnes;Chillán;Chillán Viejo,"Bulnes|(-36.74232000,-72.29854000);Chillán|(-36.60664000,-72.10344000);Chillán Viejo|(-36.62290000,-72.13170000)"
+Chile,CL,Región Metropolitana de Santiago,Alhué,Santiago,,,-34.03333333,-71.10000000,Alhué;Buin;Calera de Tango,"Alhué|(-34.03333333,-71.10000000);Buin|(-33.73257000,-70.74281000);Calera de Tango|(-33.65000000,-70.81666667)"
+Chile,CL,Tarapacá,Alto Hospicio,Santiago,,,-20.25000000,-70.11666667,Alto Hospicio;Camiña;Colchane,"Alto Hospicio|(-20.25000000,-70.11666667);Camiña|(-19.30000000,-69.41666667);Colchane|(-19.27541100,-68.63964600)"
+Chile,CL,Valparaíso,Valparaíso,Santiago,,,-33.03600000,-71.62963000,Algarrobo;Cabildo;Calle Larga,"Algarrobo|(-33.36925600,-71.66813900);Cabildo|(-32.41737000,-70.82435000);Calle Larga|(-32.85000000,-70.63333333)"
+China,CN,Anhui,Anqing,Beijing,,,30.51365000,117.04723000,Anqing;Bengbu;Bozhou,"Anqing|(30.51365000,117.04723000);Bengbu|(32.94083000,117.36083000);Bozhou|(33.87722000,115.77028000)"
+China,CN,Beijing,Beijing,Beijing,,,39.90750000,116.39723000,Beijing;Changping;Daxing,"Beijing|(39.90750000,116.39723000);Changping|(40.21612000,116.23471000);Daxing|(39.74025000,116.32693000)"
+China,CN,Chongqing,Chongqing,Beijing,,,29.56278000,106.55278000,Beibei;Caijia;Chongqing,"Beibei|(29.82739000,106.43645000);Caijia|(28.90889000,106.34040000);Chongqing|(29.56278000,106.55278000)"
+China,CN,Fujian,Badu,Beijing,,,26.81028000,119.56417000,Badu;Baiqi;Baiyun,"Badu|(26.81028000,119.56417000);Baiqi|(24.88244000,118.70869000);Baiyun|(26.03648000,118.90622000)"
+China,CN,Gansu,Baiyin,Beijing,,,36.54696000,104.17023000,Baiyin;Beidao;Dingxi Shi,"Baiyin|(36.54696000,104.17023000);Beidao|(34.56861000,105.89333000);Dingxi Shi|(35.03710000,104.38623000)"
+China,CN,Guangdong,Anbu,Beijing,,,23.44895000,116.68092000,Anbu;Chaozhou;Chenghua,"Anbu|(23.44895000,116.68092000);Chaozhou|(23.65396000,116.62262000);Chenghua|(23.46132000,116.77007000)"
+China,CN,Guangxi Zhuang,Babu,Beijing,,,24.41667000,111.51667000,Babu;Baihe;Baise City,"Babu|(24.41667000,111.51667000);Baihe|(22.13430000,107.23200000);Baise City|(23.89972000,106.61333000)"
+China,CN,Guizhou,Anshun,Beijing,,,26.25000000,105.93333000,Anshun;Aoshi;Bahuang,"Anshun|(26.25000000,105.93333000);Aoshi|(26.40167000,109.07111000);Bahuang|(27.71806000,109.01889000)"
+China,CN,Hainan,Basuo,Beijing,,,19.09390000,108.65456000,Basuo;Chongshan;Dadonghai,"Basuo|(19.09390000,108.65456000);Chongshan|(18.78229000,109.50130000);Dadonghai|(18.22056000,109.51028000)"
+China,CN,Hebei,Baoding,Beijing,,,38.85111000,115.49028000,Baoding;Beidaihehaibin;Botou,"Baoding|(38.85111000,115.49028000);Beidaihehaibin|(39.82222000,119.51806000);Botou|(38.06667000,116.56660000)"
+China,CN,Heilongjiang,Acheng,Beijing,,,45.54545000,126.97703000,Acheng;Anda;Baiquan,"Acheng|(45.54545000,126.97703000);Anda|(46.40202000,125.31454000);Baiquan|(47.60605000,126.08481000)"
+China,CN,Henan,Anyang,Beijing,,,36.09600000,114.38278000,Anyang;Anyang Shi;Binhe,"Anyang|(36.09600000,114.38278000);Anyang Shi|(36.13639000,114.33667000);Binhe|(32.68833000,112.82750000)"
+China,CN,Hong Kong SAR,,Beijing,,,,,,
+China,CN,Hubei,Anlu,Beijing,,,31.25750000,113.67833000,Anlu;Buhe;Caidian,"Anlu|(31.25750000,113.67833000);Buhe|(30.28757000,112.22979000);Caidian|(30.58333000,114.03333000)"
+China,CN,Hunan,Anjiang,Beijing,,,27.31944000,110.10306000,Anjiang;Anping;Anxiang,"Anjiang|(27.31944000,110.10306000);Anping|(27.86639000,110.11611000);Anxiang|(29.40000000,112.15000000)"
+China,CN,Inner Mongolia,Baotou,Beijing,,,40.65222000,109.82222000,Baotou;Bayan Nur;Bayannur Shi,"Baotou|(40.65222000,109.82222000);Bayan Nur|(40.74143000,107.38599000);Bayannur Shi|(41.56958000,107.49485000)"
+China,CN,Jiangsu,ChangZhou,Beijing,,,31.72322000,119.59794000,ChangZhou;Haizhou;HuaiAn,"ChangZhou|(31.72322000,119.59794000);Haizhou|(34.57300501,119.16126173);HuaiAn|(33.29433000,118.87350000)"
+China,CN,Jiangxi,Changleng,Beijing,,,28.70000000,115.81667000,Changleng;Fenyi;Ganzhou,"Changleng|(28.70000000,115.81667000);Fenyi|(27.81117000,114.66805000);Ganzhou|(25.84664000,114.93260000)"
+China,CN,Jilin,Jilin,Beijing,,,43.85083000,126.56028000,Baicheng;Baishan;Baishishan,"Baicheng|(45.60746000,122.82076000);Baishan|(41.93853000,126.41965000);Baishishan|(43.58333000,127.56667000)"
+China,CN,Liaoning,Anshan,Beijing,,,41.12361000,122.99000000,Anshan;Beipiao;Benxi,"Anshan|(41.12361000,122.99000000);Beipiao|(41.79194000,120.77917000);Benxi|(41.28861000,123.76500000)"
+China,CN,Macau SAR,,Beijing,,,,,,
+China,CN,Ningxia Huizu,Dawukou,Beijing,,,39.04194000,106.39583000,Dawukou;Dongta;Shitanjing,"Dawukou|(39.04194000,106.39583000);Dongta|(38.08140000,106.34444000);Shitanjing|(39.23417000,106.34389000)"
+China,CN,Qinghai,Delingha,Beijing,,,37.37600000,97.37457000,Delingha;Golmud;Golog Tibetan Autonomous Prefecture,"Delingha|(37.37600000,97.37457000);Golmud|(36.40672000,94.90061000);Golog Tibetan Autonomous Prefecture|(34.08595000,99.55181000)"
+China,CN,Shaanxi,Ankang,Beijing,,,32.68000000,109.01722000,Ankang;Baoji Shi;Guozhen,"Ankang|(32.68000000,109.01722000);Baoji Shi|(34.36944000,107.13635000);Guozhen|(34.36591000,107.35904000)"
+China,CN,Shandong,Anqiu,Beijing,,,36.43417000,119.19250000,Anqiu;Beizhai;Bianzhuang,"Anqiu|(36.43417000,119.19250000);Beizhai|(36.21972000,120.52889000);Bianzhuang|(34.84861000,118.04472000)"
+China,CN,Shanghai,Shanghai,Beijing,,,31.22222000,121.45806000,Shanghai;Songjiang;Zhabei,"Shanghai|(31.22222000,121.45806000);Songjiang|(31.03595000,121.21460000);Zhabei|(31.25861000,121.45972000)"
+China,CN,Shanxi,Changzhi,Beijing,,,36.18389000,113.10528000,Changzhi;Datong;Datong Shi,"Changzhi|(36.18389000,113.10528000);Datong|(40.09361000,113.29139000);Datong Shi|(40.10484000,113.63334000)"
+China,CN,Sichuan,Aba Zangzu Qiangzu Zizhizhou,Beijing,,,32.41875000,102.63664000,Aba Zangzu Qiangzu Zizhizhou;Barkam;Bazhong Shi,"Aba Zangzu Qiangzu Zizhizhou|(32.41875000,102.63664000);Barkam|(31.90059000,102.22092000);Bazhong Shi|(32.04025000,107.06230000)"
+China,CN,Taiwan,Baoying,Beijing,,,33.22917000,119.30917000,Baoying;Changshu City;Changzhou,"Baoying|(33.22917000,119.30917000);Changshu City|(31.64615000,120.74221000);Changzhou|(31.77359000,119.95401000)"
+China,CN,Tianjin,Tianjin,Beijing,,,39.14666667,117.20555556,Badaogu;Baijian;Bamencheng,"Badaogu|(39.47333333,117.32972222);Baijian|(39.99416667,117.20861111);Bamencheng|(39.57777778,117.60527778)"
+China,CN,Xinjiang,Ailan Mubage,Beijing,,,43.90845000,81.33299000,Ailan Mubage;Aksu;Aksu Diqu,"Ailan Mubage|(43.90845000,81.33299000);Aksu|(41.18418000,80.27921000);Aksu Diqu|(40.55689000,81.84629000)"
+China,CN,Xizang,Burang,Beijing,,,30.29559000,81.17511000,Burang;Dêqên;Jiangzi,"Burang|(30.29559000,81.17511000);Dêqên|(29.96178000,90.71875000);Jiangzi|(28.92026000,89.59956000)"
+China,CN,Yunnan,Chuxiong Yizu Zizhizhou,Beijing,,,25.43204000,101.70479000,Chuxiong Yizu Zizhizhou;Dali;Dali Baizu Zizhizhou,"Chuxiong Yizu Zizhizhou|(25.43204000,101.70479000);Dali|(25.58474000,100.21229000);Dali Baizu Zizhizhou|(25.68548000,100.13104000)"
+China,CN,Zhejiang,Deqing,Beijing,,,30.54485000,119.95990000,Deqing;Dongyang;Fenghua,"Deqing|(30.54485000,119.95990000);Dongyang|(29.26778000,120.22528000);Fenghua|(29.65628000,121.40640000)"
+Colombia,CO,Amazonas,El Encanto,Bogotá,,,-1.56261000,-73.25684000,El Encanto;La Chorrera;La Pedrera,"El Encanto|(-1.56261000,-73.25684000);La Chorrera|(-1.48894000,-72.72935000);La Pedrera|(-1.65596000,-70.22186000)"
+Colombia,CO,Antioquia,Abejorral,Bogotá,,,5.78928000,-75.42725000,Abejorral;Abriaquí;Alejandría,"Abejorral|(5.78928000,-75.42725000);Abriaquí|(6.63148000,-76.06444000);Alejandría|(6.36667000,-75.08333000)"
+Colombia,CO,Arauca,Arauca,Bogotá,,,7.08471000,-70.75908000,Arauca;Arauquita;Cravo Norte,"Arauca|(7.08471000,-70.75908000);Arauquita|(7.02917000,-71.42806000);Cravo Norte|(6.30173000,-70.20415000)"
+Colombia,CO,Atlántico,Baranoa,Bogotá,,,10.79497000,-74.92073000,Baranoa;Barranquilla;Campo de la Cruz,"Baranoa|(10.79497000,-74.92073000);Barranquilla|(10.96854000,-74.78132000);Campo de la Cruz|(10.37844000,-74.90258000)"
+Colombia,CO,Bogotá D.C.,Bogotá D.C.,Bogotá,,,4.61263889,-74.07050000,Bogotá D.C.,"Bogotá D.C.|(4.61263889,-74.07050000)"
+Colombia,CO,Bolívar,Achí,Bogotá,,,8.56950000,-74.55715000,Achí;Altos del Rosario;Arenal,"Achí|(8.56950000,-74.55715000);Altos del Rosario|(8.79162000,-74.16556000);Arenal|(8.45928000,-73.94331000)"
+Colombia,CO,Boyacá,Boyacá,Bogotá,,,5.45371000,-73.36250000,Almeida;Aquitania;Arcabuco,"Almeida|(4.97083000,-73.37972000);Aquitania|(5.40341000,-72.90192000);Arcabuco|(5.75463000,-73.43669000)"
+Colombia,CO,Caldas,Aguadas,Bogotá,,,5.61161000,-75.45624000,Aguadas;Anserma;Aranzazu,"Aguadas|(5.61161000,-75.45624000);Anserma|(5.20427000,-75.79167000);Aranzazu|(5.25519000,-75.50984000)"
+Colombia,CO,Caquetá,Albania,Bogotá,,,1.26325000,-75.95366000,Albania;Belén de Los Andaquies;Cartagena del Chairá,"Albania|(1.26325000,-75.95366000);Belén de Los Andaquies|(1.41667000,-75.91667000);Cartagena del Chairá|(1.33488000,-74.84289000)"
+Colombia,CO,Casanare,Aguazul,Bogotá,,,5.17282000,-72.54706000,Aguazul;Chameza;Hato Corozal,"Aguazul|(5.17282000,-72.54706000);Chameza|(5.19237000,-72.88952000);Hato Corozal|(6.15472222,-71.76527888)"
+Colombia,CO,Cauca,Almaguer,Bogotá,,,1.91472000,-76.85482000,Almaguer;Argelia;Balboa,"Almaguer|(1.91472000,-76.85482000);Argelia|(2.31728000,-77.25700000);Balboa|(2.08436000,-77.20781000)"
+Colombia,CO,Cesar,Aguachica,Bogotá,,,8.30844000,-73.61660000,Aguachica;Agustín Codazzi;Astrea,"Aguachica|(8.30844000,-73.61660000);Agustín Codazzi|(10.03672000,-73.23558000);Astrea|(9.49828000,-73.97591000)"
+Colombia,CO,Chocó,Acandí,Bogotá,,,8.51158000,-77.27719000,Acandí;Alto Baudó;Atrato,"Acandí|(8.51158000,-77.27719000);Alto Baudó|(5.51604000,-76.97449000);Atrato|(5.57362000,-76.64063000)"
+Colombia,CO,Córdoba,Ayapel,Bogotá,,,8.31372000,-75.13982000,Ayapel;Buenavista;Canalete,"Ayapel|(8.31372000,-75.13982000);Buenavista|(9.04963000,-76.00280000);Canalete|(8.67611000,-76.20417000)"
+Colombia,CO,Cundinamarca,Agua de Dios,Bogotá,,,4.37648000,-74.66995000,Agua de Dios;Albán;Anapoima,"Agua de Dios|(4.37648000,-74.66995000);Albán|(4.89432000,-74.44388000);Anapoima|(4.55099000,-74.53517000)"
+Colombia,CO,Guainía,Barranco Minas,Bogotá,,,3.09899000,-69.58297000,Barranco Minas;Cacahual;Inírida,"Barranco Minas|(3.09899000,-69.58297000);Cacahual|(3.32533000,-67.62397000);Inírida|(3.86528000,-67.92389000)"
+Colombia,CO,Guaviare,Calamar,Bogotá,,,1.95960000,-72.65315000,Calamar;El Retorno;Miraflores,"Calamar|(1.95960000,-72.65315000);El Retorno|(2.33022000,-72.62765000);Miraflores|(1.33667000,-71.95111000)"
+Colombia,CO,Huila,Acevedo,Bogotá,,,1.83611111,-75.85500000,Acevedo;Aipe;Algeciras,"Acevedo|(1.83611111,-75.85500000);Aipe|(3.22194444,-75.23750000);Algeciras|(2.52194444,-75.31444444)"
+Colombia,CO,La Guajira,Albania,Bogotá,,,11.16099000,-72.59238000,Albania;Barrancas;Dibulla,"Albania|(11.16099000,-72.59238000);Barrancas|(10.97180000,-72.69115000);Dibulla|(11.27251000,-73.30911000)"
+Colombia,CO,Magdalena,Algarrobo,Bogotá,,,10.18553000,-74.06158000,Algarrobo;Aracataca;Ariguaní,"Algarrobo|(10.18553000,-74.06158000);Aracataca|(10.59181000,-74.18983000);Ariguaní|(9.89383000,-74.13583000)"
+Colombia,CO,Meta,Acacías,Bogotá,,,3.98695000,-73.75797000,Acacías;Barranca de Upía;Cabuyaro,"Acacías|(3.98695000,-73.75797000);Barranca de Upía|(4.56963000,-72.96676000);Cabuyaro|(4.28170000,-72.79399000)"
+Colombia,CO,Nariño,Nariño,Bogotá,,,1.28995000,-77.35721000,Aldana;Ancuya;Arboleda,"Aldana|(0.88283000,-77.70103000);Ancuya|(1.26330000,-77.51376000);Arboleda|(1.49830000,-77.13613000)"
+Colombia,CO,Norte de Santander,Abrego,Bogotá,,,8.00000000,-73.20000000,Abrego;Arboledas;Bochalema,"Abrego|(8.00000000,-73.20000000);Arboledas|(7.63494000,-72.86050000);Bochalema|(7.60217000,-72.68839000)"
+Colombia,CO,Putumayo,Colón,Bogotá,,,1.19034000,-76.97369000,Colón;Mocoa;Orito,"Colón|(1.19034000,-76.97369000);Mocoa|(1.15284000,-76.65208000);Orito|(0.66749000,-76.87297000)"
+Colombia,CO,Quindío,Armenia,Bogotá,,,4.53307000,-75.70438000,Armenia;Buenavista;Calarca,"Armenia|(4.53307000,-75.70438000);Buenavista|(4.35969000,-75.73888000);Calarca|(4.50000000,-75.63333000)"
+Colombia,CO,Risaralda,Apía,Bogotá,,,5.10658000,-75.94244000,Apía;Balboa;Belén de Umbría,"Apía|(5.10658000,-75.94244000);Balboa|(4.92284000,-75.94030000);Belén de Umbría|(5.20087000,-75.86865000)"
+Colombia,CO,"San Andrés, Providencia y Santa Catalina",Providencia,Bogotá,,,12.58231690,-81.69261410,Providencia;San Andrés,"Providencia|(12.58231690,-81.69261410);San Andrés|(12.53759790,-81.72041550)"
+Colombia,CO,Santander,Aguada,Bogotá,,,6.16019000,-73.52747000,Aguada;Albania;Aratoca,"Aguada|(6.16019000,-73.52747000);Albania|(5.75894000,-73.91376000);Aratoca|(6.69432000,-73.01868000)"
+Colombia,CO,Sucre,Sucre,Bogotá,,,8.81136000,-74.72084000,Buenavista;Caimito;Chalán,"Buenavista|(9.31972222,-74.97166777);Caimito|(8.78834000,-75.13583000);Chalán|(9.54765000,-75.31128000)"
+Colombia,CO,Tolima,Alpujarra,Bogotá,,,3.39222000,-74.93271000,Alpujarra;Alvarado;Ambalema,"Alpujarra|(3.39222000,-74.93271000);Alvarado|(4.58826000,-74.97810000);Ambalema|(4.78405000,-74.76268000)"
+Colombia,CO,Valle del Cauca,Alcalá,Bogotá,,,4.67458000,-75.77188000,Alcalá;Andalucía;Ansermanuevo,"Alcalá|(4.67458000,-75.77188000);Andalucía|(4.14035000,-76.14739000);Ansermanuevo|(4.79722000,-75.99500000)"
+Colombia,CO,Vaupés,Caruru,Bogotá,,,1.02081000,-71.33788000,Caruru;Mitú;Pacoa,"Caruru|(1.02081000,-71.33788000);Mitú|(1.25778000,-70.23472000);Pacoa|(0.15636000,-70.89274000)"
+Colombia,CO,Vichada,Cumaribo,Bogotá,,,4.44552000,-69.79897000,Cumaribo;La Primavera;Puerto Carreño,"Cumaribo|(4.44552000,-69.79897000);La Primavera|(5.49056000,-70.40917000);Puerto Carreño|(6.18903000,-67.48588000)"
+Comoros,KM,Anjouan,Adda-Douéni,Moroni,,,-12.29250000,44.49722000,Adda-Douéni;Antsahé;Assimpao,"Adda-Douéni|(-12.29250000,44.49722000);Antsahé|(-12.35639000,44.52250000);Assimpao|(-12.23306000,44.31972000)"
+Comoros,KM,Grande Comore,Bahani,Moroni,,,-11.63972000,43.28417000,Bahani;Bambadjani;Bouni,"Bahani|(-11.63972000,43.28417000);Bambadjani|(-11.47861000,43.37722000);Bouni|(-11.48694000,43.38833000)"
+Comoros,KM,Mohéli,Djoyézi,Moroni,,,-12.30587000,43.77425000,Djoyézi;Fomboni;Hoani,"Djoyézi|(-12.30587000,43.77425000);Fomboni|(-12.28759000,43.74344000);Hoani|(-12.25083000,43.67472000)"
+Congo,CG,Bouenza,Kayes,Brazzaville,EMEA,17,-4.20493000,13.28608000,Kayes;Madingou,"Kayes|(-4.20493000,13.28608000);Madingou|(-4.15361000,13.55000000)"
+Congo,CG,Brazzaville,Brazzaville,Brazzaville,EMEA,17,-4.26613000,15.28318000,Brazzaville,"Brazzaville|(-4.26613000,15.28318000)"
+Congo,CG,Cuvette,Makoua,Brazzaville,EMEA,17,0.00694000,15.63333000,Makoua;Owando,"Makoua|(0.00694000,15.63333000);Owando|(-0.48193000,15.89988000)"
+Congo,CG,Cuvette-Ouest,Ewo,Brazzaville,EMEA,17,-0.87250000,14.82056000,Ewo,"Ewo|(-0.87250000,14.82056000)"
+Congo,CG,Kouilou,,Brazzaville,EMEA,17,,,,
+Congo,CG,Lékoumou,Sibiti,Brazzaville,EMEA,17,-3.68192000,13.34985000,Sibiti,"Sibiti|(-3.68192000,13.34985000)"
+Congo,CG,Likouala,Impfondo,Brazzaville,EMEA,17,1.61804000,18.05981000,Impfondo,"Impfondo|(1.61804000,18.05981000)"
+Congo,CG,Niari,Dolisie,Brazzaville,EMEA,17,-4.19834000,12.66664000,Dolisie;Mossendjo,"Dolisie|(-4.19834000,12.66664000);Mossendjo|(-2.94968000,12.70423000)"
+Congo,CG,Plateaux,Djambala,Brazzaville,EMEA,17,-2.54472000,14.75333000,Djambala;Gamboma,"Djambala|(-2.54472000,14.75333000);Gamboma|(-1.87639000,15.86444000)"
+Congo,CG,Pointe-Noire,Pointe-Noire,Brazzaville,EMEA,17,-4.77609000,11.86352000,Loandjili;Pointe-Noire,"Loandjili|(-4.75611000,11.85778000);Pointe-Noire|(-4.77609000,11.86352000)"
+Congo,CG,Pool,Kinkala,Brazzaville,EMEA,17,-4.36139000,14.76444000,Kinkala,"Kinkala|(-4.36139000,14.76444000)"
+Congo,CG,Sangha,Ouésso,Brazzaville,EMEA,17,1.61361000,16.05167000,Ouésso;Sémbé,"Ouésso|(1.61361000,16.05167000);Sémbé|(1.64806000,14.58056000)"
+Costa Rica,CR,Alajuela,Alajuela,San Jose,EMEA,13,10.01625000,-84.21163000,Alajuela;Atenas;Bijagua,"Alajuela|(10.01625000,-84.21163000);Atenas|(9.98333000,-84.38333000);Bijagua|(10.73279000,-85.05676000)"
+Costa Rica,CR,Cartago,Cartago,San Jose,EMEA,13,9.86444000,-83.91944000,Alvarado;Cartago;Concepción,"Alvarado|(9.93333000,-83.80000000);Cartago|(9.86444000,-83.91944000);Concepción|(9.93333000,-84.00000000)"
+Costa Rica,CR,Guanacaste,Abangares,San Jose,EMEA,13,10.21667000,-85.00000000,Abangares;Bagaces;Belén,"Abangares|(10.21667000,-85.00000000);Bagaces|(10.50000000,-85.25000000);Belén|(10.40789000,-85.58836000)"
+Costa Rica,CR,Heredia,Heredia,San Jose,EMEA,13,10.00236000,-84.11651000,Ángeles;Barva;Belén,"Ángeles|(9.99591000,-84.05126000);Barva|(10.08333000,-84.10000000);Belén|(9.98333000,-84.16667000)"
+Costa Rica,CR,Limón,Limón,San Jose,EMEA,13,9.99074000,-83.03596000,Batán;Guácimo;Guápiles,"Batán|(10.08354000,-83.33413000);Guácimo|(10.20000000,-83.66667000);Guápiles|(10.21682000,-83.78483000)"
+Costa Rica,CR,Puntarenas,Puntarenas,San Jose,EMEA,13,9.97625000,-84.83836000,Buenos Aires;Canoas;Chacarita,"Buenos Aires|(9.11667000,-83.25000000);Canoas|(8.53305000,-82.83844000);Chacarita|(9.98424000,-84.77892000)"
+Costa Rica,CR,San José,San José,San Jose,EMEA,13,9.93333000,-84.08333000,Acosta;Alajuelita;Aserrí,"Acosta|(9.80000000,-84.20000000);Alajuelita|(9.90000000,-84.10000000);Aserrí|(9.86667000,-84.10000000)"
+Croatia,HR,Bjelovar-Bilogora,Bjelovar,Zagreb,,,45.89861000,16.84889000,Bjelovar;Brezovac;Čazma,"Bjelovar|(45.89861000,16.84889000);Brezovac|(45.86750000,16.84083000);Čazma|(45.74818000,16.61390000)"
+Croatia,HR,Brod-Posavina,Batrina,Zagreb,,,45.18944000,17.66639000,Batrina;Brodski Varoš;Bukovlje,"Batrina|(45.18944000,17.66639000);Brodski Varoš|(45.18111000,17.97861000);Bukovlje|(45.18528000,18.07000000)"
+Croatia,HR,Dubrovnik-Neretva,Cavtat,Zagreb,,,42.58111000,18.21806000,Cavtat;Čibača;Dubrovačko primorje,"Cavtat|(42.58111000,18.21806000);Čibača|(42.62889000,18.17111000);Dubrovačko primorje|(42.78988000,17.86240000)"
+Croatia,HR,Istria,Bale,Zagreb,,,45.04056000,13.78361000,Bale;Bale-Valle;Brtonigla,"Bale|(45.04056000,13.78361000);Bale-Valle|(45.04089000,13.78565000);Brtonigla|(45.38139000,13.62944000)"
+Croatia,HR,Karlovac,,Zagreb,,,,,,
+Croatia,HR,Koprivnica-Križevci,Drnje,Zagreb,,,46.20694000,16.91694000,Drnje;Đelekovec;Đurđevac,"Drnje|(46.20694000,16.91694000);Đelekovec|(46.24989000,16.87011000);Đurđevac|(46.03972000,17.07168000)"
+Croatia,HR,Krapina-Zagorje,Bedekovčina,Zagreb,,,46.04111000,15.99639000,Bedekovčina;Budinščina;Đurmanec,"Bedekovčina|(46.04111000,15.99639000);Budinščina|(46.12785000,16.20415000);Đurmanec|(46.19708000,15.83786000)"
+Croatia,HR,Lika-Senj,Brinje,Zagreb,,,45.00250000,15.13389000,Brinje;Gospić;Karlobag,"Brinje|(45.00250000,15.13389000);Gospić|(44.54611000,15.37472000);Karlobag|(44.52750000,15.07389000)"
+Croatia,HR,Međimurje,Belica,Zagreb,,,46.40417000,16.51833000,Belica;Čakovec;Dekanovec,"Belica|(46.40417000,16.51833000);Čakovec|(46.38444000,16.43389000);Dekanovec|(46.44861000,16.58472000)"
+Croatia,HR,Osijek-Baranja,Antunovac,Zagreb,,,45.49083000,18.67500000,Antunovac;Beli Manastir;Belišće,"Antunovac|(45.49083000,18.67500000);Beli Manastir|(45.77000000,18.60361000);Belišće|(45.68028000,18.40583000)"
+Croatia,HR,Požega-Slavonia,Brestovac,Zagreb,,,45.33056000,17.59694000,Brestovac;Grad Pakrac;Grad Požega,"Brestovac|(45.33056000,17.59694000);Grad Pakrac|(45.43333000,17.20000000);Grad Požega|(45.33333000,17.66667000)"
+Croatia,HR,Primorje-Gorski Kotar,Bakar,Zagreb,,,45.30861000,14.53028000,Bakar;Banjol;Baška,"Bakar|(45.30861000,14.53028000);Banjol|(44.75000000,14.78333000);Baška|(44.97028000,14.75333000)"
+Croatia,HR,Šibenik-Knin,Brodarica,Zagreb,,,43.68000000,15.91972000,Brodarica;Drniš;Grad Drniš,"Brodarica|(43.68000000,15.91972000);Drniš|(43.86250000,16.15556000);Grad Drniš|(43.83333000,16.16667000)"
+Croatia,HR,Sisak-Moslavina,Budaševo,Zagreb,,,45.47472000,16.43667000,Budaševo;Dvor;Glina,"Budaševo|(45.47472000,16.43667000);Dvor|(45.07306000,16.37083000);Glina|(45.33806000,16.08806000)"
+Croatia,HR,Split-Dalmatia,Baška Voda,Zagreb,,,43.35694000,16.95028000,Baška Voda;Bol;Brela,"Baška Voda|(43.35694000,16.95028000);Bol|(43.26194000,16.65500000);Brela|(43.36889000,16.93417000)"
+Croatia,HR,Varaždin,Varaždin,Zagreb,,,46.30444000,16.33778000,Beretinec;Breznica;Breznički Hum,"Beretinec|(46.25000000,16.30000000);Breznica|(46.07111000,16.27111000);Breznički Hum|(46.10722000,16.27667000)"
+Croatia,HR,Virovitica-Podravina,Čačinci,Zagreb,,,45.60389000,17.87028000,Čačinci;Čađavica;Crnac,"Čačinci|(45.60389000,17.87028000);Čađavica|(45.74417000,17.85472000);Crnac|(45.69611000,17.93722000)"
+Croatia,HR,Vukovar-Syrmia,Andrijaševci,Zagreb,,,45.22472000,18.73806000,Andrijaševci;Babina Greda;Bobota,"Andrijaševci|(45.22472000,18.73806000);Babina Greda|(45.11722000,18.53694000);Bobota|(45.42111000,18.85389000)"
+Croatia,HR,Zadar,Zadar,Zagreb,,,44.11972000,15.24222000,Benkovac;Bibinje;Biograd na Moru,"Benkovac|(44.03444000,15.61278000);Bibinje|(44.07324000,15.28288000);Biograd na Moru|(43.94333000,15.45194000)"
+Croatia,HR,Zagreb,Bestovje,Zagreb,,,45.80833000,15.81667000,Bestovje;Bistra;Brckovljani,"Bestovje|(45.80833000,15.81667000);Bistra|(45.90657000,15.85087000);Brckovljani|(45.83333000,16.30000000)"
+Croatia,HR,Zagreb,Zagreb,Zagreb,,,45.81444000,15.97798000,Brezovica;Centar;Dubrava,"Brezovica|(45.72919000,15.91069000);Centar|(45.81313000,15.97753000);Dubrava|(45.83361000,16.06361000)"
+Cuba,CU,Artemisa,Artemisa,Havana,EMEA,29,22.81667000,-82.75944000,Alquízar;Artemisa;Bahía Honda,"Alquízar|(22.80517000,-82.58392000);Artemisa|(22.81667000,-82.75944000);Bahía Honda|(22.90332000,-83.15994000)"
+Cuba,CU,Camagüey,Camagüey,Havana,EMEA,29,21.38083000,-77.91694000,Camagüey;El Caney;Esmeralda,"Camagüey|(21.38083000,-77.91694000);El Caney|(21.30000000,-78.48333000);Esmeralda|(21.85139000,-78.11725000)"
+Cuba,CU,Ciego de Ávila,Ciego de Ávila,Havana,EMEA,29,21.84000000,-78.76194000,Baraguá;Chambas;Ciego de Ávila,"Baraguá|(21.68216000,-78.62567000);Chambas|(22.19534000,-78.91230000);Ciego de Ávila|(21.84000000,-78.76194000)"
+Cuba,CU,Cienfuegos,Cienfuegos,Havana,EMEA,29,22.14957000,-80.44662000,Abreus;Aguada de Pasajeros;Cienfuegos,"Abreus|(22.27797000,-80.56931000);Aguada de Pasajeros|(22.38520000,-80.84792000);Cienfuegos|(22.14957000,-80.44662000)"
+Cuba,CU,Granma,Bartolomé Masó,Havana,EMEA,29,20.16635000,-76.94291000,Bartolomé Masó;Bayamo;Campechuela,"Bartolomé Masó|(20.16635000,-76.94291000);Bayamo|(20.37417000,-76.64361000);Campechuela|(20.23329000,-77.27990000)"
+Cuba,CU,Guantánamo,Guantánamo,Havana,EMEA,29,20.14444000,-75.20917000,Baracoa;Guantánamo;Maisí,"Baracoa|(20.34711000,-74.49624000);Guantánamo|(20.14444000,-75.20917000);Maisí|(20.24673000,-74.15181000)"
+Cuba,CU,Havana,Havana,Havana,EMEA,29,23.13302000,-82.38304000,Alamar;Arroyo Naranjo;Boyeros,"Alamar|(23.15794000,-82.27837000);Arroyo Naranjo|(23.03677000,-82.36937000);Boyeros|(23.00720000,-82.40170000)"
+Cuba,CU,Holguín,Holguín,Havana,EMEA,29,20.88722000,-76.26306000,Banes;Cacocum;Cueto,"Banes|(20.96116000,-75.72200000);Cacocum|(20.73775000,-76.32574000);Cueto|(20.64855000,-75.92967000)"
+Cuba,CU,Isla de la Juventud,Nueva Gerona,Havana,EMEA,29,21.88667000,-82.80556000,Nueva Gerona,"Nueva Gerona|(21.88667000,-82.80556000)"
+Cuba,CU,Las Tunas,Las Tunas,Havana,EMEA,29,20.96167000,-76.95111000,Amancio;Colombia;Jesús Menéndez,"Amancio|(20.81914000,-77.57958000);Colombia|(20.98812000,-77.42598000);Jesús Menéndez|(21.16139000,-76.47919000)"
+Cuba,CU,Matanzas,Matanzas,Havana,EMEA,29,23.04111000,-81.57750000,Alacranes;Bolondrón;Calimete,"Alacranes|(22.76719000,-81.56803000);Bolondrón|(22.76307000,-81.44780000);Calimete|(22.53420000,-80.91105000)"
+Cuba,CU,Mayabeque,Batabanó,Havana,EMEA,29,22.71794000,-82.28965000,Batabanó;Bejucal;Güines,"Batabanó|(22.71794000,-82.28965000);Bejucal|(22.92861000,-82.38861000);Güines|(22.83727000,-82.02641000)"
+Cuba,CU,Pinar del Río,Pinar del Río,Havana,EMEA,29,22.41667000,-83.69667000,Consolación del Sur;Guane;Los Palacios,"Consolación del Sur|(22.50419000,-83.51442000);Guane|(22.20179000,-84.08484000);Los Palacios|(22.58882000,-83.24671000)"
+Cuba,CU,Sancti Spíritus,Sancti Spíritus,Havana,EMEA,29,21.92972000,-79.44250000,Cabaiguán;Condado;Fomento,"Cabaiguán|(22.07874000,-79.49726000);Condado|(21.87670000,-79.84014000);Fomento|(22.10475000,-79.72141000)"
+Cuba,CU,Santiago de Cuba,Santiago de Cuba,Havana,EMEA,29,20.02083000,-75.82667000,Contramaestre;El Cobre;Municipio de Palma Soriano,"Contramaestre|(20.29879000,-76.24511000);El Cobre|(20.04850000,-75.94579000);Municipio de Palma Soriano|(20.20897000,-76.05776000)"
+Cuba,CU,Villa Clara,Caibarién,Havana,EMEA,29,22.51996000,-79.46599000,Caibarién;Calabazar de Sagua;Camajuaní,"Caibarién|(22.51996000,-79.46599000);Calabazar de Sagua|(22.64515000,-79.89510000);Camajuaní|(22.48333000,-79.75000000)"
+Cyprus,CY,Famagusta (Mağusa),Acherítou,Nicosia,,,35.10022000,33.86155000,Acherítou;Áchna;Ammochostos Municipality,"Acherítou|(35.10022000,33.86155000);Áchna|(35.05515000,33.78388000);Ammochostos Municipality|(35.11755000,33.94335000)"
+Cyprus,CY,Kyrenia (Keryneia),Kyrenia,Nicosia,,,35.33634000,33.31729000,Kyrenia;Kyrenia Municipality;Lápithos,"Kyrenia|(35.33634000,33.31729000);Kyrenia Municipality|(35.33672000,33.31504000);Lápithos|(35.33823000,33.17368000)"
+Cyprus,CY,Larnaca (Larnaka),Aradíppou,Nicosia,,,34.95151000,33.59199000,Aradíppou;Athíenou;Dhromolaxia,"Aradíppou|(34.95151000,33.59199000);Athíenou|(35.06180000,33.54156000);Dhromolaxia|(34.87551000,33.58684000)"
+Cyprus,CY,Limassol (Leymasun),Ágios Tomás,Nicosia,,,34.71158000,32.73129000,Ágios Tomás;Ágios Týchon;Erími,"Ágios Tomás|(34.71158000,32.73129000);Ágios Týchon|(34.72606000,33.13872000);Erími|(34.67766000,32.91815000)"
+Cyprus,CY,Nicosia (Lefkoşa),Akáki,Nicosia,,,35.13341000,33.12873000,Akáki;Alámpra;Aredioú,"Akáki|(35.13341000,33.12873000);Alámpra|(34.98898000,33.39887000);Aredioú|(35.04844000,33.19610000)"
+Cyprus,CY,Paphos (Pafos),Argáka,Nicosia,,,35.06646000,32.49446000,Argáka;Chlórakas;Emba,"Argáka|(35.06646000,32.49446000);Chlórakas|(34.79768000,32.41207000);Emba|(34.80700000,32.42406000)"
+Czech Republic,CZ,Benešov,,Prague,,,,,,
+Czech Republic,CZ,Beroun,,Prague,,,,,,
+Czech Republic,CZ,Blansko,,Prague,,,,,,
+Czech Republic,CZ,Břeclav,,Prague,,,,,,
+Czech Republic,CZ,Brno-město,,Prague,,,,,,
+Czech Republic,CZ,Brno-venkov,,Prague,,,,,,
+Czech Republic,CZ,Bruntál,,Prague,,,,,,
+Czech Republic,CZ,Česká Lípa,,Prague,,,,,,
+Czech Republic,CZ,České Budějovice,,Prague,,,,,,
+Czech Republic,CZ,Český Krumlov,,Prague,,,,,,
+Czech Republic,CZ,Cheb,,Prague,,,,,,
+Czech Republic,CZ,Chomutov,,Prague,,,,,,
+Czech Republic,CZ,Chrudim,,Prague,,,,,,
+Czech Republic,CZ,Děčín,,Prague,,,,,,
+Czech Republic,CZ,Domažlice,,Prague,,,,,,
+Czech Republic,CZ,Frýdek-Místek,,Prague,,,,,,
+Czech Republic,CZ,Havlíčkův Brod,,Prague,,,,,,
+Czech Republic,CZ,Hodonín,,Prague,,,,,,
+Czech Republic,CZ,Hradec Králové,,Prague,,,,,,
+Czech Republic,CZ,Jablonec nad Nisou,,Prague,,,,,,
+Czech Republic,CZ,Jeseník,,Prague,,,,,,
+Czech Republic,CZ,Jičín,,Prague,,,,,,
+Czech Republic,CZ,Jihlava,,Prague,,,,,,
+Czech Republic,CZ,Jihočeský kraj,Bavorov,Prague,,,49.12184000,14.07893000,Bavorov;Bechyně;Benešov nad Černou,"Bavorov|(49.12184000,14.07893000);Bechyně|(49.29523000,14.46810000);Benešov nad Černou|(48.72940000,14.62737000)"
+Czech Republic,CZ,Jihomoravský kraj,Adamov,Prague,,,49.30162000,16.65253000,Adamov;Bílovice nad Svitavou;Blansko,"Adamov|(49.30162000,16.65253000);Bílovice nad Svitavou|(49.24708000,16.67247000);Blansko|(49.36304000,16.64446000)"
+Czech Republic,CZ,Jindřichův Hradec,,Prague,,,,,,
+Czech Republic,CZ,Karlovarský kraj,Abertamy,Prague,,,50.36874000,12.81826000,Abertamy;Aš;Bochov,"Abertamy|(50.36874000,12.81826000);Aš|(50.22387000,12.19499000);Bochov|(50.14872000,13.05227000)"
+Czech Republic,CZ,Karlovy Vary,,Prague,,,,,,
+Czech Republic,CZ,Karviná,,Prague,,,,,,
+Czech Republic,CZ,Kladno,,Prague,,,,,,
+Czech Republic,CZ,Klatovy,,Prague,,,,,,
+Czech Republic,CZ,Kolín,,Prague,,,,,,
+Czech Republic,CZ,Kraj Vysočina,Batelov,Prague,,,49.31425000,15.39465000,Batelov;Bohdalov;Brtnice,"Batelov|(49.31425000,15.39465000);Bohdalov|(49.47921000,15.87582000);Brtnice|(49.30695000,15.67642000)"
+Czech Republic,CZ,Královéhradecký kraj,Albrechtice nad Orlicí,Prague,,,50.13979000,16.06437000,Albrechtice nad Orlicí;Bílá Třemešná;Borohrádek,"Albrechtice nad Orlicí|(50.13979000,16.06437000);Bílá Třemešná|(50.44465000,15.74101000);Borohrádek|(50.09777000,16.09326000)"
+Czech Republic,CZ,Kroměříž,,Prague,,,,,,
+Czech Republic,CZ,Kutná Hora,,Prague,,,,,,
+Czech Republic,CZ,Liberec,,Prague,,,,,,
+Czech Republic,CZ,Liberecký kraj,Benecko,Prague,,,50.66633000,15.54816000,Benecko;Brniště;Česká Lípa,"Benecko|(50.66633000,15.54816000);Brniště|(50.72919000,14.70338000);Česká Lípa|(50.68551000,14.53764000)"
+Czech Republic,CZ,Litoměřice,,Prague,,,,,,
+Czech Republic,CZ,Louny,,Prague,,,,,,
+Czech Republic,CZ,Mělník,,Prague,,,,,,
+Czech Republic,CZ,Mladá Boleslav,,Prague,,,,,,
+Czech Republic,CZ,Moravskoslezský kraj,Albrechtice,Prague,,,49.78645000,18.52444000,Albrechtice;Bartošovice;Baška,"Albrechtice|(49.78645000,18.52444000);Bartošovice|(49.66884000,18.05461000);Baška|(49.64584000,18.37233000)"
+Czech Republic,CZ,Most,,Prague,,,,,,
+Czech Republic,CZ,Náchod,,Prague,,,,,,
+Czech Republic,CZ,Nový Jičín,,Prague,,,,,,
+Czech Republic,CZ,Nymburk,,Prague,,,,,,
+Czech Republic,CZ,Olomouc,,Prague,,,,,,
+Czech Republic,CZ,Olomoucký kraj,Bedihošť,Prague,,,49.44826000,17.16643000,Bedihošť;Bělotín;Bílá Lhota,"Bedihošť|(49.44826000,17.16643000);Bělotín|(49.59120000,17.80654000);Bílá Lhota|(49.70953000,16.97507000)"
+Czech Republic,CZ,Opava,,Prague,,,,,,
+Czech Republic,CZ,Ostrava-město,,Prague,,,,,,
+Czech Republic,CZ,Pardubice,,Prague,,,,,,
+Czech Republic,CZ,Pardubický kraj,Brandýs nad Orlicí,Prague,,,50.00194000,16.28528000,Brandýs nad Orlicí;Březová nad Svitavou;Brněnec,"Brandýs nad Orlicí|(50.00194000,16.28528000);Březová nad Svitavou|(49.64418000,16.51799000);Brněnec|(49.62735000,16.52202000)"
+Czech Republic,CZ,Pelhřimov,,Prague,,,,,,
+Czech Republic,CZ,Písek,,Prague,,,,,,
+Czech Republic,CZ,Plzeň-jih,Bělá nad Radbuzou,Prague,,,49.59115000,12.71761000,Bělá nad Radbuzou;Bezdružice;Blížejov,"Bělá nad Radbuzou|(49.59115000,12.71761000);Bezdružice|(49.90724000,12.97110000);Blížejov|(49.50000000,12.98926000)"
+Czech Republic,CZ,Plzeň-město,,Prague,,,,,,
+Czech Republic,CZ,Plzeň-sever,,Prague,,,,,,
+Czech Republic,CZ,Plzeňský kraj,,Prague,,,,,,
+Czech Republic,CZ,Prachatice,,Prague,,,,,,
+Czech Republic,CZ,Praha-východ,,Prague,,,,,,
+Czech Republic,CZ,Praha-západ,,Prague,,,,,,
+Czech Republic,CZ,"Praha, Hlavní město",Braník,Prague,,,50.03498000,14.41518000,Braník;Černý Most;Dolní Počernice,"Braník|(50.03498000,14.41518000);Černý Most|(50.10475000,14.57974000);Dolní Počernice|(50.08760000,14.57199000)"
+Czech Republic,CZ,Přerov,,Prague,,,,,,
+Czech Republic,CZ,Příbram,,Prague,,,,,,
+Czech Republic,CZ,Prostějov,,Prague,,,,,,
+Czech Republic,CZ,Rakovník,,Prague,,,,,,
+Czech Republic,CZ,Rokycany,,Prague,,,,,,
+Czech Republic,CZ,Rychnov nad Kněžnou,,Prague,,,,,,
+Czech Republic,CZ,Semily,,Prague,,,,,,
+Czech Republic,CZ,Sokolov,,Prague,,,,,,
+Czech Republic,CZ,Strakonice,,Prague,,,,,,
+Czech Republic,CZ,Středočeský kraj,Bakov nad Jizerou,Prague,,,50.48230000,14.94149000,Bakov nad Jizerou;Bělá pod Bezdězem;Benátky nad Jizerou,"Bakov nad Jizerou|(50.48230000,14.94149000);Bělá pod Bezdězem|(50.50121000,14.80418000);Benátky nad Jizerou|(50.29085000,14.82343000)"
+Czech Republic,CZ,Šumperk,,Prague,,,,,,
+Czech Republic,CZ,Svitavy,,Prague,,,,,,
+Czech Republic,CZ,Tábor,,Prague,,,,,,
+Czech Republic,CZ,Tachov,,Prague,,,,,,
+Czech Republic,CZ,Teplice,,Prague,,,,,,
+Czech Republic,CZ,Třebíč,,Prague,,,,,,
+Czech Republic,CZ,Trutnov,,Prague,,,,,,
+Czech Republic,CZ,Uherské Hradiště,,Prague,,,,,,
+Czech Republic,CZ,Ústecký kraj,Bechlín,Prague,,,50.41615000,14.34092000,Bechlín;Bečov;Benešov nad Ploučnicí,"Bechlín|(50.41615000,14.34092000);Bečov|(50.44972000,13.71784000);Benešov nad Ploučnicí|(50.74159000,14.31239000)"
+Czech Republic,CZ,Ústí nad Labem,,Prague,,,,,,
+Czech Republic,CZ,Ústí nad Orlicí,,Prague,,,,,,
+Czech Republic,CZ,Vsetín,,Prague,,,,,,
+Czech Republic,CZ,Vyškov,,Prague,,,,,,
+Czech Republic,CZ,Žďár nad Sázavou,,Prague,,,,,,
+Czech Republic,CZ,Zlín,Zlín,Prague,,,49.22645000,17.67065000,Babice;Bánov;Bílovice,"Babice|(49.12167000,17.48075000);Bánov|(48.98801000,17.71752000);Bílovice|(49.09965000,17.54961000)"
+Czech Republic,CZ,Zlínský kraj,,Prague,,,,,,
+Czech Republic,CZ,Znojmo,,Prague,,,,,,
+Democratic Republic of the Congo,CD,Bas-Uélé,Aketi,Kinshasa,,,2.73877000,23.78326000,Aketi;Bondo;Buta,"Aketi|(2.73877000,23.78326000);Bondo|(3.81461000,23.68665000);Buta|(2.78582000,24.72997000)"
+Democratic Republic of the Congo,CD,Équateur,Gemena,Kinshasa,,,3.25651000,19.77234000,Gemena;Lisala;Lukolela,"Gemena|(3.25651000,19.77234000);Lisala|(2.15127000,21.51672000);Lukolela|(-1.06046000,17.18210000)"
+Democratic Republic of the Congo,CD,Haut-Katanga,Likasi,Kinshasa,,,-10.98303000,26.73840000,Likasi;Lubumbashi,"Likasi|(-10.98303000,26.73840000);Lubumbashi|(-11.66089000,27.47938000)"
+Democratic Republic of the Congo,CD,Haut-Lomami,Bukama,Kinshasa,,,-9.20443000,25.85475000,Bukama;Kamina,"Bukama|(-9.20443000,25.85475000);Kamina|(-8.73508000,24.99798000)"
+Democratic Republic of the Congo,CD,Haut-Uélé,Isiro,Kinshasa,,,2.77391000,27.61603000,Isiro;Wamba;Watsa,"Isiro|(2.77391000,27.61603000);Wamba|(2.14838000,27.99466000);Watsa|(3.03716000,29.53551000)"
+Democratic Republic of the Congo,CD,Ituri,Bunia,Kinshasa,,,1.55941000,30.25224000,Bunia,"Bunia|(1.55941000,30.25224000)"
+Democratic Republic of the Congo,CD,Kasaï,Ilebo,Kinshasa,,,-4.33111000,20.58638000,Ilebo;Luebo;Mweka,"Ilebo|(-4.33111000,20.58638000);Luebo|(-5.35218000,21.42192000);Mweka|(-4.85187000,21.55950000)"
+Democratic Republic of the Congo,CD,Kasaï Central,,Kinshasa,,,,,,
+Democratic Republic of the Congo,CD,Kasaï Oriental,Gandajika,Kinshasa,,,-6.74504000,23.95328000,Gandajika;Kabinda;Mbuji-Mayi,"Gandajika|(-6.74504000,23.95328000);Kabinda|(-6.13791000,24.48179000);Mbuji-Mayi|(-6.13603000,23.58979000)"
+Democratic Republic of the Congo,CD,Kinshasa,Kinshasa,Kinshasa,,,-4.32758000,15.31357000,Kinshasa,"Kinshasa|(-4.32758000,15.31357000)"
+Democratic Republic of the Congo,CD,Kongo Central,Boma,Kinshasa,,,-5.85098000,13.05364000,Boma;Kasangulu;Matadi,"Boma|(-5.85098000,13.05364000);Kasangulu|(-4.58330000,15.16554000);Matadi|(-5.83861000,13.46306000)"
+Democratic Republic of the Congo,CD,Kwango,Kasongo-Lunda,Kinshasa,,,-6.47833000,16.81735000,Kasongo-Lunda,"Kasongo-Lunda|(-6.47833000,16.81735000)"
+Democratic Republic of the Congo,CD,Kwilu,Bandundu,Kinshasa,,,-3.31687000,17.38063000,Bandundu;Bulungu;Kikwit,"Bandundu|(-3.31687000,17.38063000);Bulungu|(-4.54437000,18.60364000);Kikwit|(-5.04098000,18.81619000)"
+Democratic Republic of the Congo,CD,Lomami,Lubao,Kinshasa,,,-5.38771000,25.74885000,Lubao;Mwene-Ditu,"Lubao|(-5.38771000,25.74885000);Mwene-Ditu|(-7.00906000,23.45278000)"
+Democratic Republic of the Congo,CD,Lualaba,Kasaji,Kinshasa,,,-10.38342000,23.44987000,Kasaji;Kolwezi,"Kasaji|(-10.38342000,23.44987000);Kolwezi|(-10.71666700,25.46666700)"
+Democratic Republic of the Congo,CD,Mai-Ndombe,Bolobo,Kinshasa,,,-2.15800000,16.23249000,Bolobo;Inongo;Mushie,"Bolobo|(-2.15800000,16.23249000);Inongo|(-1.92750000,18.28810000);Mushie|(-3.01728000,16.92238000)"
+Democratic Republic of the Congo,CD,Maniema,Kampene,Kinshasa,,,-3.59678000,26.66715000,Kampene;Kasongo;Kindu,"Kampene|(-3.59678000,26.66715000);Kasongo|(-4.42741000,26.66656000);Kindu|(-2.94373000,25.92237000)"
+Democratic Republic of the Congo,CD,Mongala,Bumba,Kinshasa,,,2.18771000,22.46827000,Bumba,"Bumba|(2.18771000,22.46827000)"
+Democratic Republic of the Congo,CD,Nord-Kivu,Beni,Kinshasa,,,0.49113000,29.47306000,Beni;Butembo;Goma,"Beni|(0.49113000,29.47306000);Butembo|(0.14164000,29.29117000);Goma|(-1.67409000,29.22845000)"
+Democratic Republic of the Congo,CD,Nord-Ubangi,Bosobolo,Kinshasa,,,4.18980000,19.88330000,Bosobolo;Businga;Gbadolite,"Bosobolo|(4.18980000,19.88330000);Businga|(3.33863000,20.88577000);Gbadolite|(4.27900000,21.00284000)"
+Democratic Republic of the Congo,CD,Sankuru,Lodja,Kinshasa,,,-3.52105000,23.60050000,Lodja;Lusambo,"Lodja|(-3.52105000,23.60050000);Lusambo|(-4.97503000,23.44391000)"
+Democratic Republic of the Congo,CD,Sud-Kivu,Bukavu,Kinshasa,,,-2.49077000,28.84281000,Bukavu;Kabare;Uvira,"Bukavu|(-2.49077000,28.84281000);Kabare|(-2.49682000,28.79081000);Uvira|(-3.39534000,29.13779000)"
+Democratic Republic of the Congo,CD,Sud-Ubangi,Bongandanga,Kinshasa,,,1.50695000,21.07260000,Bongandanga;Libenge,"Bongandanga|(1.50695000,21.07260000);Libenge|(3.65332000,18.63566000)"
+Democratic Republic of the Congo,CD,Tanganyika,Kabalo,Kinshasa,,,-6.05255000,26.91430000,Kabalo;Kalemie;Kongolo,"Kabalo|(-6.05255000,26.91430000);Kalemie|(-5.94749000,29.19471000);Kongolo|(-5.38532000,27.00029000)"
+Democratic Republic of the Congo,CD,Tshopo,Basoko,Kinshasa,,,1.23909000,23.61598000,Basoko;Kisangani;Yangambi,"Basoko|(1.23909000,23.61598000);Kisangani|(0.51528000,25.19099000);Yangambi|(0.76755000,24.43973000)"
+Democratic Republic of the Congo,CD,Tshuapa,Boende,Kinshasa,,,-0.28163000,20.88053000,Boende,"Boende|(-0.28163000,20.88053000)"
+Denmark,DK,Central Denmark,Aarhus,Copenhagen,,,56.15674000,10.21076000,Aarhus;Aarhus Kommune;Allingåbro,"Aarhus|(56.15674000,10.21076000);Aarhus Kommune|(56.16317000,10.16897000);Allingåbro|(56.46432000,10.31957000)"
+Denmark,DK,Denmark,Åkirkeby,Copenhagen,,,55.07080000,14.91978000,Åkirkeby;Albertslund;Albertslund Kommune,"Åkirkeby|(55.07080000,14.91978000);Albertslund|(55.65691000,12.36381000);Albertslund Kommune|(55.68022000,12.34797000)"
+Denmark,DK,North Denmark,Aalborg,Copenhagen,,,57.04800000,9.91870000,Aalborg;Aars;Åbybro,"Aalborg|(57.04800000,9.91870000);Aars|(56.80399000,9.51441000);Åbybro|(57.16249000,9.72996000)"
+Denmark,DK,Southern Denmark,Aabenraa,Copenhagen,,,55.04434000,9.41741000,Aabenraa;Aabenraa Kommune;Årslev,"Aabenraa|(55.04434000,9.41741000);Aabenraa Kommune|(54.98980000,9.31282000);Årslev|(55.30353000,10.46428000)"
+Denmark,DK,Zealand,Asnæs,Copenhagen,,,55.81229000,11.50129000,Asnæs;Bjæverskov;Borup,"Asnæs|(55.81229000,11.50129000);Bjæverskov|(55.45756000,12.03651000);Borup|(55.49472000,11.97584000)"
+Djibouti,DJ,Ali Sabieh,'Ali Sabieh,Djibouti,EMEA,14,11.15583000,42.71250000,'Ali Sabieh;Goubétto;Holhol,"'Ali Sabieh|(11.15583000,42.71250000);Goubétto|(11.42389000,43.00028000);Holhol|(11.31028000,42.92944000)"
+Djibouti,DJ,Arta,Arta,Djibouti,EMEA,14,11.52639000,42.85194000,Arta,"Arta|(11.52639000,42.85194000)"
+Djibouti,DJ,Dikhil,Dikhil,Djibouti,EMEA,14,11.10454000,42.36971000,Dikhil;Gâlâfi,"Dikhil|(11.10454000,42.36971000);Gâlâfi|(11.71583000,41.83611000)"
+Djibouti,DJ,Djibouti,Djibouti,Djibouti,EMEA,14,11.58901000,43.14503000,Djibouti;Loyada,"Djibouti|(11.58901000,43.14503000);Loyada|(11.46111000,43.25278000)"
+Djibouti,DJ,Obock,Obock,Djibouti,EMEA,14,11.96693000,43.28835000,Alaïli Ḏaḏḏa‘;Obock,"Alaïli Ḏaḏḏa‘|(12.42167000,42.89556000);Obock|(11.96693000,43.28835000)"
+Djibouti,DJ,Tadjourah,Tadjourah,Djibouti,EMEA,14,11.78778000,42.88222000,Dorra;Tadjourah,"Dorra|(12.15028000,42.47624000);Tadjourah|(11.78778000,42.88222000)"
+Dominica,DM,Saint Andrew,Calibishie,Roseau,,,15.59297000,-61.34901000,Calibishie;Marigot;Wesley,"Calibishie|(15.59297000,-61.34901000);Marigot|(15.53886000,-61.28375000);Wesley|(15.56667000,-61.31667000)"
+Dominica,DM,Saint David,Castle Bruce,Roseau,,,15.44397000,-61.25723000,Castle Bruce;Rosalie,"Castle Bruce|(15.44397000,-61.25723000);Rosalie|(15.36667000,-61.26667000)"
+Dominica,DM,Saint George,Roseau,Roseau,,,15.30174000,-61.38808000,Roseau,"Roseau|(15.30174000,-61.38808000)"
+Dominica,DM,Saint John,Portsmouth,Roseau,,,15.58333000,-61.46667000,Portsmouth,"Portsmouth|(15.58333000,-61.46667000)"
+Dominica,DM,Saint Joseph,Saint Joseph,Roseau,,,15.40000000,-61.43333000,Saint Joseph;Salisbury,"Saint Joseph|(15.40000000,-61.43333000);Salisbury|(15.43689000,-61.43637000)"
+Dominica,DM,Saint Luke,Pointe Michel,Roseau,,,15.25976000,-61.37452000,Pointe Michel,"Pointe Michel|(15.25976000,-61.37452000)"
+Dominica,DM,Saint Mark,Soufrière,Roseau,,,15.23374000,-61.35881000,Soufrière,"Soufrière|(15.23374000,-61.35881000)"
+Dominica,DM,Saint Patrick,Berekua,Roseau,,,15.23333000,-61.31667000,Berekua;La Plaine,"Berekua|(15.23333000,-61.31667000);La Plaine|(15.32768000,-61.24753000)"
+Dominica,DM,Saint Paul,Mahaut,Roseau,,,15.36357000,-61.39701000,Mahaut;Pont Cassé,"Mahaut|(15.36357000,-61.39701000);Pont Cassé|(15.36667000,-61.35000000)"
+Dominica,DM,Saint Peter,Colihaut,Roseau,,,15.48478000,-61.46215000,Colihaut,"Colihaut|(15.48478000,-61.46215000)"
+Dominican Republic,DO,Azua,Azua,Santo Domingo,,,18.45319000,-70.73490000,Azua;El Guayabal;Estebanía,"Azua|(18.45319000,-70.73490000);El Guayabal|(18.74960000,-70.83690000);Estebanía|(18.45770000,-70.64350000)"
+Dominican Republic,DO,Baoruco,El Palmar,Santo Domingo,,,18.41139000,-71.24558000,El Palmar;Galván;La Uvilla,"El Palmar|(18.41139000,-71.24558000);Galván|(18.50228000,-71.34271000);La Uvilla|(18.36186000,-71.21046000)"
+Dominican Republic,DO,Barahona,Cabral,Santo Domingo,,,18.19991000,-71.24660000,Cabral;Cachón;Canoa,"Cabral|(18.19991000,-71.24660000);Cachón|(18.24833000,-71.18912000);Canoa|(18.35499000,-71.15851000)"
+Dominican Republic,DO,Dajabón,Dajabón,Santo Domingo,,,19.54878000,-71.70829000,Dajabón;El Pino;Loma de Cabrera,"Dajabón|(19.54878000,-71.70829000);El Pino|(19.43537000,-71.47540000);Loma de Cabrera|(19.41667000,-71.58333000)"
+Dominican Republic,DO,Distrito Nacional,Bella Vista,Santo Domingo,,,18.45539000,-69.94540000,Bella Vista;Ciudad Nueva;Cristo Rey,"Bella Vista|(18.45539000,-69.94540000);Ciudad Nueva|(18.46707000,-69.89339000);Cristo Rey|(18.50168720,-69.92613430)"
+Dominican Republic,DO,Duarte,Agua Santa del Yuna,Santo Domingo,,,19.15072000,-69.80069000,Agua Santa del Yuna;Arenoso;Castillo,"Agua Santa del Yuna|(19.15072000,-69.80069000);Arenoso|(19.18732000,-69.85917000);Castillo|(19.25000000,-70.00000000)"
+Dominican Republic,DO,El Seibo,Miches,Santo Domingo,,,18.98364000,-69.04760000,Miches;Pedro Sánchez;Santa Cruz de El Seibo,"Miches|(18.98364000,-69.04760000);Pedro Sánchez|(18.86375000,-69.10868000);Santa Cruz de El Seibo|(18.76559000,-69.03886000)"
+Dominican Republic,DO,Espaillat,Cayetano Germosén,Santo Domingo,,,19.34285000,-70.47573000,Cayetano Germosén;Gaspar Hernández;Jamao al Norte,"Cayetano Germosén|(19.34285000,-70.47573000);Gaspar Hernández|(19.62748000,-70.27772000);Jamao al Norte|(19.63552000,-70.44664000)"
+Dominican Republic,DO,Hato Mayor,El Valle,Santo Domingo,,,18.93333000,-69.38333000,El Valle;Guayabo Dulce;Hato Mayor del Rey,"El Valle|(18.93333000,-69.38333000);Guayabo Dulce|(18.65000000,-69.28333000);Hato Mayor del Rey|(18.76278000,-69.25681000)"
+Dominican Republic,DO,Hermanas Mirabal,Salcedo,Santo Domingo,,,19.41667000,-70.38333000,Salcedo;Salsipuedes;Tenares,"Salcedo|(19.41667000,-70.38333000);Salsipuedes|(19.40552000,-70.37985000);Tenares|(19.37439000,-70.35087000)"
+Dominican Republic,DO,Independencia,Cristóbal,Santo Domingo,,,18.29405000,-71.29298000,Cristóbal;Duvergé;Guayabal,"Cristóbal|(18.29405000,-71.29298000);Duvergé|(18.31634000,-71.59451000);Guayabal|(18.59810000,-71.64184000)"
+Dominican Republic,DO,La Altagracia,Boca de Yuma,Santo Domingo,,,18.37825000,-68.60900000,Boca de Yuma;Higüey;Otra Banda,"Boca de Yuma|(18.37825000,-68.60900000);Higüey|(18.70000000,-68.66667000);Otra Banda|(18.65017000,-68.66281000)"
+Dominican Republic,DO,La Romana,La Romana,Santo Domingo,,,18.42733000,-68.97285000,Guaymate;La Romana,"Guaymate|(18.58793000,-68.97867000);La Romana|(18.42733000,-68.97285000)"
+Dominican Republic,DO,La Vega,Concepción de La Vega,Santo Domingo,,,19.22207000,-70.52956000,Concepción de La Vega;Constanza;Jarabacoa,"Concepción de La Vega|(19.22207000,-70.52956000);Constanza|(18.90919000,-70.74499000);Jarabacoa|(19.11683000,-70.63595000)"
+Dominican Republic,DO,María Trinidad Sánchez,Arroyo Salado,Santo Domingo,,,19.50000000,-69.90000000,Arroyo Salado;Cabrera;El Factor,"Arroyo Salado|(19.50000000,-69.90000000);Cabrera|(19.64260000,-69.90489000);El Factor|(19.31834000,-69.88827000)"
+Dominican Republic,DO,Monseñor Nouel,Bonao,Santo Domingo,,,18.91667000,-70.46667000,Bonao;Juan Adrián;Maimón,"Bonao|(18.91667000,-70.46667000);Juan Adrián|(18.76365000,-70.33732000);Maimón|(18.88333000,-70.30000000)"
+Dominican Republic,DO,Monte Cristi,Monte Cristi,Santo Domingo,,,19.83333000,-71.61667000,Cana Chapetón;Castañuelas;Guayubín,"Cana Chapetón|(19.60703000,-71.25734000);Castañuelas|(19.71387000,-71.49876000);Guayubín|(19.61667000,-71.33333000)"
+Dominican Republic,DO,Monte Plata,Monte Plata,Santo Domingo,,,18.80700000,-69.78399000,Bayaguana;Don Juan;Esperalvillo,"Bayaguana|(18.78333000,-69.60000000);Don Juan|(18.82774000,-69.94629000);Esperalvillo|(18.81509000,-70.03557000)"
+Dominican Republic,DO,Pedernales,Pedernales,Santo Domingo,,,18.08333000,-71.60000000,Juancho;Oviedo;Pedernales,"Juancho|(17.85782000,-71.29311000);Oviedo|(17.80136000,-71.40100000);Pedernales|(18.08333000,-71.60000000)"
+Dominican Republic,DO,Peravia,Baní,Santo Domingo,,,18.27964000,-70.33185000,Baní;Matanzas;Nizao,"Baní|(18.27964000,-70.33185000);Matanzas|(18.24297000,-70.41768000);Nizao|(18.24697000,-70.21053000)"
+Dominican Republic,DO,Puerto Plata,Puerto Plata,Santo Domingo,,,19.75119000,-70.70251000,Altamira;Cabarete;Estero Hondo,"Altamira|(19.70000000,-70.83333000);Cabarete|(19.74982000,-70.40829000);Estero Hondo|(19.82712000,-71.17411000)"
+Dominican Republic,DO,Samaná,Samaná,Santo Domingo,,,19.20561000,-69.33685000,Las Terrenas;Samaná;Sánchez,"Las Terrenas|(19.31102000,-69.54280000);Samaná|(19.20561000,-69.33685000);Sánchez|(19.22810000,-69.61370000)"
+Dominican Republic,DO,San Cristóbal,San Cristóbal,Santo Domingo,,,18.41667000,-70.13333000,Bajos de Haina;Cambita Garabitos;El Cacao,"Bajos de Haina|(18.41667000,-70.03333000);Cambita Garabitos|(18.50000000,-70.23333000);El Cacao|(18.52719000,-70.29585000)"
+Dominican Republic,DO,San José de Ocoa,San José de Ocoa,Santo Domingo,,,18.54661000,-70.50631000,San José de Ocoa,"San José de Ocoa|(18.54661000,-70.50631000)"
+Dominican Republic,DO,San Juan,Bohechío,Santo Domingo,,,18.77515000,-70.98889000,Bohechío;Cercado Abajo;El Cercado,"Bohechío|(18.77515000,-70.98889000);Cercado Abajo|(18.72681000,-71.51742000);El Cercado|(18.70000000,-71.46667000)"
+Dominican Republic,DO,San Pedro de Macorís,San Pedro de Macorís,Santo Domingo,,,18.45390000,-69.30864000,El Puerto;Los Llanos;Quisqueya,"El Puerto|(18.78333000,-69.46667000);Los Llanos|(18.62035000,-69.49581000);Quisqueya|(18.55542000,-69.40814000)"
+Dominican Republic,DO,Sánchez Ramírez,Cevicos,Santo Domingo,,,19.00449000,-69.97896000,Cevicos;Cotuí;Fantino,"Cevicos|(19.00449000,-69.97896000);Cotuí|(19.05272000,-70.14939000);Fantino|(19.11667000,-70.30000000)"
+Dominican Republic,DO,Santiago,Baitoa,Santo Domingo,,,19.32512000,-70.70357000,Baitoa;Bisonó;Juncalito Abajo,"Baitoa|(19.32512000,-70.70357000);Bisonó|(19.58333000,-70.86667000);Juncalito Abajo|(19.21990000,-70.81905000)"
+Dominican Republic,DO,Santiago Rodríguez,Monción,Santo Domingo,,,19.46667000,-71.16667000,Monción;Sabaneta;San Ignacio de Sabaneta,"Monción|(19.46667000,-71.16667000);Sabaneta|(19.47793000,-71.34125000);San Ignacio de Sabaneta|(19.38333000,-71.35000000)"
+Dominican Republic,DO,Santo Domingo,Boca Chica,Santo Domingo,,,18.45000000,-69.60000000,Boca Chica;Santo Domingo Este;Santo Domingo Oeste,"Boca Chica|(18.45000000,-69.60000000);Santo Domingo Este|(18.48847000,-69.85707000);Santo Domingo Oeste|(18.50000000,-70.00000000)"
+Dominican Republic,DO,Valverde,Amina,Santo Domingo,,,19.54813000,-70.99599000,Amina;Esperanza;Guatapanal,"Amina|(19.54813000,-70.99599000);Esperanza|(19.62379000,-70.97141000);Guatapanal|(19.50705000,-70.91713000)"
+Ecuador,EC,Azuay,Cantón San Fernando,Quito,,,-3.13349000,-79.26893000,Cantón San Fernando;Cuenca;Gualaceo,"Cantón San Fernando|(-3.13349000,-79.26893000);Cuenca|(-2.90055000,-79.00453000);Gualaceo|(-2.89264000,-78.77814000)"
+Ecuador,EC,Bolívar,Guaranda,Quito,,,-1.59263000,-79.00098000,Guaranda;San Miguel,"Guaranda|(-1.59263000,-79.00098000);San Miguel|(-1.70884000,-79.04311000)"
+Ecuador,EC,Cañar,Cañar,Quito,,,-2.56062000,-78.93940000,Azogues;Cañar;La Troncal,"Azogues|(-2.73969000,-78.84860000);Cañar|(-2.56062000,-78.93940000);La Troncal|(-2.42355000,-79.33977000)"
+Ecuador,EC,Carchi,El Ángel,Quito,,,0.62279000,-77.94003000,El Ángel;San Gabriel;Tulcán,"El Ángel|(0.62279000,-77.94003000);San Gabriel|(0.59318000,-77.83078000);Tulcán|(0.81187000,-77.71727000)"
+Ecuador,EC,Chimborazo,Alausí,Quito,,,-2.20329000,-78.84714000,Alausí;Guano;Riobamba,"Alausí|(-2.20329000,-78.84714000);Guano|(-1.60789000,-78.63105000);Riobamba|(-1.67098000,-78.64712000)"
+Ecuador,EC,Cotopaxi,La Maná,Quito,,,-0.94094000,-79.22506000,La Maná;Latacunga;Pujilí,"La Maná|(-0.94094000,-79.22506000);Latacunga|(-0.93521000,-78.61554000);Pujilí|(-0.95759000,-78.69636000)"
+Ecuador,EC,El Oro,Huaquillas,Quito,,,-3.47523000,-80.23084000,Huaquillas;Machala;Pasaje,"Huaquillas|(-3.47523000,-80.23084000);Machala|(-3.25861000,-79.96053000);Pasaje|(-3.32561000,-79.80697000)"
+Ecuador,EC,Esmeraldas,Esmeraldas,Quito,,,0.95920000,-79.65397000,Esmeraldas;Muisne;Pampanal de Bolívar,"Esmeraldas|(0.95920000,-79.65397000);Muisne|(0.61129000,-80.01863000);Pampanal de Bolívar|(1.35251000,-78.89360000)"
+Ecuador,EC,Galápagos,Puerto Ayora,Quito,,,-0.74018000,-90.31380000,Puerto Ayora;Puerto Baquerizo Moreno;Puerto Villamil,"Puerto Ayora|(-0.74018000,-90.31380000);Puerto Baquerizo Moreno|(-0.90172000,-89.61021000);Puerto Villamil|(-0.95542000,-90.96654000)"
+Ecuador,EC,Guayas,Alfredo Baquerizo Moreno,Quito,,,-1.91667000,-79.51667000,Alfredo Baquerizo Moreno;Baláo;Balzar,"Alfredo Baquerizo Moreno|(-1.91667000,-79.51667000);Baláo|(-2.91100000,-79.81441000);Balzar|(-1.36501000,-79.90494000)"
+Ecuador,EC,Imbabura,Atuntaqui,Quito,,,0.33247000,-78.21371000,Atuntaqui;Cotacachi;Ibarra,"Atuntaqui|(0.33247000,-78.21371000);Cotacachi|(0.30107000,-78.26428000);Ibarra|(0.35171000,-78.12233000)"
+Ecuador,EC,Loja,Loja,Quito,,,-3.99313000,-79.20422000,Loja,"Loja|(-3.99313000,-79.20422000)"
+Ecuador,EC,Los Ríos,Babahoyo,Quito,,,-1.80217000,-79.53443000,Babahoyo;Catarama;Montalvo,"Babahoyo|(-1.80217000,-79.53443000);Catarama|(-1.57504000,-79.45998000);Montalvo|(-1.79008000,-79.28759000)"
+Ecuador,EC,Manabí,Bahía de Caráquez,Quito,,,-0.59792000,-80.42367000,Bahía de Caráquez;Calceta;Cantón Portoviejo,"Bahía de Caráquez|(-0.59792000,-80.42367000);Calceta|(-0.84582000,-80.16389000);Cantón Portoviejo|(-1.05000000,-80.45000000)"
+Ecuador,EC,Morona-Santiago,Gualaquiza,Quito,,,-3.40359000,-78.58166000,Gualaquiza;Macas;Palora,"Gualaquiza|(-3.40359000,-78.58166000);Macas|(-2.30868000,-78.11135000);Palora|(-1.70131000,-77.96516000)"
+Ecuador,EC,Napo,Archidona,Quito,,,-0.90950000,-77.80772000,Archidona;Tena,"Archidona|(-0.90950000,-77.80772000);Tena|(-0.99380000,-77.81286000)"
+Ecuador,EC,Orellana,Boca Suno,Quito,,,-0.69832000,-77.14083000,Boca Suno;Francisco de Orellana Canton;Loreto Canton,"Boca Suno|(-0.69832000,-77.14083000);Francisco de Orellana Canton|(-0.46667000,-76.96667000);Loreto Canton|(-0.69487000,-77.30255000)"
+Ecuador,EC,Pastaza,Puyo,Quito,,,-1.48369000,-78.00257000,Puyo,"Puyo|(-1.48369000,-78.00257000)"
+Ecuador,EC,Pichincha,Cayambe,Quito,,,0.04084000,-78.14524000,Cayambe;Machachi;Quito,"Cayambe|(0.04084000,-78.14524000);Machachi|(-0.51011000,-78.56712000);Quito|(-0.22985000,-78.52495000)"
+Ecuador,EC,Santa Elena,Santa Elena,Quito,,,-2.22622000,-80.85873000,La Libertad;Salinas;Santa Elena,"La Libertad|(-2.23300000,-80.91039000);Salinas|(-2.21452000,-80.95151000);Santa Elena|(-2.22622000,-80.85873000)"
+Ecuador,EC,Santo Domingo de los Tsáchilas,Santo Domingo de los Colorados,Quito,,,-0.25305000,-79.17536000,Santo Domingo de los Colorados,"Santo Domingo de los Colorados|(-0.25305000,-79.17536000)"
+Ecuador,EC,Sucumbíos,Nueva Loja,Quito,,,0.08600000,-76.89528000,Nueva Loja,"Nueva Loja|(0.08600000,-76.89528000)"
+Ecuador,EC,Tungurahua,Ambato,Quito,,,-1.24908000,-78.61675000,Ambato;Baños;Pelileo,"Ambato|(-1.24908000,-78.61675000);Baños|(-1.39699000,-78.42289000);Pelileo|(-1.32990000,-78.54341000)"
+Ecuador,EC,Zamora Chinchipe,Yantzaza,Quito,,,-3.83261000,-78.76076000,Yantzaza;Zamora,"Yantzaza|(-3.83261000,-78.76076000);Zamora|(-4.06685000,-78.95488000)"
+Egypt,EG,Alexandria,Alexandria,Cairo,,,31.20176000,29.91582000,Abu Qir;Agami;Alexandria,"Abu Qir|(31.31666667,30.06666667);Agami|(31.09590000,29.76040000);Alexandria|(31.20176000,29.91582000)"
+Egypt,EG,Aswan,Aswan,Cairo,,,24.09082000,32.89942000,Abu Simbel;Aswan;Idfū,"Abu Simbel|(22.34570000,31.61624000);Aswan|(24.09082000,32.89942000);Idfū|(24.97916000,32.87722000)"
+Egypt,EG,Asyut,Abnūb,Cairo,,,27.26960000,31.15105000,Abnūb;Abū Tīj;Al Badārī,"Abnūb|(27.26960000,31.15105000);Abū Tīj|(27.04411000,31.31897000);Al Badārī|(26.99257000,31.41554000)"
+Egypt,EG,Beheira,Abū al Maţāmīr,Cairo,,,30.91018000,30.17438000,Abū al Maţāmīr;Ad Dilinjāt;Damanhūr,"Abū al Maţāmīr|(30.91018000,30.17438000);Ad Dilinjāt|(30.82796000,30.53552000);Damanhūr|(31.03408000,30.46823000)"
+Egypt,EG,Beni Suef,Al Fashn,Cairo,,,28.82431000,30.89948000,Al Fashn;Banī Suwayf;Būsh,"Al Fashn|(28.82431000,30.89948000);Banī Suwayf|(29.07441000,31.09785000);Būsh|(29.14816000,31.12733000)"
+Egypt,EG,Cairo,Cairo,Cairo,,,30.06263000,31.24967000,Badr;Bulaq;Cairo,"Badr|(30.13600000,31.71500000);Bulaq|(30.05300000,31.23000000);Cairo|(30.06263000,31.24967000)"
+Egypt,EG,Dakahlia,‘Izbat al Burj,Cairo,,,31.50840000,31.84106000,‘Izbat al Burj;Ajā;Al Jammālīyah,"‘Izbat al Burj|(31.50840000,31.84106000);Ajā|(30.94162000,31.29039000);Al Jammālīyah|(31.18065000,31.86497000)"
+Egypt,EG,Damietta,Damietta,Cairo,,,31.41648000,31.81332000,Az Zarqā;Damietta;Fāraskūr,"Az Zarqā|(31.20864000,31.63528000);Damietta|(31.41648000,31.81332000);Fāraskūr|(31.32977000,31.71507000)"
+Egypt,EG,Faiyum,Al Fayyūm,Cairo,,,29.30995000,30.84180000,Al Fayyūm;Al Wāsiţah;Ibshawāy,"Al Fayyūm|(29.30995000,30.84180000);Al Wāsiţah|(29.33778000,31.20556000);Ibshawāy|(29.35896000,30.68061000)"
+Egypt,EG,Gharbia,Al Maḩallah al Kubrá,Cairo,,,30.97063000,31.16690000,Al Maḩallah al Kubrá;Basyūn;Kafr az Zayyāt,"Al Maḩallah al Kubrá|(30.97063000,31.16690000);Basyūn|(30.93976000,30.81338000);Kafr az Zayyāt|(30.82480000,30.81805000)"
+Egypt,EG,Giza,Giza,Cairo,,,30.00808000,31.21093000,Al ‘Ayyāţ;Al Bawīţī;Al Ḩawāmidīyah,"Al ‘Ayyāţ|(29.61972000,31.25750000);Al Bawīţī|(28.34919000,28.86591000);Al Ḩawāmidīyah|(29.90000000,31.25000000)"
+Egypt,EG,Ismailia,Ismailia,Cairo,,,30.60427000,32.27225000,Ismailia,"Ismailia|(30.60427000,32.27225000)"
+Egypt,EG,Kafr El-Sheikh,Al Ḩāmūl,Cairo,,,31.31146000,31.14766000,Al Ḩāmūl;Disūq;Fuwwah,"Al Ḩāmūl|(31.31146000,31.14766000);Disūq|(31.13259000,30.64784000);Fuwwah|(31.20365000,30.54908000)"
+Egypt,EG,Luxor,Luxor,Cairo,,,25.69893000,32.64210000,Luxor;Markaz al Uqşur,"Luxor|(25.69893000,32.64210000);Markaz al Uqşur|(25.62986000,32.59017000)"
+Egypt,EG,Matrouh,Al ‘Alamayn,Cairo,,,30.83007000,28.95502000,Al ‘Alamayn;Mersa Matruh;Siwa Oasis,"Al ‘Alamayn|(30.83007000,28.95502000);Mersa Matruh|(31.35290000,27.23725000);Siwa Oasis|(29.20320000,25.51965000)"
+Egypt,EG,Minya,Abū Qurqāş,Cairo,,,27.93120000,30.83841000,Abū Qurqāş;Al Minyā;Banī Mazār,"Abū Qurqāş|(27.93120000,30.83841000);Al Minyā|(28.10988000,30.75030000);Banī Mazār|(28.50360000,30.80040000)"
+Egypt,EG,Monufia,Al Bājūr,Cairo,,,30.43046000,31.03679000,Al Bājūr;Ash Shuhadā’;Ashmūn,"Al Bājūr|(30.43046000,31.03679000);Ash Shuhadā’|(30.59683000,30.89931000);Ashmūn|(30.29735000,30.97641000)"
+Egypt,EG,New Valley,Al Khārijah,Cairo,,,25.45141000,30.54635000,Al Khārijah;Qaşr al Farāfirah,"Al Khārijah|(25.45141000,30.54635000);Qaşr al Farāfirah|(27.05680000,27.96979000)"
+Egypt,EG,North Sinai,Arish,Cairo,,,31.13159000,33.79844000,Arish,"Arish|(31.13159000,33.79844000)"
+Egypt,EG,Port Said,Port Said,Cairo,,,31.25654000,32.28411000,Port Said,"Port Said|(31.25654000,32.28411000)"
+Egypt,EG,Qalyubia,Al Khānkah,Cairo,,,30.21035000,31.36812000,Al Khānkah;Al Qanāţir al Khayrīyah;Banhā,"Al Khānkah|(30.21035000,31.36812000);Al Qanāţir al Khayrīyah|(30.19327000,31.13703000);Banhā|(30.45977000,31.18420000)"
+Egypt,EG,Qena,Dishnā,Cairo,,,26.12467000,32.47598000,Dishnā;Farshūţ;Isnā,"Dishnā|(26.12467000,32.47598000);Farshūţ|(26.05494000,32.16329000);Isnā|(25.29336000,32.55402000)"
+Egypt,EG,Red Sea,Al Quşayr,Cairo,,,26.10426000,34.27793000,Al Quşayr;El Gouna;Hurghada,"Al Quşayr|(26.10426000,34.27793000);El Gouna|(27.39417000,33.67825000);Hurghada|(27.25738000,33.81291000)"
+Egypt,EG,Sharqia,10th of Ramadan,Cairo,,,30.29939390,31.61417890,10th of Ramadan;Al Qurein;Awlad Saqr,"10th of Ramadan|(30.29939390,31.61417890);Al Qurein|(26.29300660,31.84950350);Awlad Saqr|(30.93096230,31.69132380)"
+Egypt,EG,Sohag,Sohag,Cairo,,,26.55695000,31.69478000,Akhmīm;Al Balyanā;Al Manshāh,"Akhmīm|(26.56217000,31.74503000);Al Balyanā|(26.23568000,32.00347000);Al Manshāh|(26.47686000,31.80350000)"
+Egypt,EG,South Sinai,Dahab,Cairo,,,28.48208000,34.49505000,Dahab;El-Tor;Nuwaybi‘a,"Dahab|(28.48208000,34.49505000);El-Tor|(28.24168000,33.62220000);Nuwaybi‘a|(29.04681000,34.66340000)"
+Egypt,EG,Suez,Suez,Cairo,,,29.97371000,32.52627000,Ain Sukhna;Suez,"Ain Sukhna|(29.60018000,32.31671000);Suez|(29.97371000,32.52627000)"
+El Salvador,SV,Ahuachapán,Ahuachapán,San Salvador,EMEA,13,13.92139000,-89.84500000,Ahuachapán;Atiquizaya;Concepción de Ataco,"Ahuachapán|(13.92139000,-89.84500000);Atiquizaya|(13.97694000,-89.75250000);Concepción de Ataco|(13.87028000,-89.84861000)"
+El Salvador,SV,Cabañas,Sensuntepeque,San Salvador,EMEA,13,13.86667000,-88.63333000,Sensuntepeque;Victoria,"Sensuntepeque|(13.86667000,-88.63333000);Victoria|(13.95000000,-88.63333000)"
+El Salvador,SV,Chalatenango,Chalatenango,San Salvador,EMEA,13,14.03333000,-88.93333000,Chalatenango;Nueva Concepción,"Chalatenango|(14.03333000,-88.93333000);Nueva Concepción|(14.13333000,-89.30000000)"
+El Salvador,SV,Cuscatlán,Cojutepeque,San Salvador,EMEA,13,13.71667000,-88.93333000,Cojutepeque;San Martín;Suchitoto,"Cojutepeque|(13.71667000,-88.93333000);San Martín|(13.78333000,-88.91667000);Suchitoto|(13.93806000,-89.02778000)"
+El Salvador,SV,La Libertad,La Libertad,San Salvador,EMEA,13,13.48833000,-89.32222000,Antiguo Cuscatlán;Ciudad Arce;La Libertad,"Antiguo Cuscatlán|(13.66492000,-89.25319000);Ciudad Arce|(13.84028000,-89.44722000);La Libertad|(13.48833000,-89.32222000)"
+El Salvador,SV,La Paz,El Rosario,San Salvador,EMEA,13,13.49778000,-89.02972000,El Rosario;Olocuilta;San Pedro Masahuat,"El Rosario|(13.49778000,-89.02972000);Olocuilta|(13.56972000,-89.11722000);San Pedro Masahuat|(13.54361000,-89.03861000)"
+El Salvador,SV,La Unión ,La Unión,San Salvador,EMEA,13,13.33694000,-87.84389000,Anamorós;Conchagua;Intipucá,"Anamorós|(13.74056000,-87.87361000);Conchagua|(13.30778000,-87.86472000);Intipucá|(13.19694000,-88.05444000)"
+El Salvador,SV,Morazán,Cacaopera,San Salvador,EMEA,13,13.76667000,-88.08333000,Cacaopera;Corinto;Guatajiagua,"Cacaopera|(13.76667000,-88.08333000);Corinto|(13.81083000,-87.97139000);Guatajiagua|(13.66667000,-88.20000000)"
+El Salvador,SV,San Miguel,San Miguel,San Salvador,EMEA,13,13.48333000,-88.18333000,Chapeltique;Chinameca;Chirilagua,"Chapeltique|(13.63333000,-88.26667000);Chinameca|(13.50000000,-88.35000000);Chirilagua|(13.22028000,-88.13861000)"
+El Salvador,SV,San Salvador,San Salvador,San Salvador,EMEA,13,13.68935000,-89.18718000,Aguilares;Apopa;Ayutuxtepeque,"Aguilares|(13.95722000,-89.18972000);Apopa|(13.80722000,-89.17917000);Ayutuxtepeque|(13.74556000,-89.20639000)"
+El Salvador,SV,San Vicente,San Vicente,San Salvador,EMEA,13,13.63333000,-88.80000000,Apastepeque;San Sebastián;San Vicente,"Apastepeque|(13.66667000,-88.78333000);San Sebastián|(13.73333000,-88.83333000);San Vicente|(13.63333000,-88.80000000)"
+El Salvador,SV,Santa Ana,Santa Ana,San Salvador,EMEA,13,13.99417000,-89.55972000,Candelaria de La Frontera;Chalchuapa;Coatepeque,"Candelaria de La Frontera|(14.11667000,-89.65000000);Chalchuapa|(13.98667000,-89.68111000);Coatepeque|(13.92861000,-89.50417000)"
+El Salvador,SV,Sonsonate,Sonsonate,San Salvador,EMEA,13,13.71889000,-89.72417000,Acajutla;Armenia;Izalco,"Acajutla|(13.59278000,-89.82750000);Armenia|(13.74361000,-89.49889000);Izalco|(13.74472000,-89.67306000)"
+El Salvador,SV,Usulután,Usulután,San Salvador,EMEA,13,13.35000000,-88.45000000,Berlín;Concepción Batres;Jiquilisco,"Berlín|(13.50000000,-88.53333000);Concepción Batres|(13.35000000,-88.36667000);Jiquilisco|(13.31667000,-88.58333000)"
+Equatorial Guinea,GQ,Annobón,San Antonio de Palé,Malabo,,,-1.40680000,5.63178000,San Antonio de Palé,"San Antonio de Palé|(-1.40680000,5.63178000)"
+Equatorial Guinea,GQ,Bioko Norte,Malabo,Malabo,,,3.75578000,8.78166000,Malabo;Rebola;Santiago de Baney,"Malabo|(3.75578000,8.78166000);Rebola|(3.71667000,8.83333000);Santiago de Baney|(3.69920000,8.90840000)"
+Equatorial Guinea,GQ,Bioko Sur,Luba,Malabo,,,3.45683000,8.55465000,Luba,"Luba|(3.45683000,8.55465000)"
+Equatorial Guinea,GQ,Centro Sur,Acurenam,Malabo,,,1.03225000,10.64882000,Acurenam;Bicurga;Evinayong,"Acurenam|(1.03225000,10.64882000);Bicurga|(1.58113000,10.46716000);Evinayong|(1.43677000,10.55124000)"
+Equatorial Guinea,GQ,Insular,,Malabo,,,,,,
+Equatorial Guinea,GQ,Kié-Ntem,Ebebiyin,Malabo,,,2.15106000,11.33528000,Ebebiyin;Mikomeseng;Ncue,"Ebebiyin|(2.15106000,11.33528000);Mikomeseng|(2.13609000,10.61322000);Ncue|(2.01643000,10.47066000)"
+Equatorial Guinea,GQ,Litoral,Bata,Malabo,,,1.86391000,9.76582000,Bata;Bitica;Cogo,"Bata|(1.86391000,9.76582000);Bitica|(1.42610000,9.62316000);Cogo|(1.08425000,9.69300000)"
+Equatorial Guinea,GQ,Río Muni,,Malabo,,,,,,
+Equatorial Guinea,GQ,Wele-Nzas,Aconibe,Malabo,,,1.29683000,10.93691000,Aconibe;Añisoc;Ayene,"Aconibe|(1.29683000,10.93691000);Añisoc|(1.86580000,10.76892000);Ayene|(1.85592000,10.68994000)"
+Eritrea,ER,Anseba,Keren,Asmara,,,15.77792000,38.45107000,Keren,"Keren|(15.77792000,38.45107000)"
+Eritrea,ER,Debub,Adi Keyh,Asmara,,,14.84444000,39.37722000,Adi Keyh;Dek’emhāre;Mendefera,"Adi Keyh|(14.84444000,39.37722000);Dek’emhāre|(15.07000000,39.04750000);Mendefera|(14.88722000,38.81528000)"
+Eritrea,ER,Gash-Barka,Ak’ordat,Asmara,,,15.54798000,37.88291000,Ak’ordat;Barentu;Teseney,"Ak’ordat|(15.54798000,37.88291000);Barentu|(15.10582000,37.59067000);Teseney|(15.11000000,36.65750000)"
+Eritrea,ER,Maekel,Asmara,Asmara,,,15.33805000,38.93184000,Asmara,"Asmara|(15.33805000,38.93184000)"
+Eritrea,ER,Northern Red Sea,Massawa,Asmara,,,15.60811000,39.47455000,Massawa,"Massawa|(15.60811000,39.47455000)"
+Eritrea,ER,Southern Red Sea,Assab,Asmara,,,13.00917000,42.73944000,Assab;Edd,"Assab|(13.00917000,42.73944000);Edd|(13.93088000,41.69380000)"
+Estonia,EE,Harju,Anija vald,Tallinn,,,59.27644000,25.48168000,Anija vald;Aruküla;Haabneeme,"Anija vald|(59.27644000,25.48168000);Aruküla|(59.36686000,25.07618000);Haabneeme|(59.51358000,24.82225000)"
+Estonia,EE,Hiiu,Kärdla,Tallinn,,,58.99778000,22.74917000,Kärdla,"Kärdla|(58.99778000,22.74917000)"
+Estonia,EE,Ida-Viru,Iisaku,Tallinn,,,59.10139000,27.30806000,Iisaku;Jõhvi;Jõhvi vald,"Iisaku|(59.10139000,27.30806000);Jõhvi|(59.35917000,27.42111000);Jõhvi vald|(59.35653000,27.39304000)"
+Estonia,EE,Järva,Järva-Jaani,Tallinn,,,59.03861000,25.88639000,Järva-Jaani;Koeru;Paide,"Järva-Jaani|(59.03861000,25.88639000);Koeru|(58.96306000,26.03083000);Paide|(58.88556000,25.55722000)"
+Estonia,EE,Jõgeva,Jõgeva,Tallinn,,,58.74667000,26.39389000,Jõgeva;Jõgeva vald;Mustvee,"Jõgeva|(58.74667000,26.39389000);Jõgeva vald|(58.78732000,26.38122000);Mustvee|(58.84861000,26.93972000)"
+Estonia,EE,Lääne,Haapsalu,Tallinn,,,58.94306000,23.54139000,Haapsalu;Haapsalu linn;Hullo,"Haapsalu|(58.94306000,23.54139000);Haapsalu linn|(58.93580000,23.53005000);Hullo|(58.99004000,23.24441000)"
+Estonia,EE,Lääne-Viru,Aseri,Tallinn,,,59.45056000,26.86750000,Aseri;Haljala;Haljala vald,"Aseri|(59.45056000,26.86750000);Haljala|(59.43361000,26.26139000);Haljala vald|(59.45427000,26.22015000)"
+Estonia,EE,Pärnu,Pärnu,Tallinn,,,58.38588000,24.49711000,Audru;Kihnu vald;Kilingi-Nõmme,"Audru|(58.40861000,24.37389000);Kihnu vald|(58.13000000,23.99002000);Kilingi-Nõmme|(58.15028000,24.96417000)"
+Estonia,EE,Põlva,Põlva,Tallinn,,,58.06028000,27.06944000,Kanepi;Kanepi vald;Põlva,"Kanepi|(57.98306000,26.75639000);Kanepi vald|(57.98058000,26.76151000);Põlva|(58.06028000,27.06944000)"
+Estonia,EE,Rapla,Rapla,Tallinn,,,59.00722000,24.79278000,Järvakandi;Kehtna;Kehtna vald,"Järvakandi|(58.77889000,24.82583000);Kehtna|(58.93028000,24.87806000);Kehtna vald|(58.84274000,24.89002000)"
+Estonia,EE,Saare,Kuressaare,Tallinn,,,58.24806000,22.50389000,Kuressaare;Liiva;Muhu vald,"Kuressaare|(58.24806000,22.50389000);Liiva|(58.60194000,23.24694000);Muhu vald|(58.58486000,23.25609000)"
+Estonia,EE,Tartu,Tartu,Tallinn,,,58.38062000,26.72509000,Alatskivi;Elva;Kallaste,"Alatskivi|(58.59806000,27.13361000);Elva|(58.22250000,26.42111000);Kallaste|(58.66312000,27.16164000)"
+Estonia,EE,Valga,Valga,Tallinn,,,57.77781000,26.04730000,Otepää vald;Tõrva;Valga,"Otepää vald|(58.02177000,26.45306000);Tõrva|(58.00278000,25.93500000);Valga|(57.77781000,26.04730000)"
+Estonia,EE,Viljandi,Viljandi,Tallinn,,,58.36389000,25.59000000,Abja-Paluoja;Karksi-Nuia;Mõisaküla,"Abja-Paluoja|(58.12528000,25.34972000);Karksi-Nuia|(58.10333000,25.56278000);Mõisaküla|(58.09222000,25.18639000)"
+Estonia,EE,Võru,Võru,Tallinn,,,57.83389000,27.01944000,Antsla;Antsla vald;Rõuge,"Antsla|(57.82556000,26.54056000);Antsla vald|(57.77738000,26.59520000);Rõuge|(57.72778000,26.90972000)"
+Eswatini,SZ,Hhohho,Bulembu,Mbabane,EMEA,18,-25.96667000,31.13333000,Bulembu;Hhukwini;Lobamba,"Bulembu|(-25.96667000,31.13333000);Hhukwini|(-26.31972000,31.22222000);Lobamba|(-26.46667000,31.20000000)"
+Eswatini,SZ,Lubombo,Big Bend,Mbabane,EMEA,18,-26.81667000,31.93333000,Big Bend;Dvokodvweni Inkhundla;Lomashasha,"Big Bend|(-26.81667000,31.93333000);Dvokodvweni Inkhundla|(-26.45398000,31.76456000);Lomashasha|(-26.06644000,32.00768000)"
+Eswatini,SZ,Manzini,Manzini,Mbabane,EMEA,18,-26.49884000,31.38004000,Bhunya;Ekukhanyeni;Kwaluseni,"Bhunya|(-26.55000000,31.01667000);Ekukhanyeni|(-26.38750000,31.52806000);Kwaluseni|(-26.48333000,31.33333000)"
+Eswatini,SZ,Shiselweni,Hlatikulu,Mbabane,EMEA,18,-26.97917000,31.32444000,Hlatikulu;Hluti;Kubuta,"Hlatikulu|(-26.97917000,31.32444000);Hluti|(-27.21667000,31.61667000);Kubuta|(-26.88333000,31.48333000)"
+Ethiopia,ET,Addis Ababa,Addis Ababa,Addis Ababa,,,9.02497000,38.74689000,Addis Ababa,"Addis Ababa|(9.02497000,38.74689000)"
+Ethiopia,ET,Afar,Administrative Zone 2,Addis Ababa,,,13.68513000,40.05615000,Administrative Zone 2;Administrative Zone 3;Asaita,"Administrative Zone 2|(13.68513000,40.05615000);Administrative Zone 3|(10.00902000,40.47394000);Asaita|(11.56838000,41.43869000)"
+Ethiopia,ET,Amhara,Abomsa,Addis Ababa,,,9.98333000,39.98333000,Abomsa;Addiet Canna;Ādīs Zemen,"Abomsa|(9.98333000,39.98333000);Addiet Canna|(11.26667000,37.48333000);Ādīs Zemen|(12.11667000,37.78333000)"
+Ethiopia,ET,Benishangul-Gumuz,Asosa,Addis Ababa,,,10.00000000,34.50000000,Asosa;Metekel,"Asosa|(10.00000000,34.50000000);Metekel|(10.42673000,35.71975000)"
+Ethiopia,ET,Dire Dawa,Dire Dawa,Addis Ababa,,,9.59306000,41.86611000,Dire Dawa,"Dire Dawa|(9.59306000,41.86611000)"
+Ethiopia,ET,Gambela,Administrative Zone 1,Addis Ababa,,,8.14699000,33.97335000,Administrative Zone 1;Gambēla,"Administrative Zone 1|(8.14699000,33.97335000);Gambēla|(8.25000000,34.58333000)"
+Ethiopia,ET,Harari,Harar,Addis Ababa,,,9.31387000,42.11815000,Harar,"Harar|(9.31387000,42.11815000)"
+Ethiopia,ET,Oromia,Ādīs ‘Alem,Addis Ababa,,,9.03333000,38.40000000,Ādīs ‘Alem;Āgaro;Arsi Zone,"Ādīs ‘Alem|(9.03333000,38.40000000);Āgaro|(7.85000000,36.65000000);Arsi Zone|(7.50000000,39.50000000)"
+Ethiopia,ET,Somali,Afder Zone,Addis Ababa,,,5.25000000,43.00000000,Afder Zone;Degehabur Zone;Gode Zone,"Afder Zone|(5.25000000,43.00000000);Degehabur Zone|(8.25000000,43.75000000);Gode Zone|(6.00000000,43.75000000)"
+Ethiopia,ET,"Southern Nations, Nationalities, and Peoples'",Alaba Special Wereda,Addis Ababa,,,7.45347000,38.21189000,Alaba Special Wereda;Arba Minch;Āreka,"Alaba Special Wereda|(7.45347000,38.21189000);Arba Minch|(6.03333000,37.55000000);Āreka|(7.06667000,37.70000000)"
+Ethiopia,ET,Tigray,Ādīgrat,Addis Ababa,,,14.27700000,39.46200000,Ādīgrat;Axum;Inda Silasē,"Ādīgrat|(14.27700000,39.46200000);Axum|(14.12109000,38.72337000);Inda Silasē|(14.10307000,38.28289000)"
+Faroe Islands,FO,Eysturoy,Eiði,Torshavn,,,62.27890000,-7.01230000,Eiði;Eystur;Fuglafjørður,"Eiði|(62.27890000,-7.01230000);Eystur|(62.15670000,-6.82330000);Fuglafjørður|(62.21010000,-6.81230000)"
+Faroe Islands,FO,Northern Isles,Hvannasund,Torshavn,,,62.34560000,-6.78900000,Hvannasund;Klaksvík;Kunoy,"Hvannasund|(62.34560000,-6.78900000);Klaksvík|(62.22100000,-6.58000000);Kunoy|(62.34560000,-6.89010000)"
+Faroe Islands,FO,Sandoy,Húsavík,Torshavn,,,61.80964950,-6.67949560,Húsavík;Sandur;Skálavík,"Húsavík|(61.80964950,-6.67949560);Sandur|(61.83481550,-6.81758260);Skálavík|(61.83026760,-6.66403200)"
+Faroe Islands,FO,Streymoy,Kvívík,Torshavn,,,62.14560000,-7.20980000,Kvívík;Sunda;Tórshavn,"Kvívík|(62.14560000,-7.20980000);Sunda|(62.13450000,-7.09870000);Tórshavn|(62.00000000,-7.00000000)"
+Faroe Islands,FO,Suðuroy,Fámjin,Torshavn,,,61.52468660,-6.87927050,Fámjin;Hov;Hvalba,"Fámjin|(61.52468660,-6.87927050);Hov|(61.50693570,-6.75574220);Hvalba|(61.59870000,-6.98760000)"
+Faroe Islands,FO,Vágar,Vágar,Torshavn,,,62.06670000,-7.10000000,Sørvágur;Vágar,"Sørvágur|(62.06540000,-7.37870000);Vágar|(62.06670000,-7.10000000)"
+Fiji Islands,FJ,Ba,,Suva,,,,,,
+Fiji Islands,FJ,Bua,,Suva,,,,,,
+Fiji Islands,FJ,Cakaudrove,,Suva,,,,,,
+Fiji Islands,FJ,Central,Naitasiri Province,Suva,,,-17.83333000,178.25000000,Naitasiri Province;Namosi Province;Rewa Province,"Naitasiri Province|(-17.83333000,178.25000000);Namosi Province|(-18.05000000,178.13333000);Rewa Province|(-18.08333000,178.33333000)"
+Fiji Islands,FJ,Eastern,Kadavu Province,Suva,,,-18.99331000,178.22021000,Kadavu Province;Lau Province;Levuka,"Kadavu Province|(-18.99331000,178.22021000);Lau Province|(-18.20488000,-178.79251000);Levuka|(-18.06667000,179.31667000)"
+Fiji Islands,FJ,Kadavu,,Suva,,,,,,
+Fiji Islands,FJ,Lau,,Suva,,,,,,
+Fiji Islands,FJ,Lomaiviti,,Suva,,,,,,
+Fiji Islands,FJ,Macuata,,Suva,,,,,,
+Fiji Islands,FJ,Nadroga-Navosa,,Suva,,,,,,
+Fiji Islands,FJ,Naitasiri,,Suva,,,,,,
+Fiji Islands,FJ,Namosi,,Suva,,,,,,
+Fiji Islands,FJ,Northern,Bua Province,Suva,,,-16.83333000,178.75000000,Bua Province;Cakaudrove Province;Labasa,"Bua Province|(-16.83333000,178.75000000);Cakaudrove Province|(-16.66667000,179.41667000);Labasa|(-16.43320000,179.36451000)"
+Fiji Islands,FJ,Ra,,Suva,,,,,,
+Fiji Islands,FJ,Rewa,,Suva,,,,,,
+Fiji Islands,FJ,Rotuma,,Suva,,,,,,
+Fiji Islands,FJ,Serua,,Suva,,,,,,
+Fiji Islands,FJ,Tailevu,,Suva,,,,,,
+Fiji Islands,FJ,Western,Ba,Suva,,,-17.53430000,177.67407000,Ba;Ba Province;Lautoka,"Ba|(-17.53430000,177.67407000);Ba Province|(-17.66667000,177.66667000);Lautoka|(-17.61686000,177.45049000)"
+Finland,FI,Åland Islands,Brändö,Helsinki,,,60.40750000,21.07860000,Brändö;Eckerö;Finström,"Brändö|(60.40750000,21.07860000);Eckerö|(60.22080000,19.55890000);Finström|(60.23420000,20.11390000)"
+Finland,FI,Central Finland,Äänekoski,Helsinki,,,62.60000000,25.73333000,Äänekoski;Hankasalmi;Jämsä,"Äänekoski|(62.60000000,25.73333000);Hankasalmi|(62.38333000,26.43333000);Jämsä|(61.86420000,25.19002000)"
+Finland,FI,Central Ostrobothnia,Halsua,Helsinki,,,63.46667000,24.16667000,Halsua;Kälviä;Kannus,"Halsua|(63.46667000,24.16667000);Kälviä|(63.86067000,23.45289000);Kannus|(63.90000000,23.90000000)"
+Finland,FI,Finland Proper,Alastaro,Helsinki,,,60.95000000,22.85000000,Alastaro;Askainen;Aura,"Alastaro|(60.95000000,22.85000000);Askainen|(60.56667000,21.86667000);Aura|(60.64710000,22.58755000)"
+Finland,FI,Kainuu,Hyrynsalmi,Helsinki,,,64.66667000,28.53333000,Hyrynsalmi;Kajaani;Kuhmo,"Hyrynsalmi|(64.66667000,28.53333000);Kajaani|(64.22728000,27.72846000);Kuhmo|(64.13333000,29.51667000)"
+Finland,FI,Kymenlaakso,Anjala,Helsinki,,,60.68333000,26.83333000,Anjala;Elimäki;Hamina,"Anjala|(60.68333000,26.83333000);Elimäki|(60.71667000,26.46667000);Hamina|(60.56974000,27.19794000)"
+Finland,FI,Lapland,Enontekiö,Helsinki,,,68.38573000,23.63215000,Enontekiö;Inari;Ivalo,"Enontekiö|(68.38573000,23.63215000);Inari|(68.90596000,27.02881000);Ivalo|(68.65986000,27.53891000)"
+Finland,FI,North Karelia,Eno,Helsinki,,,62.80511000,30.15422000,Eno;Ilomantsi;Joensuu,"Eno|(62.80511000,30.15422000);Ilomantsi|(62.67162000,30.93276000);Joensuu|(62.60118000,29.76316000)"
+Finland,FI,Northern Ostrobothnia,Alavieska,Helsinki,,,64.16667000,24.30000000,Alavieska;Haapajärvi;Haapavesi,"Alavieska|(64.16667000,24.30000000);Haapajärvi|(63.75000000,25.33333000);Haapavesi|(64.13333000,25.36667000)"
+Finland,FI,Northern Savonia,,Helsinki,,,,,,
+Finland,FI,Ostrobothnia,Hietalahti,Helsinki,,,63.08480000,21.61716000,Hietalahti;Isokyrö;Jakobstad,"Hietalahti|(63.08480000,21.61716000);Isokyrö|(63.01172000,22.33332000);Jakobstad|(63.67486000,22.70256000)"
+Finland,FI,Päijänne Tavastia,Artjärvi,Helsinki,,,60.74544000,26.07084000,Artjärvi;Asikkala;Auttoinen,"Artjärvi|(60.74544000,26.07084000);Asikkala|(61.21667000,25.50000000);Auttoinen|(61.29901000,25.08887000)"
+Finland,FI,Pirkanmaa,Äetsä,Helsinki,,,61.28333000,22.68333000,Äetsä;Aimala;Aitoo,"Äetsä|(61.28333000,22.68333000);Aimala|(61.33000000,23.69000000);Aitoo|(61.33897400,24.49431900)"
+Finland,FI,Satakunta,Eura,Helsinki,,,61.13333000,22.13333000,Eura;Eurajoki;Harjavalta,"Eura|(61.13333000,22.13333000);Eurajoki|(61.20000000,21.73333000);Harjavalta|(61.31667000,22.13333000)"
+Finland,FI,South Karelia,Imatra,Helsinki,,,61.17185000,28.75242000,Imatra;Joutseno;Lappeenranta,"Imatra|(61.17185000,28.75242000);Joutseno|(61.11796000,28.50763000);Lappeenranta|(61.05871000,28.18871000)"
+Finland,FI,Southern Ostrobothnia,Ähtäri,Helsinki,,,62.55403000,24.06186000,Ähtäri;Alahärmä;Alajärvi,"Ähtäri|(62.55403000,24.06186000);Alahärmä|(63.23333000,22.85000000);Alajärvi|(63.00000000,23.81667000)"
+Finland,FI,Southern Savonia,Enonkoski,Helsinki,,,62.08333000,28.93333000,Enonkoski;Haukivuori;Heinävesi,"Enonkoski|(62.08333000,28.93333000);Haukivuori|(62.01753000,27.21906000);Heinävesi|(62.43333000,28.60000000)"
+Finland,FI,Tavastia Proper,Forssa,Helsinki,,,60.81462000,23.62146000,Forssa;Hämeenlinna;Hauho,"Forssa|(60.81462000,23.62146000);Hämeenlinna|(60.99596000,24.46434000);Hauho|(61.17255000,24.56303000)"
+Finland,FI,Uusimaa,Askola,Helsinki,,,60.53333000,25.60000000,Askola;Ekenäs;Espoo,"Askola|(60.53333000,25.60000000);Ekenäs|(59.97359000,23.43389000);Espoo|(60.20520000,24.65220000)"
+France,FR,Ain,,Paris,,,,,,
+France,FR,Aisne,,Paris,,,,,,
+France,FR,Allier,,Paris,,,,,,
+France,FR,Alpes-de-Haute-Provence,,Paris,,,,,,
+France,FR,Alpes-Maritimes,,Paris,,,,,,
+France,FR,Alsace,,Paris,,,,,,
+France,FR,Ardèche,,Paris,,,,,,
+France,FR,Ardennes,,Paris,,,,,,
+France,FR,Ariège,,Paris,,,,,,
+France,FR,Aube,,Paris,,,,,,
+France,FR,Aude,,Paris,,,,,,
+France,FR,Auvergne-Rhône-Alpes,Abondance,Paris,,,46.27874000,6.72105000,Abondance;Abrest;Aigueblanche,"Abondance|(46.27874000,6.72105000);Abrest|(46.09859000,3.44461000);Aigueblanche|(45.50455000,6.50184000)"
+France,FR,Aveyron,,Paris,,,,,,
+France,FR,Bas-Rhin,,Paris,,,,,,
+France,FR,Bouches-du-Rhône,,Paris,,,,,,
+France,FR,Bourgogne-Franche-Comté,Ahuy,Paris,,,47.36944000,5.02089000,Ahuy;Aillant-sur-Tholon;Aillevillers-et-Lyaumont,"Ahuy|(47.36944000,5.02089000);Aillant-sur-Tholon|(47.87426000,3.35049000);Aillevillers-et-Lyaumont|(47.92033000,6.33775000)"
+France,FR,Bretagne,Acigné,Paris,,,48.13333000,-1.53704000,Acigné;Allaire;Amanlis,"Acigné|(48.13333000,-1.53704000);Allaire|(47.63752000,-2.16324000);Amanlis|(48.00752000,-1.47677000)"
+France,FR,Calvados,,Paris,,,,,,
+France,FR,Cantal,,Paris,,,,,,
+France,FR,Centre-Val de Loire,Abilly,Paris,,,46.93333000,0.73333000,Abilly;Abondant;Aigurande,"Abilly|(46.93333000,0.73333000);Abondant|(48.78590000,1.44006000);Aigurande|(46.43397000,1.83026000)"
+France,FR,Charente,,Paris,,,,,,
+France,FR,Charente-Maritime,,Paris,,,,,,
+France,FR,Cher,,Paris,,,,,,
+France,FR,Clipperton,,Paris,,,,,,
+France,FR,Corrèze,,Paris,,,,,,
+France,FR,Corse,Afa,Paris,,,41.98396000,8.79833000,Afa;Ajaccio;Alata,"Afa|(41.98396000,8.79833000);Ajaccio|(41.91886000,8.73812000);Alata|(41.97636000,8.74208000)"
+France,FR,Corse-du-Sud,Altagène,Paris,,,41.70979980,9.03244740,Altagène;Ambiegna;Arbellara,"Altagène|(41.70979980,9.03244740);Ambiegna|(42.08997100,8.68572790);Arbellara|(41.67053860,8.95143510)"
+France,FR,Côte-d'Or,,Paris,,,,,,
+France,FR,Côtes-d'Armor,,Paris,,,,,,
+France,FR,Creuse,,Paris,,,,,,
+France,FR,Deux-Sèvres,,Paris,,,,,,
+France,FR,Dordogne,,Paris,,,,,,
+France,FR,Doubs,,Paris,,,,,,
+France,FR,Drôme,,Paris,,,,,,
+France,FR,Essonne,,Paris,,,,,,
+France,FR,Eure,,Paris,,,,,,
+France,FR,Eure-et-Loir,,Paris,,,,,,
+France,FR,Finistère,,Paris,,,,,,
+France,FR,French Guiana,,Paris,,,,,,
+France,FR,French Polynesia,,Paris,,,,,,
+France,FR,French Southern and Antarctic Lands,,Paris,,,,,,
+France,FR,Gard,,Paris,,,,,,
+France,FR,Gers,,Paris,,,,,,
+France,FR,Gironde,,Paris,,,,,,
+France,FR,Grand-Est,Abreschviller,Paris,,,48.63698000,7.09607000,Abreschviller;Achenheim;Aiglemont,"Abreschviller|(48.63698000,7.09607000);Achenheim|(48.58070000,7.62803000);Aiglemont|(49.78031000,4.76483000)"
+France,FR,Guadeloupe,,Paris,,,,,,
+France,FR,Haut-Rhin,,Paris,,,,,,
+France,FR,Haute-Corse,Aghione,Paris,,,42.09351770,9.32400680,Aghione;Aiti;Alando,"Aghione|(42.09351770,9.32400680);Aiti|(42.40272900,9.14601550);Alando|(42.30835090,9.24872760)"
+France,FR,Haute-Garonne,,Paris,,,,,,
+France,FR,Haute-Loire,,Paris,,,,,,
+France,FR,Haute-Marne,Ageville,Paris,,,48.11003830,5.17310240,Ageville;Aigremont;Aillianville,"Ageville|(48.11003830,5.17310240);Aigremont|(48.90266770,1.99205600);Aillianville|(48.33429430,5.43849100)"
+France,FR,Haute-Saône,,Paris,,,,,,
+France,FR,Haute-Savoie,,Paris,,,,,,
+France,FR,Haute-Vienne,,Paris,,,,,,
+France,FR,Hautes-Alpes,,Paris,,,,,,
+France,FR,Hautes-Pyrénées,,Paris,,,,,,
+France,FR,Hauts-de-France,Abbeville,Paris,,,50.10521000,1.83547000,Abbeville;Ablain-Saint-Nazaire;Abscon,"Abbeville|(50.10521000,1.83547000);Ablain-Saint-Nazaire|(50.39320000,2.70880000);Abscon|(50.33333000,3.30000000)"
+France,FR,Hauts-de-Seine,,Paris,,,,,,
+France,FR,Hérault,,Paris,,,,,,
+France,FR,Île-de-France,Ableiges,Paris,,,49.08932000,1.98154000,Ableiges;Ablis;Ablon-sur-Seine,"Ableiges|(49.08932000,1.98154000);Ablis|(48.51720000,1.83624000);Ablon-sur-Seine|(48.72732000,2.42686000)"
+France,FR,Ille-et-Vilaine,,Paris,,,,,,
+France,FR,Indre,,Paris,,,,,,
+France,FR,Indre-et-Loire,,Paris,,,,,,
+France,FR,Isère,,Paris,,,,,,
+France,FR,Jura,,Paris,,,,,,
+France,FR,La Réunion,,Paris,,,,,,
+France,FR,Landes,,Paris,,,,,,
+France,FR,Loir-et-Cher,,Paris,,,,,,
+France,FR,Loire,,Paris,,,,,,
+France,FR,Loire-Atlantique,,Paris,,,,,,
+France,FR,Loiret,,Paris,,,,,,
+France,FR,Lot,,Paris,,,,,,
+France,FR,Lot-et-Garonne,,Paris,,,,,,
+France,FR,Lozère,Albaret-le-Comtal,Paris,,,44.86408830,3.06236370,Albaret-le-Comtal;Albaret-Sainte-Marie;Allenc,"Albaret-le-Comtal|(44.86408830,3.06236370);Albaret-Sainte-Marie|(44.88040430,3.17131470);Allenc|(44.54993740,3.59555250)"
+France,FR,Maine-et-Loire,,Paris,,,,,,
+France,FR,Manche,,Paris,,,,,,
+France,FR,Marne,,Paris,,,,,,
+France,FR,Martinique,,Paris,,,,,,
+France,FR,Mayenne,,Paris,,,,,,
+France,FR,Mayotte,,Paris,,,,,,
+France,FR,Métropole de Lyon,,Paris,,,,,,
+France,FR,Meurthe-et-Moselle,,Paris,,,,,,
+France,FR,Meuse,Abainville,Paris,,,48.53100980,5.48230790,Abainville;Aincreville;Amanty,"Abainville|(48.53100980,5.48230790);Aincreville|(49.36873540,5.09406930);Amanty|(48.51595410,5.56034560)"
+France,FR,Morbihan,,Paris,,,,,,
+France,FR,Moselle,,Paris,,,,,,
+France,FR,Nièvre,,Paris,,,,,,
+France,FR,Nord,,Paris,,,,,,
+France,FR,Normandie,Ablon,Paris,,,49.39214000,0.29584000,Ablon;Acquigny;Agneaux,"Ablon|(49.39214000,0.29584000);Acquigny|(49.17350000,1.17650000);Agneaux|(49.11905000,-1.10610000)"
+France,FR,Nouvelle-Aquitaine,Abzac,Paris,,,45.01667000,-0.13333000,Abzac;Agen;Agonac,"Abzac|(45.01667000,-0.13333000);Agen|(44.19991000,0.62664000);Agonac|(45.29248000,0.75025000)"
+France,FR,Occitanie,Abeilhan,Paris,,,43.44925000,3.29529000,Abeilhan;Agde;Aiguefonde,"Abeilhan|(43.44925000,3.29529000);Agde|(43.31083000,3.47583000);Aiguefonde|(43.49394000,2.31686000)"
+France,FR,Oise,,Paris,,,,,,
+France,FR,Orne,,Paris,,,,,,
+France,FR,Paris,,Paris,,,,,,
+France,FR,Pas-de-Calais,,Paris,,,,,,
+France,FR,Pays-de-la-Loire,Abbaretz,Paris,,,47.55314000,-1.53200000,Abbaretz;Ahuillé;Aigné,"Abbaretz|(47.55314000,-1.53200000);Ahuillé|(48.02086000,-0.86906000);Aigné|(48.06471000,0.11908000)"
+France,FR,Provence-Alpes-Côte-d’Azur,Aix-en-Provence,Paris,,,43.52830000,5.44973000,Aix-en-Provence;Allauch;Alleins,"Aix-en-Provence|(43.52830000,5.44973000);Allauch|(43.33573000,5.48201000);Alleins|(43.70387000,5.16203000)"
+France,FR,Puy-de-Dôme,,Paris,,,,,,
+France,FR,Pyrénées-Atlantiques,,Paris,,,,,,
+France,FR,Pyrénées-Orientales,,Paris,,,,,,
+France,FR,Rhône,,Paris,,,,,,
+France,FR,Saint Pierre and Miquelon,,Paris,,,,,,
+France,FR,Saint-Barthélemy,,Paris,,,,,,
+France,FR,Saint-Martin,,Paris,,,,,,
+France,FR,Saône-et-Loire,,Paris,,,,,,
+France,FR,Sarthe,,Paris,,,,,,
+France,FR,Savoie,,Paris,,,,,,
+France,FR,Seine-et-Marne,,Paris,,,,,,
+France,FR,Seine-Maritime,,Paris,,,,,,
+France,FR,Seine-Saint-Denis,,Paris,,,,,,
+France,FR,Somme,,Paris,,,,,,
+France,FR,Tarn,,Paris,,,,,,
+France,FR,Tarn-et-Garonne,,Paris,,,,,,
+France,FR,Territoire de Belfort,,Paris,,,,,,
+France,FR,Val-d'Oise,,Paris,,,,,,
+France,FR,Val-de-Marne,,Paris,,,,,,
+France,FR,Var,,Paris,,,,,,
+France,FR,Vaucluse,,Paris,,,,,,
+France,FR,Vendée,,Paris,,,,,,
+France,FR,Vienne,,Paris,,,,,,
+France,FR,Vosges,,Paris,,,,,,
+France,FR,Wallis and Futuna,,Paris,,,,,,
+France,FR,Yonne,,Paris,,,,,,
+France,FR,Yvelines,,Paris,,,,,,
+French Polynesia,PF,Austral Islands,Raivavae,Papeete,,,-23.86946330,-147.73244720,Raivavae;Rapa;Rimatara,"Raivavae|(-23.86946330,-147.73244720);Rapa|(-27.60822390,-144.38427770);Rimatara|(-22.64382540,-152.83120520)"
+French Polynesia,PF,Leeward Islands,Bora-Bora,Papeete,,,-16.39169250,-151.93003350,Bora-Bora;Huahine;Maupiti,"Bora-Bora|(-16.39169250,-151.93003350);Huahine|(-16.75212330,-151.07889500);Maupiti|(-16.31438490,-154.79908630)"
+French Polynesia,PF,Marquesas Islands,Fatu-Hiva,Papeete,,,-10.48604740,-138.69188860,Fatu-Hiva;Hiva-Oa;Nuku-Hiva,"Fatu-Hiva|(-10.48604740,-138.69188860);Hiva-Oa|(-9.72631690,-139.30998880);Nuku-Hiva|(-8.41030010,-141.02327110)"
+French Polynesia,PF,Tuamotu-Gambier,Anaa,Papeete,,,-17.41194390,-145.66284990,Anaa;Arutua;Fakarava,"Anaa|(-17.41194390,-145.66284990);Arutua|(-15.31203340,-146.91262850);Fakarava|(-16.29845160,-145.92218890)"
+French Polynesia,PF,Windward Islands,Arue,Papeete,,,-17.27738940,-149.87199430,Arue;Faaa;Hitiaa O Te Ra,"Arue|(-17.27738940,-149.87199430);Faaa|(-17.58391940,-149.64609260);Hitiaa O Te Ra|(-17.59142580,-149.47324810)"
+Gabon,GA,Estuaire,Cocobeach,Libreville,EMEA,17,1.00019000,9.58229000,Cocobeach;Libreville;Ntoum,"Cocobeach|(1.00019000,9.58229000);Libreville|(0.39241000,9.45356000);Ntoum|(0.39051000,9.76096000)"
+Gabon,GA,Haut-Ogooué,Franceville,Libreville,EMEA,17,-1.63333000,13.58357000,Franceville;Lékoni;Moanda,"Franceville|(-1.63333000,13.58357000);Lékoni|(-1.58431000,14.25905000);Moanda|(-1.56652000,13.19870000)"
+Gabon,GA,Moyen-Ogooué,Lambaréné,Libreville,EMEA,17,-0.70010000,10.24055000,Lambaréné;Ndjolé,"Lambaréné|(-0.70010000,10.24055000);Ndjolé|(-0.17827000,10.76488000)"
+Gabon,GA,Ngounié,Fougamou,Libreville,EMEA,17,-1.21544000,10.58378000,Fougamou;Mbigou;Mimongo,"Fougamou|(-1.21544000,10.58378000);Mbigou|(-1.90046000,11.90600000);Mimongo|(-1.61952000,11.60675000)"
+Gabon,GA,Nyanga,Mayumba,Libreville,EMEA,17,-3.43198000,10.65540000,Mayumba;Tchibanga,"Mayumba|(-3.43198000,10.65540000);Tchibanga|(-2.93323000,10.98178000)"
+Gabon,GA,Ogooué-Ivindo,Booué,Libreville,EMEA,17,-0.09207000,11.93846000,Booué;Makokou;Zadie,"Booué|(-0.09207000,11.93846000);Makokou|(0.57381000,12.86419000);Zadie|(0.92582000,13.90813000)"
+Gabon,GA,Ogooué-Lolo,Koulamoutou,Libreville,EMEA,17,-1.13667000,12.46399000,Koulamoutou;Lastoursville,"Koulamoutou|(-1.13667000,12.46399000);Lastoursville|(-0.81742000,12.70818000)"
+Gabon,GA,Ogooué-Maritime,Gamba,Libreville,EMEA,17,-2.65000000,10.00000000,Gamba;Omboué;Port-Gentil,"Gamba|(-2.65000000,10.00000000);Omboué|(-1.57464000,9.26184000);Port-Gentil|(-0.71933000,8.78151000)"
+Gabon,GA,Woleu-Ntem,Bitam,Libreville,EMEA,17,2.07597000,11.50065000,Bitam;Mitzic;Oyem,"Bitam|(2.07597000,11.50065000);Mitzic|(0.78205000,11.54904000);Oyem|(1.59950000,11.57933000)"
+Georgia,GE,Abkhazia,Bich’vinta,Tbilisi,,,43.16197000,40.34102000,Bich’vinta;Dranda;Gagra,"Bich’vinta|(43.16197000,40.34102000);Dranda|(42.87167000,41.15333000);Gagra|(43.27858000,40.27124000)"
+Georgia,GE,Adjara,Akhaldaba,Tbilisi,,,41.65395000,42.15163000,Akhaldaba;Batumi;Chakvi,"Akhaldaba|(41.65395000,42.15163000);Batumi|(41.64228000,41.63392000);Chakvi|(41.72528000,41.73278000)"
+Georgia,GE,Guria,Lanchkhuti,Tbilisi,,,42.09027000,42.03239000,Lanchkhuti;Naruja;Ozurgeti,"Lanchkhuti|(42.09027000,42.03239000);Naruja|(41.90694000,41.95417000);Ozurgeti|(41.92442000,42.00682000)"
+Georgia,GE,Imereti,Baghdatis Munitsip’alit’et’i,Tbilisi,,,42.00000000,42.90000000,Baghdatis Munitsip’alit’et’i;Chiat’ura;K’alak’i Chiat’ura,"Baghdatis Munitsip’alit’et’i|(42.00000000,42.90000000);Chiat’ura|(42.29806000,43.29889000);K’alak’i Chiat’ura|(42.28333000,43.25000000)"
+Georgia,GE,Kakheti,Akhmeta,Tbilisi,,,42.03111000,45.20750000,Akhmeta;Gurjaani;Lagodekhi,"Akhmeta|(42.03111000,45.20750000);Gurjaani|(41.74292000,45.80111000);Lagodekhi|(41.82681000,46.27667000)"
+Georgia,GE,Kvemo Kartli,Bolnisi,Tbilisi,,,41.44794000,44.53838000,Bolnisi;Bolnisis Munitsip’alit’et’i;Didi Lilo,"Bolnisi|(41.44794000,44.53838000);Bolnisis Munitsip’alit’et’i|(41.36667000,44.51667000);Didi Lilo|(41.73611000,44.96472000)"
+Georgia,GE,Mtskheta-Mtianeti,Akhalgori,Tbilisi,,,42.12597000,44.48333000,Akhalgori;Dzegvi;Gudauri,"Akhalgori|(42.12597000,44.48333000);Dzegvi|(41.84569000,44.60097000);Gudauri|(42.47797000,44.47616000)"
+Georgia,GE,Racha-Lechkhumi and Kvemo Svaneti,Ambrolauri,Tbilisi,,,42.52111000,43.16222000,Ambrolauri;Ambrolauris Munitsip’alit’et’i;Lent’ekhi,"Ambrolauri|(42.52111000,43.16222000);Ambrolauris Munitsip’alit’et’i|(42.56667000,43.10000000);Lent’ekhi|(42.78893000,42.72226000)"
+Georgia,GE,Samegrelo-Zemo Svaneti,Abasha,Tbilisi,,,42.20492840,42.20333210,Abasha;Jvari;Khobi,"Abasha|(42.20492840,42.20333210);Jvari|(42.71693000,42.05200000);Khobi|(42.31558000,41.89871000)"
+Georgia,GE,Samtskhe-Javakheti,Adigeni,Tbilisi,,,41.68191000,42.69867000,Adigeni;Adigeni Municipality;Akhaldaba,"Adigeni|(41.68191000,42.69867000);Adigeni Municipality|(41.71667000,42.73333000);Akhaldaba|(41.92945000,43.48762000)"
+Georgia,GE,Shida Kartli,Agara,Tbilisi,,,42.03761000,43.82382000,Agara;Gori;Goris Munitsip’alit’et’i,"Agara|(42.03761000,43.82382000);Gori|(41.98422000,44.11578000);Goris Munitsip’alit’et’i|(42.06667000,44.11667000)"
+Georgia,GE,Tbilisi,Tbilisi,Tbilisi,,,41.69411000,44.83368000,Tbilisi,"Tbilisi|(41.69411000,44.83368000)"
+Germany,DE,Baden-Württemberg,Aach,Berlin,,,47.84240000,8.85384000,Aach;Aalen;Abstatt,"Aach|(47.84240000,8.85384000);Aalen|(48.83777000,10.09330000);Abstatt|(49.06820000,9.29070000)"
+Germany,DE,Bavaria,Abenberg,Berlin,,,49.24282000,10.96401000,Abenberg;Abensberg;Absberg,"Abenberg|(49.24282000,10.96401000);Abensberg|(48.81684000,11.84980000);Absberg|(49.14438000,10.88101000)"
+Germany,DE,Berlin,Berlin,Berlin,,,52.52437000,13.41053000,Adlershof;Alt-Hohenschönhausen;Alt-Treptow,"Adlershof|(52.43548000,13.54825000);Alt-Hohenschönhausen|(52.54608000,13.50130000);Alt-Treptow|(52.48863000,13.45860000)"
+Germany,DE,Brandenburg,Alt Tucheband,Berlin,,,52.53732000,14.51225000,Alt Tucheband;Altdöbern;Altlandsberg,"Alt Tucheband|(52.53732000,14.51225000);Altdöbern|(51.65000000,14.03333000);Altlandsberg|(52.56503000,13.72815000)"
+Germany,DE,Bremen,Bremen,Berlin,,,53.07516000,8.80777000,Bremen;Bremerhaven;Burglesum,"Bremen|(53.07516000,8.80777000);Bremerhaven|(53.55021000,8.57673000);Burglesum|(53.16532000,8.68873000)"
+Germany,DE,Hamburg,Hamburg,Berlin,,,53.57532000,10.01534000,Alsterdorf;Altona;Barmbek-Nord,"Alsterdorf|(53.61083000,10.01306000);Altona|(53.55000000,9.93333000);Barmbek-Nord|(53.60520000,10.03988000)"
+Germany,DE,Hessen,Albshausen,Berlin,,,50.54431000,8.43784000,Albshausen;Alheim;Allendorf,"Albshausen|(50.54431000,8.43784000);Alheim|(51.03333000,9.66667000);Allendorf|(51.02995000,8.67232000)"
+Germany,DE,Lower Saxony,Abbesbüttel,Berlin,,,52.35233000,10.55649000,Abbesbüttel;Achim;Adelebsen,"Abbesbüttel|(52.35233000,10.55649000);Achim|(53.01416000,9.02630000);Adelebsen|(51.58272000,9.75461000)"
+Germany,DE,Mecklenburg-Vorpommern,Admannshagen-Bargeshagen,Berlin,,,54.13038000,11.99915000,Admannshagen-Bargeshagen;Ahlbeck;Alt Meteln,"Admannshagen-Bargeshagen|(54.13038000,11.99915000);Ahlbeck|(53.66972000,14.18622000);Alt Meteln|(53.74709000,11.34056000)"
+Germany,DE,North Rhine-Westphalia,Aachen,Berlin,,,50.77664000,6.08342000,Aachen;Ahaus;Ahlen,"Aachen|(50.77664000,6.08342000);Ahaus|(52.07936000,7.01344000);Ahlen|(51.76338000,7.88870000)"
+Germany,DE,Rhineland-Palatinate,Aach,Berlin,,,49.78333000,6.60000000,Aach;Adenau;Ahrbrück,"Aach|(49.78333000,6.60000000);Adenau|(50.38238000,6.93291000);Ahrbrück|(50.48225000,6.98804000)"
+Germany,DE,Saarland,Beckingen,Berlin,,,49.40000000,6.70000000,Beckingen;Bexbach;Blieskastel,"Beckingen|(49.40000000,6.70000000);Bexbach|(49.34615000,7.25527000);Blieskastel|(49.23724000,7.25617000)"
+Germany,DE,Saxony,Adorf,Berlin,,,50.32011000,12.25986000,Adorf;Albertstadt;Altenberg,"Adorf|(50.32011000,12.25986000);Albertstadt|(51.08333000,13.76667000);Altenberg|(50.76556000,13.75334000)"
+Germany,DE,Saxony-Anhalt,Abtsdorf,Berlin,,,51.88984000,12.72526000,Abtsdorf;Ahlsdorf;Aken,"Abtsdorf|(51.88984000,12.72526000);Ahlsdorf|(51.54543000,11.46655000);Aken|(51.85274000,12.04461000)"
+Germany,DE,Schleswig-Holstein,Achtrup,Berlin,,,54.79053000,9.02848000,Achtrup;Ahrensbök;Ahrensburg,"Achtrup|(54.79053000,9.02848000);Ahrensbök|(54.00862000,10.57434000);Ahrensburg|(53.67515000,10.22593000)"
+Germany,DE,Thuringia,Altenburg,Berlin,,,50.98763000,12.43684000,Altenburg;Altenfeld;Altengottern,"Altenburg|(50.98763000,12.43684000);Altenfeld|(50.56667000,10.96667000);Altengottern|(51.16395000,10.58093000)"
+Ghana,GH,Ahafo,Asunafo North,Accra,EMEA,11,6.81968910,-2.80770500,Asunafo North;Asunafo South;Asutifi North,"Asunafo North|(6.81968910,-2.80770500);Asunafo South|(6.68210000,-2.43997530);Asutifi North|(6.94774860,-2.76757160)"
+Ghana,GH,Ashanti,Agogo,Accra,EMEA,11,6.80004000,-1.08193000,Agogo;Bekwai;Ejura,"Agogo|(6.80004000,-1.08193000);Bekwai|(6.45195000,-1.57866000);Ejura|(7.38558000,-1.35617000)"
+Ghana,GH,Bono,Banda,Accra,EMEA,11,8.14956710,-2.36639500,Banda;Berekum East;Berekum West,"Banda|(8.14956710,-2.36639500);Berekum East|(7.43846190,-2.60295780);Berekum West|(7.43934160,-2.65497050)"
+Ghana,GH,Bono East,Atebubu-Amantin,Accra,EMEA,11,7.70237000,-1.21979430,Atebubu-Amantin;Kintampo North;Kintampo South,"Atebubu-Amantin|(7.70237000,-1.21979430);Kintampo North|(8.39635790,-1.82000070);Kintampo South|(7.98971320,-2.00711150)"
+Ghana,GH,Central,Apam,Accra,EMEA,11,5.28483000,-0.73711000,Apam;Cape Coast;Dunkwa,"Apam|(5.28483000,-0.73711000);Cape Coast|(5.10535000,-1.24660000);Dunkwa|(5.95996000,-1.77792000)"
+Ghana,GH,Eastern,Aburi,Accra,EMEA,11,5.84802000,-0.17449000,Aburi;Akim Oda;Akim Swedru,"Aburi|(5.84802000,-0.17449000);Akim Oda|(5.92665000,-0.98577000);Akim Swedru|(5.89380000,-1.01636000)"
+Ghana,GH,Greater Accra,Accra,Accra,EMEA,11,5.55602000,-0.19690000,Accra;Atsiaman;Dome,"Accra|(5.55602000,-0.19690000);Atsiaman|(5.69775000,-0.32824000);Dome|(5.65003000,-0.23610000)"
+Ghana,GH,North East,Bunkpurugu-Nyakpanduri,Accra,EMEA,11,10.46609170,-0.22711950,Bunkpurugu-Nyakpanduri;Chereponi;East Mamprusi,"Bunkpurugu-Nyakpanduri|(10.46609170,-0.22711950);Chereponi|(10.13827720,0.28242580);East Mamprusi|(10.42931860,-0.53078850)"
+Ghana,GH,Northern,Kpandae,Accra,EMEA,11,8.46885000,-0.01127000,Kpandae;Salaga;Savelugu,"Kpandae|(8.46885000,-0.01127000);Salaga|(8.55083000,-0.51875000);Savelugu|(9.62441000,-0.82530000)"
+Ghana,GH,Oti,Biakoye,Accra,EMEA,11,7.11698690,0.32324300,Biakoye;Jasikan;Kadjebi,"Biakoye|(7.11698690,0.32324300);Jasikan|(7.40940880,0.44301500);Kadjebi|(7.52631920,0.46704770)"
+Ghana,GH,Savannah,Bole,Accra,EMEA,11,9.02996640,-2.50694300,Bole;Central Gonja;East Gonja,"Bole|(9.02996640,-2.50694300);Central Gonja|(8.92784320,-1.95369720);East Gonja|(8.72568400,-1.07135790)"
+Ghana,GH,Upper East,Bawku,Accra,EMEA,11,11.06160000,-0.24169000,Bawku;Bolgatanga;Navrongo,"Bawku|(11.06160000,-0.24169000);Bolgatanga|(10.78556000,-0.85139000);Navrongo|(10.89557000,-1.09210000)"
+Ghana,GH,Upper West,Wa,Accra,EMEA,11,10.06069000,-2.50192000,Wa,"Wa|(10.06069000,-2.50192000)"
+Ghana,GH,Volta,Aflao,Accra,EMEA,11,6.11982000,1.19012000,Aflao;Anloga;Ho,"Aflao|(6.11982000,1.19012000);Anloga|(5.79473000,0.89728000);Ho|(6.60084000,0.47130000)"
+Ghana,GH,Western,Aboso,Accra,EMEA,11,5.36073000,-1.94856000,Aboso;Axim;Bibiani,"Aboso|(5.36073000,-1.94856000);Axim|(4.86641000,-2.24181000);Bibiani|(6.46346000,-2.31938000)"
+Ghana,GH,Western North,Aowin,Accra,EMEA,11,5.82143850,-2.82360430,Aowin;Bia East;Bia West,"Aowin|(5.82143850,-2.82360430);Bia East|(6.81614450,-3.00383950);Bia West|(6.56894170,-3.06628880)"
+Greece,GR,Achaea,,Athens,,,,,,
+Greece,GR,Aetolia-Acarnania,,Athens,,,,,,
+Greece,GR,Arcadia,,Athens,,,,,,
+Greece,GR,Argolis,,Athens,,,,,,
+Greece,GR,Attica,Acharnés,Athens,,,38.08333000,23.73333000,Acharnés;Aegina;Afidnés,"Acharnés|(38.08333000,23.73333000);Aegina|(37.74667000,23.42750000);Afidnés|(38.20332000,23.83982000)"
+Greece,GR,Boeotia,,Athens,,,,,,
+Greece,GR,Central Greece,Afrátion,Athens,,,38.45212000,23.68775000,Afrátion;Agía Triáda;Ágios Geórgios,"Afrátion|(38.45212000,23.68775000);Agía Triáda|(38.35505000,22.90881000);Ágios Geórgios|(38.39343000,22.93189000)"
+Greece,GR,Central Macedonia,Ádendro,Athens,,,40.67131000,22.60466000,Ádendro;Áfytos;Agía Paraskeví,"Ádendro|(40.67131000,22.60466000);Áfytos|(40.09915000,23.43670000);Agía Paraskeví|(40.48150000,23.04863000)"
+Greece,GR,Chania,,Athens,,,,,,
+Greece,GR,Corfu,Farkadóna,Athens,,,39.60000000,22.06667000,Farkadóna;Fíki;Gómfoi,"Farkadóna|(39.60000000,22.06667000);Fíki|(39.51602000,21.65556000);Gómfoi|(39.46413000,21.69342000)"
+Greece,GR,Corinthia,,Athens,,,,,,
+Greece,GR,Crete,Agía Foteiní,Athens,,,35.25459000,24.63495000,Agía Foteiní;Agía Galíni;Agía Marína,"Agía Foteiní|(35.25459000,24.63495000);Agía Galíni|(35.09707000,24.68818000);Agía Marína|(35.51778000,23.92675000)"
+Greece,GR,Drama,,Athens,,,,,,
+Greece,GR,East Attica,Ágios Athanásios,Athens,,,41.07463000,24.24545000,Ágios Athanásios;Agios Efstratios;Alexandroupoli,"Ágios Athanásios|(41.07463000,24.24545000);Agios Efstratios|(39.53910500,24.98451130);Alexandroupoli|(40.84995000,25.87644000)"
+Greece,GR,East Macedonia and Thrace,Alexandroupolis,Athens,,,40.84916600,25.85471070,Alexandroupolis;Arriana;Didymoteicho,"Alexandroupolis|(40.84916600,25.85471070);Arriana|(41.08210780,25.69035930);Didymoteicho|(41.34985800,26.48682660)"
+Greece,GR,Epirus,Agía Kyriakí,Athens,,,39.52264000,20.88358000,Agía Kyriakí;Anatolí;Anéza,"Agía Kyriakí|(39.52264000,20.88358000);Anatolí|(39.63531000,20.86578000);Anéza|(39.08658000,20.92300000)"
+Greece,GR,Euboea,,Athens,,,,,,
+Greece,GR,Grevena,,Athens,,,,,,
+Greece,GR,Imathia ,,Athens,,,,,,
+Greece,GR,Ioannina,,Athens,,,,,,
+Greece,GR,Ionian Islands,Acharávi,Athens,,,39.79360000,19.81736000,Acharávi;Agios Georgis;Ágios Matthaíos,"Acharávi|(39.79360000,19.81736000);Agios Georgis|(39.72363000,19.69969000);Ágios Matthaíos|(39.49506000,19.87336000)"
+Greece,GR,Karditsa,,Athens,,,,,,
+Greece,GR,Kastoria,,Athens,,,,,,
+Greece,GR,Kefalonia,Agía Triáda,Athens,,,39.46361000,21.89848000,Agía Triáda;Agnanteró;Anávra,"Agía Triáda|(39.46361000,21.89848000);Agnanteró|(39.48586000,21.84789000);Anávra|(39.18996000,22.09308000)"
+Greece,GR,Kilkis,,Athens,,,,,,
+Greece,GR,Kozani,,Athens,,,,,,
+Greece,GR,Laconia,,Athens,,,,,,
+Greece,GR,Larissa,,Athens,,,,,,
+Greece,GR,Lefkada,Agriá,Athens,,,39.34078000,23.01258000,Agriá;Álli Meriá;Almyrós,"Agriá|(39.34078000,23.01258000);Álli Meriá|(39.37039000,22.98350000);Almyrós|(39.18222000,22.75944000)"
+Greece,GR,Pella,,Athens,,,,,,
+Greece,GR,Peloponnese,Ágioi Theódoroi,Athens,,,37.92736000,23.14221000,Ágioi Theódoroi;Ágios Andréas;Arfará,"Ágioi Theódoroi|(37.92736000,23.14221000);Ágios Andréas|(37.34519000,22.76466000);Arfará|(37.15619000,22.04485000)"
+Greece,GR,Phthiotis,,Athens,,,,,,
+Greece,GR,Preveza,,Athens,,,,,,
+Greece,GR,Serres,,Athens,,,,,,
+Greece,GR,South Aegean,Adámas,Athens,,,36.72506000,24.44685000,Adámas;Afántou;Amorgós,"Adámas|(36.72506000,24.44685000);Afántou|(36.29354000,28.16225000);Amorgós|(36.83175000,25.89821000)"
+Greece,GR,Thessaloniki,,Athens,,,,,,
+Greece,GR,West Greece,Agrínio,Athens,,,38.62139000,21.40778000,Agrínio;Aígio;Aitolikó,"Agrínio|(38.62139000,21.40778000);Aígio|(38.24861000,22.08194000);Aitolikó|(38.43704000,21.35358000)"
+Greece,GR,West Macedonia,Aianí,Athens,,,40.16381000,21.81945000,Aianí;Akriní;Ammochóri,"Aianí|(40.16381000,21.81945000);Akriní|(40.43492000,21.90609000);Ammochóri|(40.78203000,21.48458000)"
+Greenland,GL,Avannaata,Ilulissat,Nuuk,,,69.22794880,-51.12805390,Ilulissat;Qaanaaq;Upernavik,"Ilulissat|(69.22794880,-51.12805390);Qaanaaq|(77.46740090,-69.24837110);Upernavik|(72.78686030,-56.16236710)"
+Greenland,GL,Kujalleq,Nanortalik,Nuuk,,,60.14308250,-45.25629050,Nanortalik;Narsaq;Qaqortoq,"Nanortalik|(60.14308250,-45.25629050);Narsaq|(60.91140780,-46.06857080);Qaqortoq|(60.71959600,-46.05481630)"
+Greenland,GL,Qeqertalik,Aasiaat,Nuuk,,,68.70762800,-52.89951360,Aasiaat;Kangaatsiaq;Qasigiannguit,"Aasiaat|(68.70762800,-52.89951360);Kangaatsiaq|(68.30818450,-53.47685330);Qasigiannguit|(68.81986320,-51.20916370)"
+Greenland,GL,Qeqqata,Maniitsoq,Nuuk,,,65.40657990,-52.94225730,Maniitsoq;Sisimiut,"Maniitsoq|(65.40657990,-52.94225730);Sisimiut|(66.93945740,-53.74567660)"
+Greenland,GL,Sermersooq,Ammassalik,Nuuk,,,65.61452670,-37.65014660,Ammassalik;Ittoqqortoormiit;Ivittuut,"Ammassalik|(65.61452670,-37.65014660);Ittoqqortoormiit|(70.48634210,-21.97986600);Ivittuut|(61.20651840,-48.18198510)"
+Grenada,GD,Carriacou,Hillsborough,St. George's,,,12.48292000,-61.45597000,Hillsborough,"Hillsborough|(12.48292000,-61.45597000)"
+Grenada,GD,Saint Andrew,Grenville,St. George's,,,12.12278000,-61.62498000,Grenville,"Grenville|(12.12278000,-61.62498000)"
+Grenada,GD,Saint David,Saint David’s,St. George's,,,12.04903000,-61.66875000,Saint David’s,"Saint David’s|(12.04903000,-61.66875000)"
+Grenada,GD,Saint George,Saint George's,St. George's,,,12.05288000,-61.75226000,Saint George's,"Saint George's|(12.05288000,-61.75226000)"
+Grenada,GD,Saint John,Gouyave,St. George's,,,12.16462000,-61.72965000,Gouyave,"Gouyave|(12.16462000,-61.72965000)"
+Grenada,GD,Saint Mark,Victoria,St. George's,,,12.19021000,-61.70677000,Victoria,"Victoria|(12.19021000,-61.70677000)"
+Grenada,GD,Saint Patrick,Sauteurs,St. George's,,,12.21833000,-61.63917000,Sauteurs,"Sauteurs|(12.21833000,-61.63917000)"
+Guadeloupe,GP,Basse-Terre,Basse-Terre,Basse-Terre,EMEA,29,15.99916310,-61.74998100,Baie-Mahault;Baillif;Basse-Terre,"Baie-Mahault|(16.24976070,-61.67750720);Baillif|(16.04973310,-61.75705910);Basse-Terre|(15.99916310,-61.74998100)"
+Guadeloupe,GP,Pointe-à-Pitre,Pointe-à-Pitre,Basse-Terre,EMEA,29,16.23313040,-61.56234850,Anse-Bertrand;Capesterre-de-Marie-Galante;Grand-Bourg,"Anse-Bertrand|(16.46681810,-61.55217680);Capesterre-de-Marie-Galante|(15.91763990,-61.27077860);Grand-Bourg|(15.90853800,-61.33406180)"
+Guam,GU,Agana Heights,,Hagatna,,,,,,
+Guam,GU,Asan-Maina,,Hagatna,,,,,,
+Guam,GU,Barrigada,,Hagatna,,,,,,
+Guam,GU,Chalan Pago-Ordot,,Hagatna,,,,,,
+Guam,GU,Dededo,,Hagatna,,,,,,
+Guam,GU,Hågat,,Hagatna,,,,,,
+Guam,GU,Hagåtña,,Hagatna,,,,,,
+Guam,GU,Inarajan (Inalåhan),,Hagatna,,,,,,
+Guam,GU,Mangilao,,Hagatna,,,,,,
+Guam,GU,Merizo (Malesso),,Hagatna,,,,,,
+Guam,GU,Mongmong-Toto-Maite,,Hagatna,,,,,,
+Guam,GU,Piti,,Hagatna,,,,,,
+Guam,GU,Santa Rita (Sånta Rita-Sumai),,Hagatna,,,,,,
+Guam,GU,Sinajana,,Hagatna,,,,,,
+Guam,GU,Talofofo (Talo'fo'fo),,Hagatna,,,,,,
+Guam,GU,Tamuning,,Hagatna,,,,,,
+Guam,GU,Umatac (Humåtak),,Hagatna,,,,,,
+Guam,GU,Yigo,,Hagatna,,,,,,
+Guam,GU,Yona,,Hagatna,,,,,,
+Guatemala,GT,Alta Verapaz ,Cahabón,Guatemala City,EMEA,13,15.56667000,-89.81667000,Cahabón;Chahal Guatemala;Chisec,"Cahabón|(15.56667000,-89.81667000);Chahal Guatemala|(15.79122000,-89.60518000);Chisec|(15.81667000,-90.28333000)"
+Guatemala,GT,Baja Verapaz ,Cubulco,Guatemala City,EMEA,13,15.10452000,-90.62871000,Cubulco;El Chol;Granados,"Cubulco|(15.10452000,-90.62871000);El Chol|(14.96055000,-90.48799000);Granados|(14.91649000,-90.52292000)"
+Guatemala,GT,Chimaltenango ,Chimaltenango,Guatemala City,EMEA,13,14.66111000,-90.81944000,Acatenango;Chimaltenango;Comalapa,"Acatenango|(14.55451000,-90.94368000);Chimaltenango|(14.66111000,-90.81944000);Comalapa|(14.74086000,-90.88761000)"
+Guatemala,GT,Chiquimula ,Chiquimula,Guatemala City,EMEA,13,14.80000000,-89.54583000,Camotán;Chiquimula;Concepción Las Minas,"Camotán|(14.82017000,-89.37224000);Chiquimula|(14.80000000,-89.54583000);Concepción Las Minas|(14.52173000,-89.45717000)"
+Guatemala,GT,El Progreso ,El Jícaro,Guatemala City,EMEA,13,14.91667000,-89.90000000,El Jícaro;Guastatoya;Morazán,"El Jícaro|(14.91667000,-89.90000000);Guastatoya|(14.85417000,-90.06944000);Morazán|(14.93278000,-90.14306000)"
+Guatemala,GT,Escuintla ,Escuintla,Guatemala City,EMEA,13,14.30500000,-90.78500000,Escuintla;Guanagazapa;Iztapa,"Escuintla|(14.30500000,-90.78500000);Guanagazapa|(14.22528000,-90.64333000);Iztapa|(13.93333000,-90.70750000)"
+Guatemala,GT,Guatemala ,Amatitlán,Guatemala City,EMEA,13,14.47740000,-90.63489000,Amatitlán;Chinautla;Chuarrancho,"Amatitlán|(14.47740000,-90.63489000);Chinautla|(14.70289000,-90.49983000);Chuarrancho|(14.81794000,-90.51568000)"
+Guatemala,GT,Huehuetenango ,Huehuetenango,Guatemala City,EMEA,13,15.31918000,-91.47241000,Aguacatán;Barillas;Chiantla,"Aguacatán|(15.34222000,-91.31141000);Barillas|(15.80361000,-91.31583000);Chiantla|(15.35484000,-91.45807000)"
+Guatemala,GT,Izabal ,El Estor,Guatemala City,EMEA,13,15.53333000,-89.35000000,El Estor;Lívingston;Los Amates,"El Estor|(15.53333000,-89.35000000);Lívingston|(15.82826000,-88.75039000);Los Amates|(15.25645000,-89.09723000)"
+Guatemala,GT,Jalapa ,Jalapa,Guatemala City,EMEA,13,14.63472000,-89.98889000,Jalapa;Mataquescuintla;Monjas,"Jalapa|(14.63472000,-89.98889000);Mataquescuintla|(14.52917000,-90.18417000);Monjas|(14.50000000,-89.86667000)"
+Guatemala,GT,Jutiapa ,Jutiapa,Guatemala City,EMEA,13,14.29167000,-89.89583000,Agua Blanca;Asunción Mita;Atescatempa,"Agua Blanca|(14.50000000,-89.65000000);Asunción Mita|(14.33083000,-89.71083000);Atescatempa|(14.17444000,-89.74250000)"
+Guatemala,GT,Petén ,Dolores,Guatemala City,EMEA,13,16.51178000,-89.41704000,Dolores;Flores;La Libertad,"Dolores|(16.51178000,-89.41704000);Flores|(16.92258000,-89.89941000);La Libertad|(16.78850000,-90.11698000)"
+Guatemala,GT,Quetzaltenango ,Quetzaltenango,Guatemala City,EMEA,13,14.83472000,-91.51806000,Almolonga;Cabricán;Cajolá,"Almolonga|(14.81591000,-91.49464000);Cabricán|(15.07485000,-91.64800000);Cajolá|(14.92205000,-91.61478000)"
+Guatemala,GT,Quiché ,Canillá,Guatemala City,EMEA,13,15.16549000,-90.85256000,Canillá;Chajul;Chicamán,"Canillá|(15.16549000,-90.85256000);Chajul|(15.48523000,-91.03520000);Chicamán|(15.34786000,-90.79968000)"
+Guatemala,GT,Retalhuleu ,Retalhuleu,Guatemala City,EMEA,13,14.53611000,-91.67778000,Champerico;El Asintal;Municipio de San Felipe,"Champerico|(14.29337000,-91.91214000);El Asintal|(14.59626000,-91.72744000);Municipio de San Felipe|(14.63009000,-91.60261000)"
+Guatemala,GT,Sacatepéquez ,Alotenango,Guatemala City,EMEA,13,14.48028000,-90.80750000,Alotenango;Antigua Guatemala;Ciudad Vieja,"Alotenango|(14.48028000,-90.80750000);Antigua Guatemala|(14.56111000,-90.73444000);Ciudad Vieja|(14.52396000,-90.76308000)"
+Guatemala,GT,San Marcos ,San Marcos,Guatemala City,EMEA,13,14.96389000,-91.79444000,Catarina;Ciudad Tecún Umán;Comitancillo,"Catarina|(14.85354000,-92.07682000);Ciudad Tecún Umán|(14.67737000,-92.14039000);Comitancillo|(15.08937000,-91.74971000)"
+Guatemala,GT,Santa Rosa ,Barberena,Guatemala City,EMEA,13,14.30739000,-90.36156000,Barberena;Casillas;Chiquimulilla,"Barberena|(14.30739000,-90.36156000);Casillas|(14.42222000,-90.24417000);Chiquimulilla|(14.08380000,-90.38547000)"
+Guatemala,GT,Sololá ,Sololá,Guatemala City,EMEA,13,14.77222000,-91.18333000,Concepción;Municipio de Nahualá;Municipio de Panajachel,"Concepción|(14.78417000,-91.14754000);Municipio de Nahualá|(14.77548000,-91.41616000);Municipio de Panajachel|(14.74676000,-91.14935000)"
+Guatemala,GT,Suchitepéquez ,Chicacao,Guatemala City,EMEA,13,14.54295000,-91.32636000,Chicacao;Cuyotenango;Mazatenango,"Chicacao|(14.54295000,-91.32636000);Cuyotenango|(14.54006000,-91.57179000);Mazatenango|(14.53417000,-91.50333000)"
+Guatemala,GT,Totonicapán ,Totonicapán,Guatemala City,EMEA,13,14.91167000,-91.36111000,Momostenango;Municipio de Momostenango;Municipio de Santa María Chiquimula,"Momostenango|(15.04437000,-91.40864000);Municipio de Momostenango|(15.04726000,-91.40625000);Municipio de Santa María Chiquimula|(15.02886000,-91.32917000)"
+Guatemala,GT,Zacapa,,Guatemala City,EMEA,13,,,,
+Guernsey,GG,Alderney,,St Peter Port,,,,,,
+Guernsey,GG,Castel,,St Peter Port,,,,,,
+Guernsey,GG,Forest,,St Peter Port,,,,,,
+Guernsey,GG,Sark,,St Peter Port,,,,,,
+Guernsey,GG,St Andrew,,St Peter Port,,,,,,
+Guernsey,GG,St Martin,,St Peter Port,,,,,,
+Guernsey,GG,St Peter Port,,St Peter Port,,,,,,
+Guernsey,GG,St Pierre du Bois,,St Peter Port,,,,,,
+Guernsey,GG,St Sampson,,St Peter Port,,,,,,
+Guernsey,GG,St Saviour,,St Peter Port,,,,,,
+Guernsey,GG,Torteval,,St Peter Port,,,,,,
+Guernsey,GG,Vale,,St Peter Port,,,,,,
+Guinea,GN,Beyla,,Conakry,,,,,,
+Guinea,GN,Boffa,,Conakry,,,,,,
+Guinea,GN,Boké,Boké,Conakry,,,10.93217000,-14.29055000,Boffa;Boké;Boke Prefecture,"Boffa|(10.33333000,-14.16667000);Boké|(10.93217000,-14.29055000);Boke Prefecture|(11.08333000,-14.41667000)"
+Guinea,GN,Boké,,Conakry,,,,,,
+Guinea,GN,Conakry,Conakry,Conakry,,,9.53795000,-13.67729000,Camayenne;Conakry,"Camayenne|(9.53500000,-13.68778000);Conakry|(9.53795000,-13.67729000)"
+Guinea,GN,Coyah,,Conakry,,,,,,
+Guinea,GN,Dabola,,Conakry,,,,,,
+Guinea,GN,Dalaba,,Conakry,,,,,,
+Guinea,GN,Dinguiraye,,Conakry,,,,,,
+Guinea,GN,Dubréka,,Conakry,,,,,,
+Guinea,GN,Faranah,,Conakry,,,,,,
+Guinea,GN,Faranah,,Conakry,,,,,,
+Guinea,GN,Forécariah,,Conakry,,,,,,
+Guinea,GN,Fria,,Conakry,,,,,,
+Guinea,GN,Gaoual,,Conakry,,,,,,
+Guinea,GN,Guéckédou,,Conakry,,,,,,
+Guinea,GN,Kankan,,Conakry,,,,,,
+Guinea,GN,Kankan,Kankan,Conakry,,,10.38542000,-9.30568000,Kankan;Kankan Prefecture;Kérouané,"Kankan|(10.38542000,-9.30568000);Kankan Prefecture|(10.27100000,-9.17800000);Kérouané|(9.26667000,-9.01667000)"
+Guinea,GN,Kérouané,,Conakry,,,,,,
+Guinea,GN,Kindia,Kindia,Conakry,,,10.08333000,-12.80000000,Coyah;Dubréka;Forécariah,"Coyah|(9.75000000,-13.41667000);Dubréka|(9.79111000,-13.52333000);Forécariah|(9.43056000,-13.08806000)"
+Guinea,GN,Kindia,,Conakry,,,,,,
+Guinea,GN,Kissidougou,,Conakry,,,,,,
+Guinea,GN,Koubia,,Conakry,,,,,,
+Guinea,GN,Koundara,,Conakry,,,,,,
+Guinea,GN,Kouroussa,,Conakry,,,,,,
+Guinea,GN,Labé,,Conakry,,,,,,
+Guinea,GN,Labé,Labé,Conakry,,,11.31823000,-12.28332000,Koubia;Labé;Labe Prefecture,"Koubia|(11.58333000,-11.83333000);Labé|(11.31823000,-12.28332000);Labe Prefecture|(11.36600000,-12.30000000)"
+Guinea,GN,Lélouma,,Conakry,,,,,,
+Guinea,GN,Lola,,Conakry,,,,,,
+Guinea,GN,Macenta,,Conakry,,,,,,
+Guinea,GN,Mali,,Conakry,,,,,,
+Guinea,GN,Mamou,Mamou,Conakry,,,10.37546000,-12.09148000,Dalaba;Mamou;Mamou Prefecture,"Dalaba|(10.75000000,-12.30000000);Mamou|(10.37546000,-12.09148000);Mamou Prefecture|(10.45900000,-11.81500000)"
+Guinea,GN,Mamou,,Conakry,,,,,,
+Guinea,GN,Mandiana,,Conakry,,,,,,
+Guinea,GN,Nzérékoré,Nzérékoré,Conakry,,,7.75624000,-8.81790000,Beyla;Beyla Prefecture;Gueckedou,"Beyla|(8.69011000,-8.64869000);Beyla Prefecture|(8.91667000,-8.41667000);Gueckedou|(8.56744000,-10.13360000)"
+Guinea,GN,Nzérékoré,,Conakry,,,,,,
+Guinea,GN,Pita,,Conakry,,,,,,
+Guinea,GN,Siguiri,,Conakry,,,,,,
+Guinea,GN,Télimélé,,Conakry,,,,,,
+Guinea,GN,Tougué,,Conakry,,,,,,
+Guinea,GN,Yomou,,Conakry,,,,,,
+Guinea-Bissau,GW,Bafatá,Bafatá,Bissau,,,12.16583000,-14.66167000,Bafatá;Contuboel Sector,"Bafatá|(12.16583000,-14.66167000);Contuboel Sector|(12.55500000,-14.64100000)"
+Guinea-Bissau,GW,Biombo,Quinhámel,Bissau,,,11.88694000,-15.85556000,Quinhámel,"Quinhámel|(11.88694000,-15.85556000)"
+Guinea-Bissau,GW,Bolama,Bolama,Bissau,,,11.57694000,-15.47611000,Bolama;Bubaque,"Bolama|(11.57694000,-15.47611000);Bubaque|(11.28333000,-15.83333000)"
+Guinea-Bissau,GW,Cacheu,Cacheu,Bissau,,,12.27444000,-16.16528000,Cacheu;Canchungo,"Cacheu|(12.27444000,-16.16528000);Canchungo|(12.06722000,-16.03333000)"
+Guinea-Bissau,GW,Gabú,Gabú,Bissau,,,12.28000000,-14.22222000,Gabú,"Gabú|(12.28000000,-14.22222000)"
+Guinea-Bissau,GW,Leste,,Bissau,,,,,,
+Guinea-Bissau,GW,Norte,,Bissau,,,,,,
+Guinea-Bissau,GW,Oio,Bissorã,Bissau,,,12.22306000,-15.44750000,Bissorã;Farim;Mansôa,"Bissorã|(12.22306000,-15.44750000);Farim|(12.48389000,-15.22167000);Mansôa|(12.07333000,-15.31889000)"
+Guinea-Bissau,GW,Quinara,Buba,Bissau,,,11.58889000,-14.99583000,Buba,"Buba|(11.58889000,-14.99583000)"
+Guinea-Bissau,GW,Sul,,Bissau,,,,,,
+Guinea-Bissau,GW,Tombali,Catió,Bissau,,,11.28250000,-15.25472000,Catió;Quebo,"Catió|(11.28250000,-15.25472000);Quebo|(11.33333000,-14.93333000)"
+Guyana,GY,Barima-Waini,Mabaruma,Georgetown,EMEA,5,8.20000000,-59.78333000,Mabaruma,"Mabaruma|(8.20000000,-59.78333000)"
+Guyana,GY,Cuyuni-Mazaruni,Bartica,Georgetown,EMEA,5,6.40799000,-58.62192000,Bartica,"Bartica|(6.40799000,-58.62192000)"
+Guyana,GY,Demerara-Mahaica,Georgetown,Georgetown,EMEA,5,6.80448000,-58.15527000,Georgetown;Mahaica Village,"Georgetown|(6.80448000,-58.15527000);Mahaica Village|(6.68405000,-57.92181000)"
+Guyana,GY,East Berbice-Corentyne,New Amsterdam,Georgetown,EMEA,5,6.24793000,-57.51710000,New Amsterdam;Skeldon,"New Amsterdam|(6.24793000,-57.51710000);Skeldon|(5.88333000,-57.13333000)"
+Guyana,GY,Essequibo Islands-West Demerara,Parika,Georgetown,EMEA,5,6.83712000,-58.42941000,Parika;Vreed-en-Hoop,"Parika|(6.83712000,-58.42941000);Vreed-en-Hoop|(6.80927000,-58.19798000)"
+Guyana,GY,Mahaica-Berbice,Mahaicony Village,Georgetown,EMEA,5,6.57633000,-57.80486000,Mahaicony Village;Rosignol,"Mahaicony Village|(6.57633000,-57.80486000);Rosignol|(6.27095000,-57.53697000)"
+Guyana,GY,Pomeroon-Supenaam,Anna Regina,Georgetown,EMEA,5,7.26439000,-58.50769000,Anna Regina,"Anna Regina|(7.26439000,-58.50769000)"
+Guyana,GY,Potaro-Siparuni,Mahdia,Georgetown,EMEA,5,5.26667000,-59.15000000,Mahdia,"Mahdia|(5.26667000,-59.15000000)"
+Guyana,GY,Upper Demerara-Berbice,Linden,Georgetown,EMEA,5,6.00809000,-58.30714000,Linden,"Linden|(6.00809000,-58.30714000)"
+Guyana,GY,Upper Takutu-Upper Essequibo,Lethem,Georgetown,EMEA,5,3.38333000,-59.80000000,Lethem,"Lethem|(3.38333000,-59.80000000)"
+Haiti,HT,Artibonite,Anse Rouge,Port-au-Prince,,,19.63382000,-73.05530000,Anse Rouge;Arrondissement de Saint-Marc;Désarmes,"Anse Rouge|(19.63382000,-73.05530000);Arrondissement de Saint-Marc|(19.00000000,-72.50000000);Désarmes|(18.99345000,-72.39058000)"
+Haiti,HT,Centre,Arrondissement de Cerca La Source,Port-au-Prince,,,19.11667000,-71.75000000,Arrondissement de Cerca La Source;Cerca la Source;Hinche,"Arrondissement de Cerca La Source|(19.11667000,-71.75000000);Cerca la Source|(19.16696000,-71.79015000);Hinche|(19.15000000,-72.01667000)"
+Haiti,HT,Grand'Anse,Anse-à-Veau,Port-au-Prince,,,18.50110000,-73.34490000,Anse-à-Veau;Chambellan;Corail,"Anse-à-Veau|(18.50110000,-73.34490000);Chambellan|(18.55037000,-74.31317000);Corail|(18.56766000,-73.88942000)"
+Haiti,HT,Nippes,Ansavo,Port-au-Prince,,,18.41667000,-73.50000000,Ansavo;Baradères;Miragoâne,"Ansavo|(18.41667000,-73.50000000);Baradères|(18.48255000,-73.63884000);Miragoâne|(18.44599000,-73.08957000)"
+Haiti,HT,Nord,Acul du Nord,Port-au-Prince,,,19.66667000,-72.28333000,Acul du Nord;Arrondissement de la Grande Rivière du Nord;Arrondissement de Plaisance,"Acul du Nord|(19.66667000,-72.28333000);Arrondissement de la Grande Rivière du Nord|(19.51667000,-72.16667000);Arrondissement de Plaisance|(19.66756000,-72.54908000)"
+Haiti,HT,Nord-Est,Arrondissement de Fort Liberté,Port-au-Prince,,,19.56667000,-71.83333000,Arrondissement de Fort Liberté;Arrondissement du Trou du Nord;Caracol,"Arrondissement de Fort Liberté|(19.56667000,-71.83333000);Arrondissement du Trou du Nord|(19.55000000,-71.98333000);Caracol|(19.69274000,-72.01733000)"
+Haiti,HT,Nord-Ouest,Arcahaie,Port-au-Prince,,,19.81667000,-72.91667000,Arcahaie;Arrondissement de Port-de-Paix;Arrondissement de Saint-Louis du Nord,"Arcahaie|(19.81667000,-72.91667000);Arrondissement de Port-de-Paix|(19.83333000,-72.88333000);Arrondissement de Saint-Louis du Nord|(19.85000000,-72.66667000)"
+Haiti,HT,Ouest,Anse à Galets,Port-au-Prince,,,18.83449000,-72.86644000,Anse à Galets;Arcahaie;Arrondissement de Croix des Bouquets,"Anse à Galets|(18.83449000,-72.86644000);Arcahaie|(18.83333000,-72.41667000);Arrondissement de Croix des Bouquets|(18.48333000,-72.01667000)"
+Haiti,HT,Sud,Aquin,Port-au-Prince,,,18.27974000,-73.39433000,Aquin;Arrondissement de Port-Salut;Arrondissement des Cayes,"Aquin|(18.27974000,-73.39433000);Arrondissement de Port-Salut|(18.13333000,-73.90000000);Arrondissement des Cayes|(18.30000000,-73.83333000)"
+Haiti,HT,Sud-Est,Anse-à-Pitre,Port-au-Prince,,,18.05000000,-71.75000000,Anse-à-Pitre;Arrondissement de Bainet;Arrondissement de Jacmel,"Anse-à-Pitre|(18.05000000,-71.75000000);Arrondissement de Bainet|(18.25000000,-72.85000000);Arrondissement de Jacmel|(18.33333000,-72.50000000)"
+Honduras,HN,Atlántida,Arizona,Tegucigalpa,EMEA,13,15.63333000,-87.31667000,Arizona;Atenas de San Cristóbal;Corozal,"Arizona|(15.63333000,-87.31667000);Atenas de San Cristóbal|(15.68333000,-87.31667000);Corozal|(15.80000000,-86.71667000)"
+Honduras,HN,Bay Islands,Coxen Hole,Tegucigalpa,EMEA,13,16.31759000,-86.53793000,Coxen Hole;French Harbor;Guanaja,"Coxen Hole|(16.31759000,-86.53793000);French Harbor|(16.35000000,-86.43333000);Guanaja|(16.44795000,-85.89431000)"
+Honduras,HN,Choluteca,Choluteca,Tegucigalpa,EMEA,13,13.28261000,-87.20119000,Apacilagua;Choluteca;Ciudad Choluteca,"Apacilagua|(13.45821000,-87.01122000);Choluteca|(13.28261000,-87.20119000);Ciudad Choluteca|(13.30028000,-87.19083000)"
+Honduras,HN,Colón,Balfate,Tegucigalpa,EMEA,13,15.75709000,-86.29048000,Balfate;Bonito Oriental;Corocito,"Balfate|(15.75709000,-86.29048000);Bonito Oriental|(15.74641000,-85.73610000);Corocito|(15.75000000,-85.78333000)"
+Honduras,HN,Comayagua,Comayagua,Tegucigalpa,EMEA,13,14.48412000,-87.60060000,Aguas del Padre;Ajuterique;Cerro Blanco,"Aguas del Padre|(14.56667000,-87.88333000);Ajuterique|(14.38333000,-87.70000000);Cerro Blanco|(14.66667000,-87.78333000)"
+Honduras,HN,Copán,Copán,Tegucigalpa,EMEA,13,14.83333000,-89.15000000,Agua Caliente;Buenos Aires;Cabañas,"Agua Caliente|(14.88333000,-88.81667000);Buenos Aires|(15.03333000,-88.96667000);Cabañas|(14.76000000,-89.06000000)"
+Honduras,HN,Cortés,Agua Azul,Tegucigalpa,EMEA,13,14.91667000,-87.96667000,Agua Azul;Agua Azul Rancho;Armenta,"Agua Azul|(14.91667000,-87.96667000);Agua Azul Rancho|(14.90000000,-87.95000000);Armenta|(15.50000000,-88.05000000)"
+Honduras,HN,El Paraíso,El Paraíso,Tegucigalpa,EMEA,13,13.85381000,-86.53094000,Alauca;Araulí;Cuyalí,"Alauca|(13.84020000,-86.69526000);Araulí|(13.95000000,-86.55000000);Cuyalí|(13.88333000,-86.55000000)"
+Honduras,HN,Francisco Morazán,Agalteca,Tegucigalpa,EMEA,13,14.45000000,-87.26667000,Agalteca;Alubarén;Cedros,"Agalteca|(14.45000000,-87.26667000);Alubarén|(13.78226000,-87.46990000);Cedros|(14.50464000,-87.21680000)"
+Honduras,HN,Gracias a Dios,Ahuas,Tegucigalpa,EMEA,13,15.46923000,-84.34479000,Ahuas;Auas;Auka,"Ahuas|(15.46923000,-84.34479000);Auas|(15.48333000,-84.33333000);Auka|(14.94087000,-83.83229000)"
+Honduras,HN,Intibucá,Intibucá,Tegucigalpa,EMEA,13,14.43000000,-88.17000000,Camasca;Colomoncagua;Concepción,"Camasca|(14.00000000,-88.38333000);Colomoncagua|(13.97245000,-88.27673000);Concepción|(14.04725000,-88.31942000)"
+Honduras,HN,La Paz,La Paz,Tegucigalpa,EMEA,13,14.31944000,-87.67917000,Aguanqueterique;Cabañas;Cane,"Aguanqueterique|(13.98606000,-87.64622000);Cabañas|(13.99419000,-88.02864000);Cane|(14.28333000,-87.66667000)"
+Honduras,HN,Lempira,Belén,Tegucigalpa,EMEA,13,14.50834000,-88.42819000,Belén;Candelaria;Cololaca,"Belén|(14.50834000,-88.42819000);Candelaria|(14.06072000,-88.55913000);Cololaca|(14.31189000,-88.87720000)"
+Honduras,HN,Ocotepeque,Antigua Ocotepeque,Tegucigalpa,EMEA,13,14.40000000,-89.20000000,Antigua Ocotepeque;Belén Gualcho;Concepción,"Antigua Ocotepeque|(14.40000000,-89.20000000);Belén Gualcho|(14.48333000,-88.80000000);Concepción|(14.52383000,-89.19371000)"
+Honduras,HN,Olancho,Arimís,Tegucigalpa,EMEA,13,14.78333000,-86.00000000,Arimís;Campamento;Catacamas,"Arimís|(14.78333000,-86.00000000);Campamento|(14.55000000,-86.65000000);Catacamas|(14.60384000,-85.54261000)"
+Honduras,HN,Santa Bárbara,Santa Bárbara,Tegucigalpa,EMEA,13,14.91944000,-88.23611000,Agualote;Arada;Atima,"Agualote|(15.33528000,-88.55306000);Arada|(14.85000000,-88.30000000);Atima|(14.93333000,-88.48333000)"
+Honduras,HN,Valle,Agua Fría,Tegucigalpa,EMEA,13,13.46889000,-87.55111000,Agua Fría;Alianza;Amapala,"Agua Fría|(13.46889000,-87.55111000);Alianza|(13.44815000,-87.68643000);Amapala|(13.29222000,-87.65389000)"
+Honduras,HN,Yoro,Yoro,Tegucigalpa,EMEA,13,15.13750000,-87.12778000,Agua Blanca Sur;Arenal;Armenia,"Agua Blanca Sur|(15.25000000,-87.88333000);Arenal|(15.35000000,-86.83333000);Armenia|(15.46667000,-86.36667000)"
+Hong Kong S.A.R.,HK,Central and Western,Admiralty,Hong Kong,,,22.27800000,114.16400000,Admiralty;Central,"Admiralty|(22.27800000,114.16400000);Central|(22.28100000,114.15900000)"
+Hong Kong S.A.R.,HK,Eastern,,Hong Kong,,,,,,
+Hong Kong S.A.R.,HK,Islands,Tai O,Hong Kong,,,22.24700000,113.86900000,Tai O,"Tai O|(22.24700000,113.86900000)"
+Hong Kong S.A.R.,HK,Kowloon City,Kowloon Tong,Hong Kong,,,22.33700000,114.17900000,Kowloon Tong,"Kowloon Tong|(22.33700000,114.17900000)"
+Hong Kong S.A.R.,HK,Kwai Tsing,,Hong Kong,,,,,,
+Hong Kong S.A.R.,HK,Kwun Tong,Kwun Tong,Hong Kong,,,22.31000000,114.22500000,Kwun Tong;Lam Tin,"Kwun Tong|(22.31000000,114.22500000);Lam Tin|(22.30700000,114.23500000)"
+Hong Kong S.A.R.,HK,North,Sheung Shui,Hong Kong,,,22.50100000,114.12300000,Sheung Shui,"Sheung Shui|(22.50100000,114.12300000)"
+Hong Kong S.A.R.,HK,Sai Kung,Sai Kung,Hong Kong,,,22.38400000,114.27300000,Sai Kung;Tseung Kwan O,"Sai Kung|(22.38400000,114.27300000);Tseung Kwan O|(22.31900000,114.26300000)"
+Hong Kong S.A.R.,HK,Sha Tin,Sha Tin,Hong Kong,,,22.38300000,114.18800000,Ma On Shan;Sha Tin;Sha Tin Wai,"Ma On Shan|(22.42200000,114.23000000);Sha Tin|(22.38300000,114.18800000);Sha Tin Wai|(22.38000000,114.19100000)"
+Hong Kong S.A.R.,HK,Sham Shui Po,Cheung Sha Wan,Hong Kong,,,22.33600000,114.15100000,Cheung Sha Wan;Lai Chi Kok,"Cheung Sha Wan|(22.33600000,114.15100000);Lai Chi Kok|(22.33700000,114.14600000)"
+Hong Kong S.A.R.,HK,Southern,Aberdeen,Hong Kong,,,22.24700000,114.15200000,Aberdeen;Stanley;Stanley Peninsula,"Aberdeen|(22.24700000,114.15200000);Stanley|(22.22000000,114.21400000);Stanley Peninsula|(22.21000000,114.21700000)"
+Hong Kong S.A.R.,HK,Tai Po,Tai Po,Hong Kong,,,22.44900000,114.16000000,Tai Mei Tuk;Tai Po,"Tai Mei Tuk|(22.45700000,114.18400000);Tai Po|(22.44900000,114.16000000)"
+Hong Kong S.A.R.,HK,Tsuen Wan,Tsuen Wan,Hong Kong,,,22.37100000,114.11400000,Tsuen Wan;Tuen Mun,"Tsuen Wan|(22.37100000,114.11400000);Tuen Mun|(22.39500000,113.97300000)"
+Hong Kong S.A.R.,HK,Tuen Mun,,Hong Kong,,,,,,
+Hong Kong S.A.R.,HK,Wan Chai,Wan Chai,Hong Kong,,,22.27800000,114.18200000,Causeway Bay;Wan Chai,"Causeway Bay|(22.28000000,114.18500000);Wan Chai|(22.27800000,114.18200000)"
+Hong Kong S.A.R.,HK,Wong Tai Sin,Wong Tai Sin,Hong Kong,,,22.34100000,114.19300000,Wong Tai Sin,"Wong Tai Sin|(22.34100000,114.19300000)"
+Hong Kong S.A.R.,HK,Yau Tsim Mong,Mong Kok,Hong Kong,,,22.31900000,114.16900000,Mong Kok;Tsim Sha Tsui,"Mong Kok|(22.31900000,114.16900000);Tsim Sha Tsui|(22.29800000,114.17200000)"
+Hong Kong S.A.R.,HK,Yuen Long,Yuen Long,Hong Kong,,,22.44400000,114.02700000,Yuen Long,"Yuen Long|(22.44400000,114.02700000)"
+Hungary,HU,Bács-Kiskun,Ágasegyháza,Budapest,,,46.84025000,19.45208000,Ágasegyháza;Akasztó;Apostag,"Ágasegyháza|(46.84025000,19.45208000);Akasztó|(46.69167000,19.20423000);Apostag|(46.88208000,18.96210000)"
+Hungary,HU,Baranya,Beremend,Budapest,,,45.79108000,18.43263000,Beremend;Bóly;Bólyi Járás,"Beremend|(45.79108000,18.43263000);Bóly|(45.96722000,18.51833000);Bólyi Járás|(45.98075000,18.48449000)"
+Hungary,HU,Békés,Békés,Budapest,,,46.76667000,21.13333000,Battonya;Békés;Békéscsaba,"Battonya|(46.28333000,21.01667000);Békés|(46.76667000,21.13333000);Békéscsaba|(46.68333000,21.10000000)"
+Hungary,HU,Békéscsaba,,Budapest,,,,,,
+Hungary,HU,Borsod-Abaúj-Zemplén,Abaújszántó,Budapest,,,48.28333000,21.20000000,Abaújszántó;Alsózsolca;Arló,"Abaújszántó|(48.28333000,21.20000000);Alsózsolca|(48.06982000,20.88046000);Arló|(48.18333000,20.26667000)"
+Hungary,HU,Budapest,Budapest,Budapest,,,47.49835000,19.04045000,Budapest;Budapest I. kerület;Budapest II. kerület,"Budapest|(47.49835000,19.04045000);Budapest I. kerület|(47.49705000,19.03961000);Budapest II. kerület|(47.51984000,19.02218000)"
+Hungary,HU,Csongrád County,Algyő,Budapest,,,46.33472000,20.20849000,Algyő;Apátfalva;Ásotthalom,"Algyő|(46.33472000,20.20849000);Apátfalva|(46.16667000,20.58333000);Ásotthalom|(46.19875000,19.78334000)"
+Hungary,HU,Debrecen,,Budapest,,,,,,
+Hungary,HU,Dunaújváros,,Budapest,,,,,,
+Hungary,HU,Eger,,Budapest,,,,,,
+Hungary,HU,Érd,,Budapest,,,,,,
+Hungary,HU,Fejér County,Aba,Budapest,,,47.02907000,18.52172000,Aba;Adony;Alap,"Aba|(47.02907000,18.52172000);Adony|(47.11940000,18.86493000);Alap|(46.79915000,18.68938000)"
+Hungary,HU,Győr,,Budapest,,,,,,
+Hungary,HU,Győr-Moson-Sopron County,Abda,Budapest,,,47.69464000,17.54489000,Abda;Ágfalva;Ásványráró,"Abda|(47.69464000,17.54489000);Ágfalva|(47.68991000,16.51658000);Ásványráró|(47.82733000,17.49418000)"
+Hungary,HU,Hajdú-Bihar County,Bagamér,Budapest,,,47.44882000,21.98900000,Bagamér;Balmazújváros;Balmazújvárosi Járás,"Bagamér|(47.44882000,21.98900000);Balmazújváros|(47.61667000,21.35000000);Balmazújvárosi Járás|(47.61840000,21.14882000)"
+Hungary,HU,Heves County,Abasár,Budapest,,,47.79705000,20.00324000,Abasár;Adács;Andornaktálya,"Abasár|(47.79705000,20.00324000);Adács|(47.69210000,19.97696000);Andornaktálya|(47.85000000,20.41667000)"
+Hungary,HU,Hódmezővásárhely,,Budapest,,,,,,
+Hungary,HU,Jász-Nagykun-Szolnok County,Abádszalók,Budapest,,,47.46667000,20.60000000,Abádszalók;Alattyán;Besenyszög,"Abádszalók|(47.46667000,20.60000000);Alattyán|(47.42705000,20.04219000);Besenyszög|(47.30000000,20.26667000)"
+Hungary,HU,Kaposvár,,Budapest,,,,,,
+Hungary,HU,Kecskemét,,Budapest,,,,,,
+Hungary,HU,Komárom-Esztergom,Ács,Budapest,,,47.71000000,18.01555556,Ács;Aka;Almásfüzitő,"Ács|(47.71000000,18.01555556);Aka|(47.40206944,18.07163056);Almásfüzitő|(47.72870000,18.25538889)"
+Hungary,HU,Miskolc,,Budapest,,,,,,
+Hungary,HU,Nagykanizsa,,Budapest,,,,,,
+Hungary,HU,Nógrád County,Balassagyarmat,Budapest,,,48.07296000,19.29614000,Balassagyarmat;Balassagyarmati Járás;Bátonyterenye,"Balassagyarmat|(48.07296000,19.29614000);Balassagyarmati Járás|(48.01657000,19.30594000);Bátonyterenye|(47.96962000,19.84076000)"
+Hungary,HU,Nyíregyháza,,Budapest,,,,,,
+Hungary,HU,Pécs,,Budapest,,,,,,
+Hungary,HU,Pest County,Abony,Budapest,,,47.18990000,20.00476000,Abony;Acsa;Albertirsa,"Abony|(47.18990000,20.00476000);Acsa|(47.79425000,19.38795000);Albertirsa|(47.24315000,19.61686000)"
+Hungary,HU,Salgótarján,,Budapest,,,,,,
+Hungary,HU,Somogy County,Ádánd,Budapest,,,46.85931000,18.16442000,Ádánd;Babócsa;Balatonberény,"Ádánd|(46.85931000,18.16442000);Babócsa|(46.04155000,17.34332000);Balatonberény|(46.70701000,17.32013000)"
+Hungary,HU,Sopron,,Budapest,,,,,,
+Hungary,HU,Szabolcs-Szatmár-Bereg County,Ajak,Budapest,,,48.17664000,22.06273000,Ajak;Anarcs;Apagy,"Ajak|(48.17664000,22.06273000);Anarcs|(48.17642000,22.11167000);Apagy|(47.96431000,21.93539000)"
+Hungary,HU,Szeged,,Budapest,,,,,,
+Hungary,HU,Székesfehérvár,,Budapest,,,,,,
+Hungary,HU,Szekszárd,,Budapest,,,,,,
+Hungary,HU,Szolnok,,Budapest,,,,,,
+Hungary,HU,Szombathely,,Budapest,,,,,,
+Hungary,HU,Tatabánya,,Budapest,,,,,,
+Hungary,HU,Tolna County,Báta,Budapest,,,46.12864000,18.77027000,Báta;Bátaszék;Bogyiszló,"Báta|(46.12864000,18.77027000);Bátaszék|(46.19373000,18.72307000);Bogyiszló|(46.38638000,18.82962000)"
+Hungary,HU,Vas County,Bük,Budapest,,,47.38486000,16.75065000,Bük;Celldömölk;Celldömölki Járás,"Bük|(47.38486000,16.75065000);Celldömölk|(47.25713000,17.15027000);Celldömölki Járás|(47.25001000,17.13209000)"
+Hungary,HU,Veszprém,,Budapest,,,,,,
+Hungary,HU,Veszprém County,Ajka,Budapest,,,47.10196000,17.55892000,Ajka;Ajkai Járás;Badacsonytomaj,"Ajka|(47.10196000,17.55892000);Ajkai Járás|(47.07988000,17.56375000);Badacsonytomaj|(46.80711000,17.51385000)"
+Hungary,HU,Zala County,Becsehely,Budapest,,,46.44755000,16.77710000,Becsehely;Cserszegtomaj;Gyenesdiás,"Becsehely|(46.44755000,16.77710000);Cserszegtomaj|(46.80165000,17.22096000);Gyenesdiás|(46.77058000,17.28660000)"
+Hungary,HU,Zalaegerszeg,,Budapest,,,,,,
+Iceland,IS,Capital,Álftanes,Reykjavik,,,64.10000000,-22.01667000,Álftanes;Garðabær;Hafnarfjörður,"Álftanes|(64.10000000,-22.01667000);Garðabær|(64.08865000,-21.92298000);Hafnarfjörður|(64.06710000,-21.93774000)"
+Iceland,IS,Eastern,Borgarfjarðarhreppur,Reykjavik,,,65.43401000,-13.82933000,Borgarfjarðarhreppur;Breiðdalshreppur;Egilsstaðir,"Borgarfjarðarhreppur|(65.43401000,-13.82933000);Breiðdalshreppur|(64.83333000,-14.25000000);Egilsstaðir|(65.26687000,-14.39485000)"
+Iceland,IS,Northeastern,Akureyri,Reykjavik,,,65.68353000,-18.08780000,Akureyri;Dalvík;Dalvíkurbyggð,"Akureyri|(65.68353000,-18.08780000);Dalvík|(65.97018000,-18.52861000);Dalvíkurbyggð|(65.87318000,-18.60844000)"
+Iceland,IS,Northwestern,Akrahreppur,Reykjavik,,,65.35505000,-18.79572000,Akrahreppur;Húnaþing Vestra;Sauðárkrókur,"Akrahreppur|(65.35505000,-18.79572000);Húnaþing Vestra|(65.25000000,-20.91667000);Sauðárkrókur|(65.74611000,-19.63944000)"
+Iceland,IS,Southern,Ásahreppur,Reykjavik,,,63.87589000,-20.59484000,Ásahreppur;Bláskógabyggð;Flóahreppur,"Ásahreppur|(63.87589000,-20.59484000);Bláskógabyggð|(64.41667000,-20.33333000);Flóahreppur|(63.89569000,-20.80159000)"
+Iceland,IS,Southern Peninsula,Garður,Reykjavik,,,64.06558000,-22.64656000,Garður;Grindavík;Keflavík,"Garður|(64.06558000,-22.64656000);Grindavík|(63.83849000,-22.43931000);Keflavík|(64.00492000,-22.56242000)"
+Iceland,IS,Western,Akranes,Reykjavik,,,64.32179000,-22.07490000,Akranes;Borgarbyggð;Borgarnes,"Akranes|(64.32179000,-22.07490000);Borgarbyggð|(64.71446000,-21.23788000);Borgarnes|(64.53834000,-21.92064000)"
+Iceland,IS,Westfjords,Ísafjarðarbær,Reykjavik,,,66.07586000,-23.12794000,Ísafjarðarbær;Ísafjörður;Reykhólahreppur,"Ísafjarðarbær|(66.07586000,-23.12794000);Ísafjörður|(66.07475000,-23.13498000);Reykhólahreppur|(65.60990000,-22.33324000)"
+India,IN,Andaman and Nicobar Islands,Bamboo Flat,New Delhi,,,11.70000000,92.71667000,Bamboo Flat;Nicobar;Port Blair,"Bamboo Flat|(11.70000000,92.71667000);Nicobar|(7.03002000,93.79028000);Port Blair|(11.66613000,92.74635000)"
+India,IN,Andhra Pradesh,Addanki,New Delhi,,,15.81061000,79.97338000,Addanki;Adoni;Akasahebpet,"Addanki|(15.81061000,79.97338000);Adoni|(15.62788000,77.27495000);Akasahebpet|(17.50455000,82.56597000)"
+India,IN,Arunachal Pradesh,Along,New Delhi,,,28.16951000,94.80060000,Along;Anjaw;Basar,"Along|(28.16951000,94.80060000);Anjaw|(28.06549000,96.82878000);Basar|(27.99008000,94.69451000)"
+India,IN,Assam,Abhayapuri,New Delhi,,,26.32255000,90.68526000,Abhayapuri;Amguri;Badarpur,"Abhayapuri|(26.32255000,90.68526000);Amguri|(26.81482000,94.52614000);Badarpur|(24.86852000,92.59606000)"
+India,IN,Bihar,Amarpur,New Delhi,,,25.03967000,86.90247000,Amarpur;Araria;Arrah,"Amarpur|(25.03967000,86.90247000);Araria|(26.20000000,87.40000000);Arrah|(25.55629000,84.66335000)"
+India,IN,Chandigarh,Chandigarh,New Delhi,,,30.73629000,76.78840000,Chandigarh,"Chandigarh|(30.73629000,76.78840000)"
+India,IN,Chhattisgarh,Akaltara,New Delhi,,,22.02463000,82.42641000,Akaltara;Ambagarh Chauki;Ambikapur,"Akaltara|(22.02463000,82.42641000);Ambagarh Chauki|(20.77644000,80.74608000);Ambikapur|(23.11892000,83.19537000)"
+India,IN,Dadra and Nagar Haveli and Daman and Diu,Amli,New Delhi,,,20.28333000,73.01667000,Amli;Dadra;Dadra & Nagar Haveli,"Amli|(20.28333000,73.01667000);Dadra|(20.32504000,72.96618000);Dadra & Nagar Haveli|(20.20651000,73.00811000)"
+India,IN,Delhi,Delhi,New Delhi,,,28.65195000,77.23149000,Alipur;Bawana;Central Delhi,"Alipur|(28.79862000,77.13314000);Bawana|(28.79820000,77.03431000);Central Delhi|(28.64857000,77.21895000)"
+India,IN,Goa,Aldona,New Delhi,,,15.59337000,73.87482000,Aldona;Arambol;Baga,"Aldona|(15.59337000,73.87482000);Arambol|(15.68681000,73.70449000);Baga|(15.56517000,73.75517000)"
+India,IN,Gujarat,Abrama,New Delhi,,,20.85865000,72.90648000,Abrama;Adalaj;Agol,"Abrama|(20.85865000,72.90648000);Adalaj|(23.16453000,72.58107000);Agol|(23.15000000,72.26666667)"
+India,IN,Haryana,Ambala,New Delhi,,,30.32854000,76.94220000,Ambala;Asandh;Ateli Mandi,"Ambala|(30.32854000,76.94220000);Asandh|(29.52119000,76.60552000);Ateli Mandi|(28.10080000,76.25980000)"
+India,IN,Himachal Pradesh,Arki,New Delhi,,,31.15196000,76.96675000,Arki;Baddi;Banjar,"Arki|(31.15196000,76.96675000);Baddi|(30.95783000,76.79136000);Banjar|(31.63900000,77.34055000)"
+India,IN,Jammu and Kashmir,Akhnur,New Delhi,,,32.86667000,74.73333000,Akhnur;Anantnag;Awantipur,"Akhnur|(32.86667000,74.73333000);Anantnag|(33.73068000,75.15418000);Awantipur|(33.91978000,75.01515000)"
+India,IN,Jharkhand,Bagra,New Delhi,,,23.73333000,86.31667000,Bagra;Barka Kana;Barki Saria,"Bagra|(23.73333000,86.31667000);Barka Kana|(23.62118000,85.46748000);Barki Saria|(24.17594000,85.88938000)"
+India,IN,Karnataka,Afzalpur,New Delhi,,,17.19986000,76.36018000,Afzalpur;Ajjampur;Aland,"Afzalpur|(17.19986000,76.36018000);Ajjampur|(13.72794000,76.00680000);Aland|(17.56425000,76.56854000)"
+India,IN,Kerala,Adoor,New Delhi,,,9.15595000,76.73192000,Adoor;Alappuzha;Aluva,"Adoor|(9.15595000,76.73192000);Alappuzha|(9.49004000,76.32640000);Aluva|(10.10764000,76.35158000)"
+India,IN,Ladakh,Kargil,New Delhi,,,34.55765000,76.12622000,Kargil;Leh,"Kargil|(34.55765000,76.12622000);Leh|(34.16504000,77.58402000)"
+India,IN,Lakshadweep,Lakshadweep,New Delhi,,,11.27333000,74.04582000,Kavaratti;Lakshadweep,"Kavaratti|(10.56688000,72.64203000);Lakshadweep|(11.27333000,74.04582000)"
+India,IN,Madhya Pradesh,Agar,New Delhi,,,23.71177000,76.01571000,Agar;Ajaigarh;Akodia,"Agar|(23.71177000,76.01571000);Ajaigarh|(24.89879000,80.25921000);Akodia|(23.38027000,76.59875000)"
+India,IN,Maharashtra,Achalpur,New Delhi,,,21.25665000,77.51006000,Achalpur;Adawad;Agar Panchaitan,"Achalpur|(21.25665000,77.51006000);Adawad|(21.21666667,75.45000000);Agar Panchaitan|(18.17369200,72.98853300)"
+India,IN,Manipur,Bishnupur,New Delhi,,,24.60769000,93.77998000,Bishnupur;Chandel;Churachandpur,"Bishnupur|(24.60769000,93.77998000);Chandel|(24.57390000,94.29130000);Churachandpur|(24.33333000,93.68333000)"
+India,IN,Meghalaya,Cherrapunji,New Delhi,,,25.30089000,91.69619000,Cherrapunji;East Garo Hills;East Jaintia Hills,"Cherrapunji|(25.30089000,91.69619000);East Garo Hills|(25.61372000,90.62426000);East Jaintia Hills|(25.35976000,92.36680000)"
+India,IN,Mizoram,Aizawl,New Delhi,,,23.80000000,92.90000000,Aizawl;Champhai;Darlawn,"Aizawl|(23.80000000,92.90000000);Champhai|(23.47444000,93.32556000);Darlawn|(24.01336000,92.92439000)"
+India,IN,Nagaland,Dimapur,New Delhi,,,25.77852000,93.78508000,Dimapur;Kohima;Mokokchung,"Dimapur|(25.77852000,93.78508000);Kohima|(25.67467000,94.11099000);Mokokchung|(26.31393000,94.51675000)"
+India,IN,Odisha,Angul,New Delhi,,,20.84089000,85.10192000,Angul;Angul District;Asika,"Angul|(20.84089000,85.10192000);Angul District|(20.84903000,85.06079000);Asika|(19.61114000,84.65998000)"
+India,IN,Puducherry,Puducherry,New Delhi,,,11.93381000,79.82979000,Karaikal;Mahe;Puducherry,"Karaikal|(10.92209000,79.83353000);Mahe|(11.70000000,75.53333000);Puducherry|(11.93381000,79.82979000)"
+India,IN,Punjab,Abohar,New Delhi,,,30.14453000,74.19552000,Abohar;Adampur;Ajitgarh,"Abohar|(30.14453000,74.19552000);Adampur|(31.43224000,75.71484000);Ajitgarh|(30.65000000,76.70000000)"
+India,IN,Rajasthan,Abhaneri,New Delhi,,,27.00743000,76.60760000,Abhaneri;Abu;Abu Road,"Abhaneri|(27.00743000,76.60760000);Abu|(24.59365000,72.71756000);Abu Road|(24.48012000,72.78186000)"
+India,IN,Sikkim,East District,New Delhi,,,27.33333000,88.66667000,East District;Gangtok;Gyalshing,"East District|(27.33333000,88.66667000);Gangtok|(27.32574000,88.61216000);Gyalshing|(27.28952000,88.25764000)"
+India,IN,Tamil Nadu,Abiramam,New Delhi,,,9.44230000,78.43990000,Abiramam;Adirampattinam;Aduthurai,"Abiramam|(9.44230000,78.43990000);Adirampattinam|(10.34059000,79.37905000);Aduthurai|(11.01542000,79.48093000)"
+India,IN,Telangana,Adilabad,New Delhi,,,19.50000000,78.50000000,Adilabad;Alampur;Andol,"Adilabad|(19.50000000,78.50000000);Alampur|(15.87987000,78.13352000);Andol|(17.81458000,78.07713000)"
+India,IN,Tripura,Agartala,New Delhi,,,23.83605000,91.27939000,Agartala;Amarpur;Ambasa,"Agartala|(23.83605000,91.27939000);Amarpur|(23.52570000,91.65879000);Ambasa|(23.93600000,91.85436000)"
+India,IN,Uttar Pradesh,Achhnera,New Delhi,,,27.17826000,77.75674000,Achhnera;Afzalgarh;Agra,"Achhnera|(27.17826000,77.75674000);Afzalgarh|(29.39370000,78.67393000);Agra|(27.18333000,78.01667000)"
+India,IN,Uttarakhand,Almora,New Delhi,,,29.69223000,79.49789000,Almora;Bageshwar;Banbasa,"Almora|(29.69223000,79.49789000);Bageshwar|(29.97315000,79.83224000);Banbasa|(28.99132000,80.07608000)"
+India,IN,West Bengal,Adra,New Delhi,,,23.49601500,86.67249000,Adra;Ahmedpur;Aknapur,"Adra|(23.49601500,86.67249000);Ahmedpur|(23.83009000,87.68661000);Aknapur|(18.38576389,77.27225278)"
+Indonesia,ID,Aceh,Banda Aceh,Jakarta,,,5.54167000,95.33333000,Banda Aceh;Bireun;Kabupaten Aceh Barat,"Banda Aceh|(5.54167000,95.33333000);Bireun|(5.20300000,96.70090000);Kabupaten Aceh Barat|(4.45000000,96.16667000)"
+Indonesia,ID,Bali,Amlapura,Jakarta,,,-8.45000000,115.61667000,Amlapura;Banjar;Banjar Wangsian,"Amlapura|(-8.45000000,115.61667000);Banjar|(-8.19000000,114.96750000);Banjar Wangsian|(-8.49497000,115.42342000)"
+Indonesia,ID,Banten,Kabupaten Lebak,Jakarta,,,-6.65000000,106.21667000,Kabupaten Lebak;Kabupaten Pandeglang;Kabupaten Serang,"Kabupaten Lebak|(-6.65000000,106.21667000);Kabupaten Pandeglang|(-6.63333000,105.75000000);Kabupaten Serang|(-6.15000000,106.00000000)"
+Indonesia,ID,Bengkulu,Bengkulu,Jakarta,,,-3.80044000,102.26554000,Bengkulu;Curup;Kabupaten Bengkulu Selatan,"Bengkulu|(-3.80044000,102.26554000);Curup|(-3.47030000,102.52070000);Kabupaten Bengkulu Selatan|(-4.35000000,103.03333000)"
+Indonesia,ID,DI Yogyakarta,Kabupaten Bantul,Jakarta,,,-7.90000000,110.36667000,Kabupaten Bantul;Kabupaten Gunung Kidul;Kabupaten Kulon Progo,"Kabupaten Bantul|(-7.90000000,110.36667000);Kabupaten Gunung Kidul|(-7.98333000,110.61667000);Kabupaten Kulon Progo|(-7.64500000,110.02694000)"
+Indonesia,ID,DKI Jakarta,Jakarta Barat,Jakarta,,,-6.15999160,106.67485740,Jakarta Barat;Jakarta Pusat;Jakarta Selatan,"Jakarta Barat|(-6.15999160,106.67485740);Jakarta Pusat|(-6.18222610,106.79526480);Jakarta Selatan|(-6.28392950,106.71967730)"
+Indonesia,ID,Gorontalo,Gorontalo,Jakarta,,,0.53750000,123.06250000,Gorontalo;Kabupaten Boalemo;Kabupaten Bone Bolango,"Gorontalo|(0.53750000,123.06250000);Kabupaten Boalemo|(0.62689000,122.35680000);Kabupaten Bone Bolango|(0.50296000,123.27501000)"
+Indonesia,ID,Jambi,Bejubang Dua,Jakarta,,,-1.79230000,103.31670000,Bejubang Dua;Jambi City;Kabupaten Batang Hari,"Bejubang Dua|(-1.79230000,103.31670000);Jambi City|(-1.60000000,103.61667000);Kabupaten Batang Hari|(-1.75000000,103.11667000)"
+Indonesia,ID,Jawa Barat,Arjawinangun,Jakarta,,,-6.64528000,108.41028000,Arjawinangun;Astanajapura;Bandung,"Arjawinangun|(-6.64528000,108.41028000);Astanajapura|(-6.80170000,108.63110000);Bandung|(-6.92222000,107.60694000)"
+Indonesia,ID,Jawa Tengah,Adiwerna,Jakarta,,,-6.93750000,109.13250000,Adiwerna;Ambarawa;Baekrajan,"Adiwerna|(-6.93750000,109.13250000);Ambarawa|(-7.26333000,110.39750000);Baekrajan|(-6.76740000,110.85410000)"
+Indonesia,ID,Jawa Timur,Babat,Jakarta,,,-7.11282000,112.16354000,Babat;Balung;Bangil,"Babat|(-7.11282000,112.16354000);Balung|(-7.73333000,113.91667000);Bangil|(-7.59939000,112.81860000)"
+Indonesia,ID,Kalimantan Barat,Bengkayang,Jakarta,,,1.06911000,109.66393000,Bengkayang;Kapuas Hulu;Kayong Utara,"Bengkayang|(1.06911000,109.66393000);Kapuas Hulu|(0.83333000,112.80000000);Kayong Utara|(-1.06023000,110.10402000)"
+Indonesia,ID,Kalimantan Selatan,Amuntai,Jakarta,,,-2.41773000,115.24941000,Amuntai;Banjarmasin;Barabai,"Amuntai|(-2.41773000,115.24941000);Banjarmasin|(-3.31987000,114.59075000);Barabai|(-2.58333000,115.38333000)"
+Indonesia,ID,Kalimantan Tengah,Kabupaten Barito Selatan,Jakarta,,,-1.86667000,114.73333000,Kabupaten Barito Selatan;Kabupaten Barito Timur;Kabupaten Barito Utara,"Kabupaten Barito Selatan|(-1.86667000,114.73333000);Kabupaten Barito Timur|(-1.93333000,115.10000000);Kabupaten Barito Utara|(-0.98333000,115.10000000)"
+Indonesia,ID,Kalimantan Timur,Balikpapan,Jakarta,,,-1.26753000,116.82887000,Balikpapan;Bontang;City of Balikpapan,"Balikpapan|(-1.26753000,116.82887000);Bontang|(0.13240000,117.48540000);City of Balikpapan|(-1.24204000,116.89419000)"
+Indonesia,ID,Kalimantan Utara,Kabupaten Bulungan,Jakarta,,,3.00000000,117.16667000,Kabupaten Bulungan;Kabupaten Malinau;Kabupaten Nunukan,"Kabupaten Bulungan|(3.00000000,117.16667000);Kabupaten Malinau|(2.45000000,115.68333000);Kabupaten Nunukan|(4.13333000,116.70000000)"
+Indonesia,ID,Kepulauan Bangka Belitung,Kabupaten Bangka,Jakarta,,,-1.91667000,105.93333000,Kabupaten Bangka;Kabupaten Bangka Barat;Kabupaten Bangka Selatan,"Kabupaten Bangka|(-1.91667000,105.93333000);Kabupaten Bangka Barat|(-1.95839000,105.53741000);Kabupaten Bangka Selatan|(-2.66803000,106.01257000)"
+Indonesia,ID,Kepulauan Riau,Kabupaten Bintan,Jakarta,,,0.95000000,104.61944000,Kabupaten Bintan;Kabupaten Karimun;Kabupaten Kepulauan Anambas,"Kabupaten Bintan|(0.95000000,104.61944000);Kabupaten Karimun|(0.80764000,103.41911000);Kabupaten Kepulauan Anambas|(3.00000000,106.00000000)"
+Indonesia,ID,Lampung,Bandar Lampung,Jakarta,,,-5.42917000,105.26111000,Bandar Lampung;Kabupaten Lampung Barat;Kabupaten Lampung Selatan,"Bandar Lampung|(-5.42917000,105.26111000);Kabupaten Lampung Barat|(-5.14904000,104.19309000);Kabupaten Lampung Selatan|(-5.45310000,104.98770000)"
+Indonesia,ID,Maluku,Amahai,Jakarta,,,-3.33984000,128.91975000,Amahai;Ambon;Kabupaten Buru,"Amahai|(-3.33984000,128.91975000);Ambon|(-3.69583000,128.18333000);Kabupaten Buru|(-3.32767000,126.68413000)"
+Indonesia,ID,Maluku Utara,East Halmahera Regency,Jakarta,,,1.33517000,128.48627000,East Halmahera Regency;Kabupaten Halmahera Barat;Kabupaten Halmahera Selatan,"East Halmahera Regency|(1.33517000,128.48627000);Kabupaten Halmahera Barat|(1.41709000,127.55264000);Kabupaten Halmahera Selatan|(-0.39550000,127.90833000)"
+Indonesia,ID,Nusa Tenggara Barat,Bima,Jakarta,,,-8.46006000,118.72667000,Bima;Dompu;Gili Air,"Bima|(-8.46006000,118.72667000);Dompu|(-8.53650000,118.46340000);Gili Air|(-8.35783000,116.08240000)"
+Indonesia,ID,Nusa Tenggara Timur,Atambua,Jakarta,,,-9.10611000,124.89250000,Atambua;Ende;Kabupaten Alor,"Atambua|(-9.10611000,124.89250000);Ende|(-8.84320000,121.66230000);Kabupaten Alor|(-8.30000000,124.56667000)"
+Indonesia,ID,Papua,Abepura,Jakarta,,,-2.59640000,140.63240000,Abepura;Biak;Insrom,"Abepura|(-2.59640000,140.63240000);Biak|(-1.17670000,136.08200000);Insrom|(-1.14473000,136.03134000)"
+Indonesia,ID,Papua Barat,Kabupaten Fakfak,Jakarta,,,-2.92641000,132.29608000,Kabupaten Fakfak;Kabupaten Kaimana;Kabupaten Manokwari,"Kabupaten Fakfak|(-2.92641000,132.29608000);Kabupaten Kaimana|(-3.66093000,133.77451000);Kabupaten Manokwari|(-0.90000000,133.75000000)"
+Indonesia,ID,Papua Barat Daya,Kabupaten Maybrat,Jakarta,,,-1.21550000,132.35092000,Kabupaten Maybrat;Kabupaten Raja Ampat;Kabupaten Sorong,"Kabupaten Maybrat|(-1.21550000,132.35092000);Kabupaten Raja Ampat|(-0.50000000,130.00000000);Kabupaten Sorong|(-1.16667000,131.50000000)"
+Indonesia,ID,Papua Pegunungan,Kabupaten Jayawijaya,Jakarta,,,-4.08333000,139.08333000,Kabupaten Jayawijaya;Kabupaten Lanny Jaya;Kabupaten Mamberamo Tengah,"Kabupaten Jayawijaya|(-4.08333000,139.08333000);Kabupaten Lanny Jaya|(-3.91244000,138.28766000);Kabupaten Mamberamo Tengah|(-2.46064000,138.45245000)"
+Indonesia,ID,Papua Selatan,Kabupaten Asmat,Jakarta,,,-5.37950000,138.46344000,Kabupaten Asmat;Kabupaten Boven Digoel;Kabupaten Mappi,"Kabupaten Asmat|(-5.37950000,138.46344000);Kabupaten Boven Digoel|(-5.70519000,140.36349000);Kabupaten Mappi|(-6.49971000,139.34441000)"
+Indonesia,ID,Papua Tengah,Kabupaten Deiyai,Jakarta,,,-3.94737000,135.95032000,Kabupaten Deiyai;Kabupaten Dogiyai;Kabupaten Intan Jaya,"Kabupaten Deiyai|(-3.94737000,135.95032000);Kabupaten Dogiyai|(-4.03186000,135.43945000);Kabupaten Intan Jaya|(-3.41016000,136.70837000)"
+Indonesia,ID,Riau,Balaipungut,Jakarta,,,1.05949000,101.29054000,Balaipungut;Batam;Dumai,"Balaipungut|(1.05949000,101.29054000);Batam|(1.14937000,104.02491000);Dumai|(1.66711000,101.44316000)"
+Indonesia,ID,Sulawesi Barat,Kabupaten Majene,Jakarta,,,-3.15000000,118.86667000,Kabupaten Majene;Kabupaten Mamasa;Kabupaten Mamuju,"Kabupaten Majene|(-3.15000000,118.86667000);Kabupaten Mamasa|(-2.96492000,119.30631000);Kabupaten Mamuju|(-2.50000000,119.41667000)"
+Indonesia,ID,Sulawesi Selatan,Galesong,Jakarta,,,-5.31660000,119.36610000,Galesong;Kabupaten Bantaeng;Kabupaten Barru,"Galesong|(-5.31660000,119.36610000);Kabupaten Bantaeng|(-5.48333000,119.98333000);Kabupaten Barru|(-4.43333000,119.68333000)"
+Indonesia,ID,Sulawesi Tengah,Kabupaten Banggai,Jakarta,,,-0.91141000,122.71836000,Kabupaten Banggai;Kabupaten Banggai Kepulauan;Kabupaten Banggai Laut,"Kabupaten Banggai|(-0.91141000,122.71836000);Kabupaten Banggai Kepulauan|(-1.30236000,123.03726000);Kabupaten Banggai Laut|(-1.61841000,123.49388000)"
+Indonesia,ID,Sulawesi Tenggara,Kabupaten Bombana,Jakarta,,,-4.62570000,121.81641000,Kabupaten Bombana;Kabupaten Buton;Kabupaten Buton Selatan,"Kabupaten Bombana|(-4.62570000,121.81641000);Kabupaten Buton|(-5.31667000,122.91667000);Kabupaten Buton Selatan|(-5.56667000,122.70000000)"
+Indonesia,ID,Sulawesi Utara,Kabupaten Bolaang Mongondow,Jakarta,,,0.75000000,124.08333000,Kabupaten Bolaang Mongondow;Kabupaten Bolaang Mongondow Selatan;Kabupaten Bolaang Mongondow Timur,"Kabupaten Bolaang Mongondow|(0.75000000,124.08333000);Kabupaten Bolaang Mongondow Selatan|(0.40912000,123.75961000);Kabupaten Bolaang Mongondow Timur|(0.72073000,124.50256000)"
+Indonesia,ID,Sumatera Barat,Bukittinggi,Jakarta,,,-0.30907000,100.37055000,Bukittinggi;Kabupaten Agam;Kabupaten Dharmasraya,"Bukittinggi|(-0.30907000,100.37055000);Kabupaten Agam|(-0.25000000,100.16667000);Kabupaten Dharmasraya|(-1.05000000,101.36700000)"
+Indonesia,ID,Sumatera Selatan,Baturaja,Jakarta,,,-4.12891000,104.16695000,Baturaja;Kabupaten Empat Lawang;Kabupaten Muara Enim,"Baturaja|(-4.12891000,104.16695000);Kabupaten Empat Lawang|(3.22667000,99.09256000);Kabupaten Muara Enim|(-4.23270000,103.61410000)"
+Indonesia,ID,Sumatera Utara,Ambarita,Jakarta,,,2.68140000,98.83110000,Ambarita;Bandar;Belawan,"Ambarita|(2.68140000,98.83110000);Bandar|(2.05000000,99.75000000);Belawan|(3.77550000,98.68320000)"
+Iran,IR,Alborz,Asara,Tehran,,,36.03913120,51.19087090,Asara;Charbagh;Eshtehard,"Asara|(36.03913120,51.19087090);Charbagh|(35.84060280,50.83944800);Eshtehard|(35.72813000,50.41422000)"
+Iran,IR,Ardabil,Ardabil,Tehran,,,38.24980000,48.29330000,Abibeiglou;Anbaran;Ardabil,"Abibeiglou|(38.28362000,48.54482890);Anbaran|(38.48843440,48.41767760);Ardabil|(38.24980000,48.29330000)"
+Iran,IR,Bushehr,Bushehr,Tehran,,,28.96887000,50.83657000,Ab Pakhsh;Abad;Ahram,"Ab Pakhsh|(29.36788550,51.05140670);Abad|(29.02994140,51.23435480);Ahram|(28.88260000,51.27460000)"
+Iran,IR,Chaharmahal and Bakhtiari,Aluni,Tehran,,,31.55421910,51.04972240,Aluni;Ardal;Babaheydar,"Aluni|(31.55421910,51.04972240);Ardal|(32.00501060,50.61478550);Babaheydar|(32.33058500,50.45960420)"
+Iran,IR,East Azerbaijan,Abeshahmad,Tehran,,,39.04976740,47.30755790,Abeshahmad;Achachi;Ahar,"Abeshahmad|(39.04976740,47.30755790);Achachi|(37.39543380,47.79039870);Ahar|(38.47740000,47.06990000)"
+Iran,IR,Fars,Abadeh,Tehran,,,31.16080000,52.65060000,Abadeh;Abadeh Tashk;Ahel,"Abadeh|(31.16080000,52.65060000);Abadeh Tashk|(29.80720880,53.72005450);Ahel|(27.21120460,53.65720510)"
+Iran,IR,Gilan,Ahmadsargurab,Tehran,,,37.12805600,49.36666700,Ahmadsargurab;Amlash;Asalem,"Ahmadsargurab|(37.12805600,49.36666700);Amlash|(37.09246800,50.17314410);Asalem|(37.72003980,48.92658170)"
+Iran,IR,Golestan,Aliabad-e-Katul,Tehran,,,36.91016390,54.83907210,Aliabad-e-Katul;Anbar Olum;Aq Qala,"Aliabad-e-Katul|(36.91016390,54.83907210);Anbar Olum|(37.13300090,54.61230750);Aq Qala|(37.16667000,54.58333000)"
+Iran,IR,Hamadan,Hamadan,Tehran,,,34.80000000,48.51666667,Ab Meshkin;Abarlaq-e Sofla;Abdalan,"Ab Meshkin|(35.61305556,48.26916667);Abarlaq-e Sofla|(34.67138889,48.22833333);Abdalan|(34.65277778,48.24555556)"
+Iran,IR,Hormozgan,Abu Musa,Tehran,,,26.05474000,55.16243000,Abu Musa;Abumusa;Bandar Abbas,"Abu Musa|(26.05474000,55.16243000);Abumusa|(27.19805600,54.36861100);Bandar Abbas|(27.18650000,56.28080000)"
+Iran,IR,Ilam,Ilam,Tehran,,,33.63740000,46.42270000,abdanan;Arkavaz;Aseman Abad,"abdanan|(32.99260000,47.41980000);Arkavaz|(33.38544050,46.57578680);Aseman Abad|(33.85182450,46.44400060)"
+Iran,IR,Isfahan,Isfahan,Tehran,,,32.65246000,51.67462000,Abouzeidabad;Abrisham;Afus,"Abouzeidabad|(33.90165760,51.74337370);Abrisham|(32.55613000,51.57325000);Afus|(33.02495550,50.08812900)"
+Iran,IR,Kerman,Kerman,Tehran,,,30.28321000,57.07879000,Aminshahr;Anar;Anbarabad,"Aminshahr|(30.84221360,55.33205130);Anar|(30.85000000,55.35000000);Anbarabad|(28.43333000,58.16667000)"
+Iran,IR,Kermanshah,Kermanshah,Tehran,,,34.31417000,47.06500000,azeh Abad;Banevreh;Bayangan,"azeh Abad|(34.49698980,47.04017400);Banevreh|(34.96917880,46.35028830);Bayangan|(34.98088040,46.26785870)"
+Iran,IR,Khuzestan,Abadan,Tehran,,,30.33920000,48.30430000,Abadan;Abezhdan;Abou Homeyzeh,"Abadan|(30.33920000,48.30430000);Abezhdan|(32.15000000,49.40000000);Abou Homeyzeh|(31.52809530,48.21535710)"
+Iran,IR,Kohgiluyeh and Boyer-Ahmad,Bahmai,Tehran,,,31.05000000,50.08333000,Bahmai;Basht;Charam,"Bahmai|(31.05000000,50.08333000);Basht|(30.45000000,51.11667000);Charam|(30.76667000,50.85000000)"
+Iran,IR,Kurdistan,Armardeh,Tehran,,,35.93224610,45.79138040,Armardeh;Babarashani;Baneh,"Armardeh|(35.93224610,45.79138040);Babarashani|(35.67817150,47.79385330);Baneh|(35.99750000,45.88530000)"
+Iran,IR,Lorestan,Aleshtar,Tehran,,,33.86419000,48.26258000,Aleshtar;Aligudarz;Azna,"Aleshtar|(33.86419000,48.26258000);Aligudarz|(33.40400000,49.69179000);Azna|(33.45643000,49.45646000)"
+Iran,IR,Markazi,Abyek,Tehran,,,36.06667000,50.55000000,Abyek;Arak;Ashtian,"Abyek|(36.06667000,50.55000000);Arak|(34.09493000,49.69809000);Ashtian|(34.45000000,50.05000000)"
+Iran,IR,Mazandaran,Abbasabad,Tehran,,,36.63333000,51.15000000,Abbasabad;Alasht;Amir Kala,"Abbasabad|(36.63333000,51.15000000);Alasht|(36.06550040,52.83250090);Amir Kala|(36.59866300,52.65631190)"
+Iran,IR,North Khorasan,Ashkhaneh,Tehran,,,37.55917080,56.90694800,Ashkhaneh;Ava;Bojnurd,"Ashkhaneh|(37.55917080,56.90694800);Ava|(37.47722200,56.74111100);Bojnurd|(37.47473000,57.32903000)"
+Iran,IR,Qazvin,Qazvin,Tehran,,,36.26877000,50.00410000,Abgarm;Abyek;Alborz,"Abgarm|(35.75687280,49.27735090);Abyek|(36.04711650,50.51818350);Alborz|(36.18861000,50.07829000)"
+Iran,IR,Qom,Qom,Tehran,,,34.64010000,50.87640000,Dastjerd;Jafarie;Kahak,"Dastjerd|(34.55380730,50.23906220);Jafarie|(34.77450740,50.50651060);Kahak|(34.39196580,50.85463990)"
+Iran,IR,Razavi Khorasan,Ahmad-abad-e-Solat,Tehran,,,35.11510780,60.68452830,Ahmad-abad-e-Solat;Anabad;Bajestan,"Ahmad-abad-e-Solat|(35.11510780,60.68452830);Anabad|(35.25017460,57.80098200);Bajestan|(34.58333000,58.13333000)"
+Iran,IR,Semnan,Semnan,Tehran,,,35.57691000,53.39205000,Amiriyeh;Aradan;Bastam,"Amiriyeh|(36.02872950,54.13541820);Aradan|(35.24814880,52.48640420);Bastam|(36.48439080,54.99071350)"
+Iran,IR,Sistan and Baluchestan,Adimi,Tehran,,,31.11497090,61.39258850,Adimi;Bampour;Bazmān,"Adimi|(31.11497090,61.39258850);Bampour|(27.19519200,60.44720640);Bazmān|(27.85550560,60.16714090)"
+Iran,IR,South Khorasan,Arian Shahr,Tehran,,,33.33146920,59.22934410,Arian Shahr;Asadieh;Ayask,"Arian Shahr|(33.33146920,59.22934410);Asadieh|(32.91389070,60.01498450);Ayask|(33.88666690,58.36903090)"
+Iran,IR,Tehran,Tehran,Tehran,,,35.69439000,51.42151000,Abali;Absard;Ahmadabad-E Mostowfi,"Abali|(35.76759600,51.94129930);Absard|(35.62931440,52.13407450);Ahmadabad-E Mostowfi|(35.63518510,51.20369200)"
+Iran,IR,West Azarbaijan,Avajiq,Tehran,,,39.31388900,44.16472200,Avajiq;Baruq;Bazargan,"Avajiq|(39.31388900,44.16472200);Baruq|(36.95302880,46.31413220);Bazargan|(39.39093260,44.37321590)"
+Iran,IR,Yazd,Yazd,Tehran,,,31.89722000,54.36750000,Abarkooh;Abarkuh;Ahmadabad,"Abarkooh|(31.12628100,53.22159240);Abarkuh|(31.00000000,53.41667000);Ahmadabad|(32.35666700,53.99194400)"
+Iran,IR,Zanjan,Zanjan,Tehran,,,36.67642000,48.49628000,Abbar;Abhar;Alvand,"Abbar|(36.92958670,48.93254920);Abhar|(36.14680000,49.21800000);Alvand|(36.31885000,49.16773000)"
+Iraq,IQ,Al Anbar,‘Anah,Baghdad,,,34.36857000,41.98194000,‘Anah;‘Anat al Qadīmah;Al Fallūjah,"‘Anah|(34.36857000,41.98194000);‘Anat al Qadīmah|(34.46934000,41.94223000);Al Fallūjah|(33.34913000,43.78599000)"
+Iraq,IQ,Al Muthanna,Ar Rumaythah,Baghdad,,,31.52845000,45.20377000,Ar Rumaythah;As Samawah,"Ar Rumaythah|(31.52845000,45.20377000);As Samawah|(31.33198000,45.29440000)"
+Iraq,IQ,Al-Qādisiyyah,‘Afak,Baghdad,,,32.06430000,45.24743000,‘Afak;Ad Dīwānīyah;Ash Shāmīyah,"‘Afak|(32.06430000,45.24743000);Ad Dīwānīyah|(31.99289000,44.92552000);Ash Shāmīyah|(31.96257000,44.60075000)"
+Iraq,IQ,Babylon,Al Ḩillah,Baghdad,,,32.46367000,44.41963000,Al Ḩillah;Al Musayyib;Imam Qasim,"Al Ḩillah|(32.46367000,44.41963000);Al Musayyib|(32.77872000,44.29005000);Imam Qasim|(32.29799000,44.68282000)"
+Iraq,IQ,Baghdad,Baghdad,Baghdad,,,33.34058000,44.40088000,Abu Ghraib District;Abū Ghurayb;Adamiyah,"Abu Ghraib District|(33.29194000,44.06919000);Abū Ghurayb|(33.30563000,44.18477000);Adamiyah|(33.36917800,44.33955940)"
+Iraq,IQ,Basra,Al Başrah al Qadīmah,Baghdad,,,30.50316000,47.81507000,Al Başrah al Qadīmah;Al Fāw;Al Hārithah,"Al Başrah al Qadīmah|(30.50316000,47.81507000);Al Fāw|(29.97421000,48.47309000);Al Hārithah|(30.58481000,47.76114000)"
+Iraq,IQ,Dhi Qar,Ash Shaţrah,Baghdad,,,31.40906000,46.17270000,Ash Shaţrah;Nāḩiyat al Fuhūd;Nasiriyah,"Ash Shaţrah|(31.40906000,46.17270000);Nāḩiyat al Fuhūd|(30.96972000,46.72278000);Nasiriyah|(31.05799000,46.25726000)"
+Iraq,IQ,Diyala,Al Miqdādīyah,Baghdad,,,33.97861000,44.93694000,Al Miqdādīyah;Baladrūz;Baqubah,"Al Miqdādīyah|(33.97861000,44.93694000);Baladrūz|(33.69631000,45.07782000);Baqubah|(33.75403000,44.60518000)"
+Iraq,IQ,Dohuk,Al ‘Amādīyah,Baghdad,,,37.09214000,43.48769000,Al ‘Amādīyah;Batifa;Dihok,"Al ‘Amādīyah|(37.09214000,43.48769000);Batifa|(37.17454000,43.01233000);Dihok|(36.86709000,42.98845000)"
+Iraq,IQ,Erbil,Erbil,Baghdad,,,36.18333000,44.01193000,Arbil;Erbil;Koysinceq,"Arbil|(36.19070000,44.00947000);Erbil|(36.18333000,44.01193000);Koysinceq|(36.08289000,44.62873000)"
+Iraq,IQ,Karbala,Karbala,Baghdad,,,32.61603000,44.02488000,Al Hindīyah;Karbala,"Al Hindīyah|(32.54671000,44.22765000);Karbala|(32.61603000,44.02488000)"
+Iraq,IQ,Kirkuk,Kirkuk,Baghdad,,,35.46806000,44.39222000,Kirkuk,"Kirkuk|(35.46806000,44.39222000)"
+Iraq,IQ,Maysan,‘Alī al Gharbī,Baghdad,,,32.46186000,46.68794000,‘Alī al Gharbī;Al ‘Amārah;Al-Mejar Al-Kabi District,"‘Alī al Gharbī|(32.46186000,46.68794000);Al ‘Amārah|(31.83561000,47.14483000);Al-Mejar Al-Kabi District|(31.42940000,47.20355000)"
+Iraq,IQ,Najaf,Najaf,Baghdad,,,32.02594000,44.34625000,Al Mishkhāb;Kufa;Najaf,"Al Mishkhāb|(31.80437000,44.48930000);Kufa|(32.05114000,44.44017000);Najaf|(32.02594000,44.34625000)"
+Iraq,IQ,Nineveh,‘Aqrah,Baghdad,,,36.76038000,43.89428000,‘Aqrah;Al Mawşil al Jadīdah;Al-Hamdaniya,"‘Aqrah|(36.76038000,43.89428000);Al Mawşil al Jadīdah|(36.33271000,43.10555000);Al-Hamdaniya|(36.27093000,43.37758000)"
+Iraq,IQ,Saladin,Ad Dujayl,Baghdad,,,33.84667000,44.23444000,Ad Dujayl;Balad;Bayjī,"Ad Dujayl|(33.84667000,44.23444000);Balad|(34.01485000,44.14574000);Bayjī|(34.92915000,43.48878000)"
+Iraq,IQ,Sulaymaniyah,As Sulaymānīyah,Baghdad,,,35.56496000,45.43290000,As Sulaymānīyah;Baynjiwayn;Ḩalabjah,"As Sulaymānīyah|(35.56496000,45.43290000);Baynjiwayn|(35.62054000,45.94908000);Ḩalabjah|(35.17778000,45.98611000)"
+Iraq,IQ,Wasit,Al ‘Azīzīyah,Baghdad,,,32.90941000,45.06359000,Al ‘Azīzīyah;Al Ḩayy;Al Kūt,"Al ‘Azīzīyah|(32.90941000,45.06359000);Al Ḩayy|(32.17419000,46.04345000);Al Kūt|(32.51280000,45.81817000)"
+Ireland,IE,Carlow,,Dublin,,,,,,
+Ireland,IE,Cavan,,Dublin,,,,,,
+Ireland,IE,Clare,,Dublin,,,,,,
+Ireland,IE,Connacht,Athenry,Dublin,,,53.29639000,-8.74306000,Athenry;Ballaghaderreen;Ballina,"Athenry|(53.29639000,-8.74306000);Ballaghaderreen|(53.90000000,-8.58333000);Ballina|(54.11667000,-9.16667000)"
+Ireland,IE,Cork,,Dublin,,,,,,
+Ireland,IE,Donegal,,Dublin,,,,,,
+Ireland,IE,Dublin,,Dublin,,,,,,
+Ireland,IE,Galway,,Dublin,,,,,,
+Ireland,IE,Kerry,,Dublin,,,,,,
+Ireland,IE,Kildare,,Dublin,,,,,,
+Ireland,IE,Kilkenny,,Dublin,,,,,,
+Ireland,IE,Laois,,Dublin,,,,,,
+Ireland,IE,Leinster,Abbeyleix,Dublin,,,52.91331000,-7.34456000,Abbeyleix;An Iarmhí;An Longfort,"Abbeyleix|(52.91331000,-7.34456000);An Iarmhí|(53.50000000,-7.50000000);An Longfort|(53.66667000,-7.75000000)"
+Ireland,IE,Leitrim,,Dublin,,,,,,
+Ireland,IE,Limerick,,Dublin,,,,,,
+Ireland,IE,Longford,,Dublin,,,,,,
+Ireland,IE,Louth,,Dublin,,,,,,
+Ireland,IE,Mayo,,Dublin,,,,,,
+Ireland,IE,Meath,,Dublin,,,,,,
+Ireland,IE,Monaghan,,Dublin,,,,,,
+Ireland,IE,Munster,Abbeyfeale,Dublin,,,52.38139000,-9.30250000,Abbeyfeale;Adare;Aghada,"Abbeyfeale|(52.38139000,-9.30250000);Adare|(52.56194000,-8.79556000);Aghada|(51.83917000,-8.21222000)"
+Ireland,IE,Offaly,,Dublin,,,,,,
+Ireland,IE,Roscommon,,Dublin,,,,,,
+Ireland,IE,Sligo,,Dublin,,,,,,
+Ireland,IE,Tipperary,,Dublin,,,,,,
+Ireland,IE,Ulster,An Cabhán,Dublin,,,53.91667000,-7.25000000,An Cabhán;Bailieborough;Ballybofey,"An Cabhán|(53.91667000,-7.25000000);Bailieborough|(53.91667000,-6.96667000);Ballybofey|(54.80000000,-7.78333000)"
+Ireland,IE,Waterford,,Dublin,,,,,,
+Ireland,IE,Westmeath,,Dublin,,,,,,
+Ireland,IE,Wexford,,Dublin,,,,,,
+Ireland,IE,Wicklow,,Dublin,,,,,,
+Israel,IL,Central,Bet Dagan,Jerusalem,,,32.00191000,34.82977000,Bet Dagan;Bet Yiẕẖaq;Bnei Ayish,"Bet Dagan|(32.00191000,34.82977000);Bet Yiẕẖaq|(32.32751000,34.88878000);Bnei Ayish|(31.78333000,34.75000000)"
+Israel,IL,Haifa,Haifa,Jerusalem,,,32.81841000,34.98850000,Atlit;Caesarea;Daliyat al Karmel,"Atlit|(32.68889000,34.94236000);Caesarea|(32.51888000,34.90459000);Daliyat al Karmel|(32.69383000,35.04686000)"
+Israel,IL,Jerusalem,Jerusalem,Jerusalem,,,31.76904000,35.21633000,Abū Ghaush;Bet Shemesh;Har Adar,"Abū Ghaush|(31.80592000,35.10930000);Bet Shemesh|(31.73072000,34.99293000);Har Adar|(31.82754000,35.13093000)"
+Israel,IL,Northern,‘Eilabun,Jerusalem,,,32.83693000,35.40029000,‘Eilabun;‘Uzeir;Acre,"‘Eilabun|(32.83693000,35.40029000);‘Uzeir|(32.79212000,35.32984000);Acre|(32.92814000,35.07647000)"
+Israel,IL,Southern,‘En Boqeq,Jerusalem,,,31.19941000,35.36253000,‘En Boqeq;Arad;Ashdod,"‘En Boqeq|(31.19941000,35.36253000);Arad|(31.25882000,35.21282000);Ashdod|(31.79213000,34.64966000)"
+Israel,IL,Tel Aviv,Tel Aviv,Jerusalem,,,32.08088000,34.78057000,Azor;Bat Yam;Bnei Brak,"Azor|(32.02430000,34.80632000);Bat Yam|(32.02379000,34.75185000);Bnei Brak|(32.08074000,34.83380000)"
+Italy,IT,Abruzzo,Abbateggio,Rome,,,42.22421000,14.01001000,Abbateggio;Acciano;Aielli,"Abbateggio|(42.22421000,14.01001000);Acciano|(42.17677000,13.71783000);Aielli|(42.08146000,13.59113000)"
+Italy,IT,Agrigento,,Rome,,,,,,
+Italy,IT,Alessandria,,Rome,,,,,,
+Italy,IT,Ancona,,Rome,,,,,,
+Italy,IT,Aosta Valley,Allein,Rome,,,45.80723000,7.27262000,Allein;Antagnod;Antey-Saint-Andrè,"Allein|(45.80723000,7.27262000);Antagnod|(45.81484000,7.68931000);Antey-Saint-Andrè|(45.80603000,7.58666000)"
+Italy,IT,Apulia,Accadia,Rome,,,41.15768000,15.33100000,Accadia;Acquarica del Capo;Acquaviva delle Fonti,"Accadia|(41.15768000,15.33100000);Acquarica del Capo|(39.90979000,18.24680000);Acquaviva delle Fonti|(40.89704000,16.84330000)"
+Italy,IT,Arezzo,,Rome,,,,,,
+Italy,IT,Ascoli Piceno,,Rome,,,,,,
+Italy,IT,Asti,,Rome,,,,,,
+Italy,IT,Avellino,,Rome,,,,,,
+Italy,IT,Barletta-Andria-Trani,Andria,Rome,,,41.23117000,16.29797000,Andria;Barletta;Bisceglie,"Andria|(41.23117000,16.29797000);Barletta|(41.31429000,16.28165000);Bisceglie|(41.24264000,16.50104000)"
+Italy,IT,Basilicata,Abriola,Rome,,,40.50748000,15.81310000,Abriola;Accettura;Acerenza,"Abriola|(40.50748000,15.81310000);Accettura|(40.49102000,16.15798000);Acerenza|(40.79386000,15.93808000)"
+Italy,IT,Belluno,,Rome,,,,,,
+Italy,IT,Benevento,,Rome,,,,,,
+Italy,IT,Bergamo,,Rome,,,,,,
+Italy,IT,Biella,,Rome,,,,,,
+Italy,IT,Brescia,,Rome,,,,,,
+Italy,IT,Brindisi,,Rome,,,,,,
+Italy,IT,Calabria,Acconia,Rome,,,38.83585000,16.26530000,Acconia;Acquaformosa;Acquappesa,"Acconia|(38.83585000,16.26530000);Acquaformosa|(39.72278000,16.09096000);Acquappesa|(39.49573000,15.95419000)"
+Italy,IT,Caltanissetta,,Rome,,,,,,
+Italy,IT,Campania,Acerno,Rome,,,40.73771000,15.05695000,Acerno;Acerra;Afragola,"Acerno|(40.73771000,15.05695000);Acerra|(40.94477000,14.37140000);Afragola|(40.92298000,14.30935000)"
+Italy,IT,Campobasso,,Rome,,,,,,
+Italy,IT,Caserta,,Rome,,,,,,
+Italy,IT,Catanzaro,,Rome,,,,,,
+Italy,IT,Chieti,,Rome,,,,,,
+Italy,IT,Como,,Rome,,,,,,
+Italy,IT,Cosenza,,Rome,,,,,,
+Italy,IT,Cremona,,Rome,,,,,,
+Italy,IT,Crotone,,Rome,,,,,,
+Italy,IT,Cuneo,,Rome,,,,,,
+Italy,IT,Emilia-Romagna,Agazzano,Rome,,,44.94726000,9.51875000,Agazzano;Albareto;Alberi,"Agazzano|(44.94726000,9.51875000);Albareto|(44.44692000,9.70228000);Alberi|(44.74837000,10.33045000)"
+Italy,IT,Enna,,Rome,,,,,,
+Italy,IT,Fermo,,Rome,,,,,,
+Italy,IT,Ferrara,,Rome,,,,,,
+Italy,IT,Foggia,,Rome,,,,,,
+Italy,IT,Forlì-Cesena,,Rome,,,,,,
+Italy,IT,Friuli–Venezia Giulia,Aiello del Friuli,Rome,,,45.87276000,13.36038000,Aiello del Friuli;Amaro;Ampezzo,"Aiello del Friuli|(45.87276000,13.36038000);Amaro|(46.37367000,13.09368000);Ampezzo|(46.41459000,12.79634000)"
+Italy,IT,Frosinone,,Rome,,,,,,
+Italy,IT,Gorizia,,Rome,,,,,,
+Italy,IT,Grosseto,,Rome,,,,,,
+Italy,IT,Imperia,,Rome,,,,,,
+Italy,IT,Isernia,,Rome,,,,,,
+Italy,IT,L'Aquila,,Rome,,,,,,
+Italy,IT,La Spezia,,Rome,,,,,,
+Italy,IT,Latina,,Rome,,,,,,
+Italy,IT,Lazio,Accumoli,Rome,,,42.69476000,13.24761000,Accumoli;Acilia-Castel Fusano-Ostia Antica;Acquafondata,"Accumoli|(42.69476000,13.24761000);Acilia-Castel Fusano-Ostia Antica|(41.76337000,12.33078000);Acquafondata|(41.54282000,13.95281000)"
+Italy,IT,Lecce,,Rome,,,,,,
+Italy,IT,Lecco,,Rome,,,,,,
+Italy,IT,Liguria,Airole,Rome,,,43.87092000,7.55414000,Airole;Alassio;Albenga,"Airole|(43.87092000,7.55414000);Alassio|(44.00393000,8.16713000);Albenga|(44.04997000,8.21829000)"
+Italy,IT,Livorno,,Rome,,,,,,
+Italy,IT,Lodi,,Rome,,,,,,
+Italy,IT,Lombardy,Abbadia Cerreto,Rome,,,45.31217000,9.59416000,Abbadia Cerreto;Abbadia Lariana;Abbazia,"Abbadia Cerreto|(45.31217000,9.59416000);Abbadia Lariana|(45.89947000,9.33518000);Abbazia|(45.74800000,9.84205000)"
+Italy,IT,Lucca,,Rome,,,,,,
+Italy,IT,Macerata,,Rome,,,,,,
+Italy,IT,Mantua,,Rome,,,,,,
+Italy,IT,Marche,Acqualagna,Rome,,,43.62606000,12.67596000,Acqualagna;Acquasanta Terme;Acquaviva Picena,"Acqualagna|(43.62606000,12.67596000);Acquasanta Terme|(42.77084000,13.41418000);Acquaviva Picena|(42.94037000,13.82227000)"
+Italy,IT,Massa and Carrara,,Rome,,,,,,
+Italy,IT,Matera,,Rome,,,,,,
+Italy,IT,Modena,,Rome,,,,,,
+Italy,IT,Molise,Molise,Rome,,,41.63147000,14.49252000,Acquaviva Collecroce;Acquaviva d'Isernia;Agnone,"Acquaviva Collecroce|(41.86624000,14.74733000);Acquaviva d'Isernia|(41.67132000,14.14770000);Agnone|(41.81043000,14.37524000)"
+Italy,IT,Monza and Brianza,,Rome,,,,,,
+Italy,IT,Novara,,Rome,,,,,,
+Italy,IT,Nuoro,,Rome,,,,,,
+Italy,IT,Oristano,,Rome,,,,,,
+Italy,IT,Padua,,Rome,,,,,,
+Italy,IT,Palermo,,Rome,,,,,,
+Italy,IT,Parma,,Rome,,,,,,
+Italy,IT,Pavia,,Rome,,,,,,
+Italy,IT,Perugia,,Rome,,,,,,
+Italy,IT,Pesaro and Urbino,,Rome,,,,,,
+Italy,IT,Pescara,,Rome,,,,,,
+Italy,IT,Piacenza,,Rome,,,,,,
+Italy,IT,Piedmont,Acceglio,Rome,,,44.47463000,6.99092000,Acceglio;Acqui Terme;Agliano,"Acceglio|(44.47463000,6.99092000);Acqui Terme|(44.67552000,8.46934000);Agliano|(44.79164000,8.25124000)"
+Italy,IT,Pisa,,Rome,,,,,,
+Italy,IT,Pistoia,,Rome,,,,,,
+Italy,IT,Pordenone,,Rome,,,,,,
+Italy,IT,Potenza,,Rome,,,,,,
+Italy,IT,Prato,,Rome,,,,,,
+Italy,IT,Ragusa,,Rome,,,,,,
+Italy,IT,Ravenna,Ravenna,Rome,,,44.41344000,12.20121000,Alfonsine;Bagnacavallo;Bagnara di Romagna,"Alfonsine|(44.50768000,12.03743000);Bagnacavallo|(44.41402000,11.97813000);Bagnara di Romagna|(44.38930000,11.82726000)"
+Italy,IT,Reggio Emilia,,Rome,,,,,,
+Italy,IT,Rieti,,Rome,,,,,,
+Italy,IT,Rimini,,Rome,,,,,,
+Italy,IT,Rovigo,,Rome,,,,,,
+Italy,IT,Salerno,,Rome,,,,,,
+Italy,IT,Sardinia,Abbasanta,Rome,,,40.12812000,8.81760000,Abbasanta;Aggius;Aglientu,"Abbasanta|(40.12812000,8.81760000);Aggius|(40.92995000,9.06517000);Aglientu|(41.07906000,9.11267000)"
+Italy,IT,Sassari,,Rome,,,,,,
+Italy,IT,Savona,,Rome,,,,,,
+Italy,IT,Sicily,Acate,Rome,,,37.02318000,14.49302000,Acate;Aci Bonaccorsi;Aci Castello,"Acate|(37.02318000,14.49302000);Aci Bonaccorsi|(37.59640000,15.10724000);Aci Castello|(37.55564000,15.14535000)"
+Italy,IT,Siena,,Rome,,,,,,
+Italy,IT,Siracusa,,Rome,,,,,,
+Italy,IT,Sondrio,,Rome,,,,,,
+Italy,IT,South Sardinia,,Rome,,,,,,
+Italy,IT,Taranto,,Rome,,,,,,
+Italy,IT,Teramo,,Rome,,,,,,
+Italy,IT,Terni,,Rome,,,,,,
+Italy,IT,Trapani,,Rome,,,,,,
+Italy,IT,Trentino-South Tyrol,Ala,Rome,,,45.76072000,11.00458000,Ala;Albiano;Aldeno,"Ala|(45.76072000,11.00458000);Albiano|(46.14451000,11.19459000);Aldeno|(45.97758000,11.09276000)"
+Italy,IT,Treviso,,Rome,,,,,,
+Italy,IT,Trieste,,Rome,,,,,,
+Italy,IT,Tuscany,Abbadia San Salvatore,Rome,,,42.88120000,11.67220000,Abbadia San Salvatore;Abetone;Acquaviva,"Abbadia San Salvatore|(42.88120000,11.67220000);Abetone|(44.14595000,10.66407000);Acquaviva|(43.11566000,11.86249000)"
+Italy,IT,Udine,,Rome,,,,,,
+Italy,IT,Umbria,Acquasparta,Rome,,,42.68915000,12.54275000,Acquasparta;Allerona;Alviano,"Acquasparta|(42.68915000,12.54275000);Allerona|(42.81174000,11.97451000);Alviano|(42.59084000,12.29775000)"
+Italy,IT,Varese,,Rome,,,,,,
+Italy,IT,Veneto,Abano Terme,Rome,,,45.35753000,11.78725000,Abano Terme;Abbazia Pisani;Adria,"Abano Terme|(45.35753000,11.78725000);Abbazia Pisani|(45.61270000,11.85429000);Adria|(45.05445000,12.05599000)"
+Italy,IT,Verbano-Cusio-Ossola,,Rome,,,,,,
+Italy,IT,Vercelli,,Rome,,,,,,
+Italy,IT,Verona,,Rome,,,,,,
+Italy,IT,Vibo Valentia,,Rome,,,,,,
+Italy,IT,Vicenza,,Rome,,,,,,
+Italy,IT,Viterbo,,Rome,,,,,,
+Ivory Coast,CI,Abidjan,Abidjan,Yamoussoukro,,,5.30966000,-4.01266000,Abidjan;Abobo;Anyama,"Abidjan|(5.30966000,-4.01266000);Abobo|(5.41613000,-4.01590000);Anyama|(5.49462000,-4.05183000)"
+Ivory Coast,CI,Agnéby,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Bafing,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Bas-Sassandra,Gbôklé,Yamoussoukro,,,4.95712000,-6.09372000,Gbôklé;Nawa;San-Pédro,"Gbôklé|(4.95712000,-6.09372000);Nawa|(5.80112000,-6.60313000);San-Pédro|(4.76768000,-6.65033000)"
+Ivory Coast,CI,Comoé,Abengourou,Yamoussoukro,,,6.72972000,-3.49639000,Abengourou;Aboisso;Adiaké,"Abengourou|(6.72972000,-3.49639000);Aboisso|(5.46779000,-3.20711000);Adiaké|(5.28634000,-3.30403000)"
+Ivory Coast,CI,Denguélé,Folon,Yamoussoukro,,,9.81241000,-7.51894000,Folon;Kabadougou;Odienné,"Folon|(9.81241000,-7.51894000);Kabadougou|(9.60571000,-7.43774000);Odienné|(9.50511000,-7.56433000)"
+Ivory Coast,CI,Dix-Huit Montagnes,Bangolo,Yamoussoukro,,,7.01232000,-7.48639000,Bangolo;Biankouma;Cavally,"Bangolo|(7.01232000,-7.48639000);Biankouma|(7.73909000,-7.61377000);Cavally|(6.56343000,-7.92526000)"
+Ivory Coast,CI,Fromager,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Gôh-Djiboua,Divo,Yamoussoukro,,,5.83739000,-5.35723000,Divo;Gagnoa;Gôh,"Divo|(5.83739000,-5.35723000);Gagnoa|(6.13193000,-5.95060000);Gôh|(6.14459000,-5.92644000)"
+Ivory Coast,CI,Haut-Sassandra,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Lacs,Arrah,Yamoussoukro,,,6.67342000,-3.96938000,Arrah;Bélier;Bocanda,"Arrah|(6.67342000,-3.96938000);Bélier|(7.02582000,-5.06744000);Bocanda|(7.06264000,-4.49948000)"
+Ivory Coast,CI,Lagunes,Adzopé,Yamoussoukro,,,6.10694000,-3.86194000,Adzopé;Affery;Agboville,"Adzopé|(6.10694000,-3.86194000);Affery|(6.32035000,-3.95235000);Agboville|(5.92801000,-4.21319000)"
+Ivory Coast,CI,Marahoué,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Montagnes,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Moyen-Cavally,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Moyen-Comoé,,Yamoussoukro,,,,,,
+Ivory Coast,CI,N'zi-Comoé,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Sassandra-Marahoué,Bouaflé,Yamoussoukro,,,6.99041000,-5.74420000,Bouaflé;Daloa;Haut-Sassandra,"Bouaflé|(6.99041000,-5.74420000);Daloa|(6.87735000,-6.45022000);Haut-Sassandra|(6.66961000,-6.50116000)"
+Ivory Coast,CI,Savanes,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Sud-Bandama,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Sud-Comoé,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Vallée du Bandama,Béoumi,Yamoussoukro,,,7.67395000,-5.58085000,Béoumi;Botro;Bouaké,"Béoumi|(7.67395000,-5.58085000);Botro|(7.85249000,-5.31063000);Bouaké|(7.69385000,-5.03031000)"
+Ivory Coast,CI,Woroba,Bafing,Yamoussoukro,,,8.40611000,-7.58048000,Bafing;Béré;Mankono,"Bafing|(8.40611000,-7.58048000);Béré|(8.18952000,-6.17157000);Mankono|(8.05861000,-6.18972000)"
+Ivory Coast,CI,Worodougou,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Yamoussoukro,,Yamoussoukro,,,,,,
+Ivory Coast,CI,Zanzan,Bondoukou,Yamoussoukro,,,8.04020000,-2.80003000,Bondoukou;Bouna;Bounkani,"Bondoukou|(8.04020000,-2.80003000);Bouna|(9.26927000,-2.99510000);Bounkani|(9.47841000,-3.31238000)"
+Jamaica,JM,Clarendon,Aenon Town,Kingston,,,18.21027000,-77.39851000,Aenon Town;Alley;Alston,"Aenon Town|(18.21027000,-77.39851000);Alley|(17.79036000,-77.27085000);Alston|(18.17639000,-77.43468000)"
+Jamaica,JM,Hanover,Askenish,Kingston,,,18.38492000,-78.14910000,Askenish;Cacoon;Cacoon Castle,"Askenish|(18.38492000,-78.14910000);Cacoon|(18.41642000,-78.20730000);Cacoon Castle|(18.40247000,-78.01336000)"
+Jamaica,JM,Kingston,Kingston,Kingston,,,17.99702000,-76.79358000,Allman Town;Bournemouth Gardens;Campbell Town,"Allman Town|(17.98297000,-76.78685000);Bournemouth Gardens|(17.97009000,-76.76266000);Campbell Town|(17.97914000,-76.78134000)"
+Jamaica,JM,Manchester,Alligator Pond,Kingston,,,17.88369000,-77.56068000,Alligator Pond;Asia/Pratville;Auchtembeddie,"Alligator Pond|(17.88369000,-77.56068000);Asia/Pratville|(17.91584000,-77.41563000);Auchtembeddie|(18.22543000,-77.60361000)"
+Jamaica,JM,Portland,Balcarres,Kingston,,,18.16735000,-76.72061000,Balcarres;Bangor Ridge;Belvedere,"Balcarres|(18.16735000,-76.72061000);Bangor Ridge|(18.13637000,-76.68903000);Belvedere|(18.20772000,-76.69671000)"
+Jamaica,JM,Saint Andrew,Arcadia,Kingston,,,18.03737000,-76.78201000,Arcadia;Arlene Gardens;Arnett Gardens,"Arcadia|(18.03737000,-76.78201000);Arlene Gardens|(18.03713000,-76.81791000);Arnett Gardens|(17.99150000,-76.79829000)"
+Jamaica,JM,Saint Ann,Aboukir,Kingston,,,18.25090000,-77.34327000,Aboukir;Alderton;Alexandria,"Aboukir|(18.25090000,-77.34327000);Alderton|(18.28706000,-77.20832000);Alexandria|(18.30411000,-77.35311000)"
+Jamaica,JM,Saint Catherine,Above Rocks,Kingston,,,18.11432000,-76.87590000,Above Rocks;Bartons;Bellas Gate,"Above Rocks|(18.11432000,-76.87590000);Bartons|(18.02895000,-77.13322000);Bellas Gate|(18.04715000,-77.14906000)"
+Jamaica,JM,Saint Elizabeth,Aberdeen,Kingston,,,18.20508000,-77.67932000,Aberdeen;Accompong;Alligator Pond,"Aberdeen|(18.20508000,-77.67932000);Accompong|(18.22985000,-77.74816000);Alligator Pond|(17.86932000,-77.56769000)"
+Jamaica,JM,Saint James,Adelphi,Kingston,,,18.45060000,-77.78590000,Adelphi;Albion;Anchovy,"Adelphi|(18.45060000,-77.78590000);Albion|(18.48471000,-77.91408000);Anchovy|(18.41030000,-77.93166000)"
+Jamaica,JM,Saint Mary,Amiel Town,Kingston,,,18.34027000,-76.97612000,Amiel Town;Annotto Bay;Baileys Vale,"Amiel Town|(18.34027000,-76.97612000);Annotto Bay|(18.27170000,-76.76523000);Baileys Vale|(18.34527000,-76.92593000)"
+Jamaica,JM,Saint Thomas,Airy Castle,Kingston,,,17.92506000,-76.34216000,Airy Castle;Albion;Amity Hall,"Airy Castle|(17.92506000,-76.34216000);Albion|(17.90119000,-76.60761000);Amity Hall|(17.96759000,-76.25698000)"
+Jamaica,JM,Trelawny,Albert Town,Kingston,,,18.29434000,-77.54239000,Albert Town;Alps;Bounty Hall,"Albert Town|(18.29434000,-77.54239000);Alps|(18.35498000,-77.50897000);Bounty Hall|(18.45801000,-77.71663000)"
+Jamaica,JM,Westmoreland,12th Street,Kingston,,,18.21097000,-78.13603000,12th Street;Amity;Ashton,"12th Street|(18.21097000,-78.13603000);Amity|(18.27361000,-77.89805000);Ashton|(18.23139000,-77.92074000)"
+Japan,JP,Aichi,Aisai-shi,Tokyo,,,35.17234000,136.69478000,Aisai-shi;Ama-gun;Anjō-shi,"Aisai-shi|(35.17234000,136.69478000);Ama-gun|(35.17174000,136.82308000);Anjō-shi|(34.94341000,137.07165000)"
+Japan,JP,Akita,Akita,Tokyo,,,39.71667000,140.11667000,Akita;Akita Shi;Daisen,"Akita|(39.71667000,140.11667000);Akita Shi|(39.71043000,140.23207000);Daisen|(39.44116000,140.48961000)"
+Japan,JP,Aomori,Aomori,Tokyo,,,40.81667000,140.73333000,Aomori;Aomori Shi;Goshogawara,"Aomori|(40.81667000,140.73333000);Aomori Shi|(40.77001000,140.75423000);Goshogawara|(40.80444000,140.44139000)"
+Japan,JP,Chiba,Chiba,Tokyo,,,35.60000000,140.11667000,Abiko;Abiko-shi;Asahi-shi,"Abiko|(35.86667000,140.01667000);Abiko-shi|(35.86947000,140.06510000);Asahi-shi|(35.73443000,140.65549000)"
+Japan,JP,Ehime,Hōjō,Tokyo,,,33.97661000,132.77767000,Hōjō;Imabari-shi;Iyo,"Hōjō|(33.97661000,132.77767000);Imabari-shi|(34.06667000,132.99791000);Iyo|(33.75139000,132.70139000)"
+Japan,JP,Fukui,Asahi,Tokyo,,,35.97259000,136.12455000,Asahi;Awara-shi;Echizen-shi,"Asahi|(35.97259000,136.12455000);Awara-shi|(36.22777000,136.25154000);Echizen-shi|(35.88946000,136.17723000)"
+Japan,JP,Fukuoka,Fukuoka,Tokyo,,,33.60000000,130.41667000,Amagi;Asakura Shi;Buzen,"Amagi|(33.41804000,130.65413000);Asakura Shi|(33.41684000,130.74167000);Buzen|(33.61153000,131.13002000)"
+Japan,JP,Fukushima,Fukushima,Tokyo,,,37.75000000,140.46667000,Aizu-wakamatsu Shi;Date-shi;Fukushima,"Aizu-wakamatsu Shi|(37.45071000,139.96814000);Date-shi|(37.81667000,140.51667000);Fukushima|(37.75000000,140.46667000)"
+Japan,JP,Gifu,Ena-shi,Tokyo,,,35.44722000,137.41810000,Ena-shi;Gero;Gero-shi,"Ena-shi|(35.44722000,137.41810000);Gero|(35.80000000,137.23333000);Gero-shi|(35.75000000,137.25000000)"
+Japan,JP,Gunma,Agatsuma-gun,Tokyo,,,36.57368000,138.67243000,Agatsuma-gun;Annaka;Annaka Shi,"Agatsuma-gun|(36.57368000,138.67243000);Annaka|(36.33011000,138.89585000);Annaka Shi|(36.34079000,138.77647000)"
+Japan,JP,Hiroshima,Hiroshima,Tokyo,,,34.40000000,132.45000000,Aki-takata Shi;Etajima-shi;Fuchū-shi,"Aki-takata Shi|(34.70248000,132.67770000);Etajima-shi|(34.21989000,132.44345000);Fuchū-shi|(34.56667000,133.23333000)"
+Japan,JP,Hokkaidō,Abashiri,Tokyo,,,44.02127000,144.26971000,Abashiri;Abashiri Shi;Akabira,"Abashiri|(44.02127000,144.26971000);Abashiri Shi|(43.98565000,144.21051000);Akabira|(43.55139000,142.05306000)"
+Japan,JP,Hyōgo,Aioi,Tokyo,,,34.80361000,134.46806000,Aioi;Aioi Shi;Akashi,"Aioi|(34.80361000,134.46806000);Aioi Shi|(34.82719000,134.46699000);Akashi|(34.65524000,135.00687000)"
+Japan,JP,Ibaraki,Ami,Tokyo,,,36.03333000,140.20000000,Ami;Bandō;Bandō-shi,"Ami|(36.03333000,140.20000000);Bandō|(36.06997000,139.86705000);Bandō-shi|(36.06384000,139.88787000)"
+Japan,JP,Ishikawa,Hakui,Tokyo,,,36.88333000,136.78333000,Hakui;Hakui Shi;Hakusan Shi,"Hakui|(36.88333000,136.78333000);Hakui Shi|(36.91136000,136.81626000);Hakusan Shi|(36.27558000,136.66966000)"
+Japan,JP,Iwate,Hachimantai,Tokyo,,,39.89979000,141.12989000,Hachimantai;Hachimantai Shi;Hanamaki,"Hachimantai|(39.89979000,141.12989000);Hachimantai Shi|(40.02390000,140.99113000);Hanamaki|(39.38333000,141.11667000)"
+Japan,JP,Kagawa,Higashikagawa Shi,Tokyo,,,34.21158000,134.33350000,Higashikagawa Shi;Kan’onji Shi;Kan’onjichō,"Higashikagawa Shi|(34.21158000,134.33350000);Kan’onji Shi|(34.08457000,133.67448000);Kan’onjichō|(34.12760000,133.64598000)"
+Japan,JP,Kagoshima,Kagoshima,Tokyo,,,31.56667000,130.55000000,Aira Shi;Akune;Akune Shi,"Aira Shi|(31.78460000,130.60668000);Akune|(32.01667000,130.20000000);Akune Shi|(32.02516000,130.19768000)"
+Japan,JP,Kanagawa,Atsugi,Tokyo,,,35.44272000,139.36931000,Atsugi;Atsugi Shi;Ayase Shi,"Atsugi|(35.44272000,139.36931000);Atsugi Shi|(35.46513000,139.32707000);Ayase Shi|(35.43995000,139.43089000)"
+Japan,JP,Kōchi,Kōchi,Tokyo,,,33.55888889,133.53138889,Achi;Agematsu;Aki,"Achi|(35.44388889,137.74750000);Agematsu|(35.78388889,137.69416667);Aki|(33.50250000,133.90722222)"
+Japan,JP,Kumamoto,Kumamoto,Tokyo,,,32.80589000,130.69181000,Amakusa Gun;Amakusa Shi;Arao Shi,"Amakusa Gun|(32.48513000,130.07240000);Amakusa Shi|(32.38515000,130.15014000);Arao Shi|(32.97619000,130.47562000)"
+Japan,JP,Kyōto,Arashiyama,Tokyo,,,35.01481000,135.67755000,Arashiyama;Ayabe;Ayabe-shi,"Arashiyama|(35.01481000,135.67755000);Ayabe|(35.30000000,135.25000000);Ayabe-shi|(35.35263000,135.34465000)"
+Japan,JP,Mie,Hisai-motomachi,Tokyo,,,34.66667000,136.46667000,Hisai-motomachi;Iga-shi;Inabe,"Hisai-motomachi|(34.66667000,136.46667000);Iga-shi|(34.76855000,136.13013000);Inabe|(35.11344000,136.57205000)"
+Japan,JP,Miyagi,Furukawa,Tokyo,,,38.57167000,140.95556000,Furukawa;Higashimatshushima Shi;Higashimatsushima,"Furukawa|(38.57167000,140.95556000);Higashimatshushima Shi|(38.41089000,141.17717000);Higashimatsushima|(38.40886000,141.17901000)"
+Japan,JP,Miyazaki,Miyazaki,Tokyo,,,31.91667000,131.41667000,Ebino-shi;Hyūga-shi;Kobayashi,"Ebino-shi|(32.01667000,130.80000000);Hyūga-shi|(32.37710000,131.52275000);Kobayashi|(31.98333000,130.98333000)"
+Japan,JP,Nagano,Nagano,Tokyo,,,36.65000000,138.18333000,Azumino-Shi;Chikuma Shi;Chino,"Azumino-Shi|(36.32716000,137.83988000);Chikuma Shi|(36.53369840,138.12012300);Chino|(35.99440000,138.15428000)"
+Japan,JP,Nagasaki,Nagasaki,Tokyo,,,32.75000000,129.88333000,Fukuechō;Gotō Shi;Hirado,"Fukuechō|(32.69852260,128.84721640);Gotō Shi|(32.69514240,128.84081040);Hirado|(33.36853000,129.55247000)"
+Japan,JP,Nara,Gojō,Tokyo,,,34.35000000,135.70000000,Gojō;Gojō-shi;Gose,"Gojō|(34.35000000,135.70000000);Gojō-shi|(34.35081000,135.69489000);Gose|(34.45000000,135.73333000)"
+Japan,JP,Niigata,Niigata,Tokyo,,,37.88637000,139.00589000,Agano Shi;Arai;Gosen,"Agano Shi|(37.81420000,139.25914000);Arai|(37.00059000,138.22590000);Gosen|(37.73333000,139.16667000)"
+Japan,JP,Ōita,Ōita,Tokyo,,,33.23333000,131.60000000,Beppu;Beppu Shi;Bungo-ōno Shi,"Beppu|(33.27945000,131.49751000);Beppu Shi|(33.28573000,131.45280000);Bungo-ōno Shi|(32.97249000,131.51210000)"
+Japan,JP,Okayama,Okayama,Tokyo,,,34.65000000,133.93333000,Akaiwa Shi;Asakuchi Shi;Bizen Shi,"Akaiwa Shi|(34.83767000,134.01792000);Asakuchi Shi|(34.53607000,133.59456000);Bizen Shi|(34.79504000,134.23510000)"
+Japan,JP,Okinawa,Okinawa,Tokyo,,,26.47489480,127.91146870,Chatan;Ginowan Shi;Gushikawa,"Chatan|(26.32009910,127.76368270);Ginowan Shi|(26.28149680,127.77849160);Gushikawa|(26.35891020,127.86758780)"
+Japan,JP,Ōsaka,Daitō Shi,Tokyo,,,34.71284000,135.63576000,Daitō Shi;Daitōchō;Fujiidera-shi,"Daitō Shi|(34.71284000,135.63576000);Daitōchō|(34.71378000,135.62033000);Fujiidera-shi|(34.57422000,135.59730000)"
+Japan,JP,Saga,Saga,Tokyo,,,33.23333000,130.30000000,Imari Shi;Imarichō-kō;Kanzaki Shi,"Imari Shi|(33.30409000,129.88598000);Imarichō-kō|(33.27362000,129.87877000);Kanzaki Shi|(33.34446000,130.35883000)"
+Japan,JP,Saitama,Saitama,Tokyo,,,35.90807000,139.65657000,Ageo Shi;Ageoshimo;Asaka,"Ageo Shi|(35.97043000,139.58159000);Ageoshimo|(35.97145000,139.61382000);Asaka|(35.80472000,139.60194000)"
+Japan,JP,Shiga,Higashiōmi-shi,Tokyo,,,35.10890000,136.17920000,Higashiōmi-shi;Hikone;Hikone-shi,"Higashiōmi-shi|(35.10890000,136.17920000);Hikone|(35.25000000,136.25000000);Hikone-shi|(35.23036000,136.20760000)"
+Japan,JP,Shimane,Gōtsu Shi,Tokyo,,,34.98095000,132.29488000,Gōtsu Shi;Gōtsuchō;Hamada,"Gōtsu Shi|(34.98095000,132.29488000);Gōtsuchō|(35.00856000,132.22570000);Hamada|(34.88333000,132.08333000)"
+Japan,JP,Shizuoka,Shizuoka,Tokyo,,,34.98333000,138.38333000,Atami;Atami-shi;Fuji Shi,"Atami|(35.08834000,139.05325000);Atami-shi|(35.08957000,139.06357000);Fuji Shi|(35.20106000,138.69905000)"
+Japan,JP,Tochigi,Ashikaga,Tokyo,,,36.33333000,139.45000000,Ashikaga;Fujioka;Imaichi,"Ashikaga|(36.33333000,139.45000000);Fujioka|(36.25000000,139.65000000);Imaichi|(36.71667000,139.68333000)"
+Japan,JP,Tokushima,Tokushima,Tokyo,,,34.06667000,134.56667000,Anan Shi;Awa-shi;Ikedachō,"Anan Shi|(33.87716000,134.60644000);Awa-shi|(34.10000000,134.25000000);Ikedachō|(34.02849000,133.80616000)"
+Japan,JP,Tokyo,Tokyo,Tokyo,,,35.68950000,139.69171000,Adachi Ku;Akiruno-shi;Akishima-shi,"Adachi Ku|(35.77880000,139.79509000);Akiruno-shi|(35.73285000,139.22525000);Akishima-shi|(35.70782000,139.36418000)"
+Japan,JP,Tottori,Kurayoshi-shi,Tokyo,,,35.39110000,133.74577000,Kurayoshi-shi;Sakaiminato;Sakaiminato Shi,"Kurayoshi-shi|(35.39110000,133.74577000);Sakaiminato|(35.53774000,133.23094000);Sakaiminato Shi|(35.52034000,133.22704000)"
+Japan,JP,Toyama,Fukumitsu,Tokyo,,,36.55751000,136.86945000,Fukumitsu;Himi Shi;Himimachi,"Fukumitsu|(36.55751000,136.86945000);Himi Shi|(36.87218000,136.94066000);Himimachi|(36.85609000,136.98850000)"
+Japan,JP,Wakayama,Wakayama,Tokyo,,,34.23333000,135.16667000,Arida Shi;Gobō;Hashimoto,"Arida Shi|(34.07937000,135.14230000);Gobō|(33.88153000,135.16960000);Hashimoto|(34.31667000,135.61667000)"
+Japan,JP,Yamagata,Yamagata,Tokyo,,,38.23333000,140.36667000,Higashine;Higashine Shi;Kaminoyama,"Higashine|(38.43889000,140.40056000);Higashine Shi|(38.42559000,140.46670000);Kaminoyama|(38.15389000,140.27361000)"
+Japan,JP,Yamaguchi,Hagi,Tokyo,,,34.40000000,131.41667000,Hagi;Hagi Shi;Hikari,"Hagi|(34.40000000,131.41667000);Hagi Shi|(34.43206000,131.50623000);Hikari|(33.95500000,131.95000000)"
+Japan,JP,Yamanashi,Chūō-shi,Tokyo,,,35.58418000,138.54110000,Chūō-shi;Enzan;Fuefuki-shi,"Chūō-shi|(35.58418000,138.54110000);Enzan|(35.70000000,138.73333000);Fuefuki-shi|(35.59955000,138.68067000)"
+Jersey,JE,Grouville,Vingtaine de la Rocque,Saint Helier,,,49.17048880,-2.03389140,Vingtaine de la Rocque;Vingtaine de la Rue;Vingtaine de Longueville,"Vingtaine de la Rocque|(49.17048880,-2.03389140);Vingtaine de la Rue|(49.18661230,-2.05316130);Vingtaine de Longueville|(49.19001830,-2.04917800)"
+Jersey,JE,St Brelade,Vingtaine de la Moye,Saint Helier,,,49.18445480,-2.23950470,Vingtaine de la Moye;Vingtaine de Noirmont;Vingtaine des Quennevais,"Vingtaine de la Moye|(49.18445480,-2.23950470);Vingtaine de Noirmont|(49.17269850,-2.22550510);Vingtaine des Quennevais|(49.19704320,-2.21618080)"
+Jersey,JE,St Clement,Grande Vingtaine,Saint Helier,,,49.17207130,-2.06199370,Grande Vingtaine;Vingtaine de Samarès;Vingtaine du Rocquier,"Grande Vingtaine|(49.17207130,-2.06199370);Vingtaine de Samarès|(49.16497580,-2.09880290);Vingtaine du Rocquier|(49.17250500,-2.06543840)"
+Jersey,JE,St Helier,Vingtaine de Bas du Mont au Prêtre,Saint Helier,,,49.19939590,-2.11964080,Vingtaine de Bas du Mont au Prêtre;Vingtaine de Haut du Mont au Prêtre;Vingtaine de la Ville,"Vingtaine de Bas du Mont au Prêtre|(49.19939590,-2.11964080);Vingtaine de Haut du Mont au Prêtre|(49.20242510,-2.09919230);Vingtaine de la Ville|(49.17883320,-2.10357590)"
+Jersey,JE,St John,Vingtaine de Hérupe,Saint Helier,,,49.23330120,-2.12357080,Vingtaine de Hérupe;Vingtaine du Douet;Vingtaine du Nord,"Vingtaine de Hérupe|(49.23330120,-2.12357080);Vingtaine du Douet|(49.23459620,-2.17227710);Vingtaine du Nord|(49.23938780,-2.12069720)"
+Jersey,JE,St Lawrence,Vingtaine Bas de la Vallée,Saint Helier,,,49.19584680,-2.15669220,Vingtaine Bas de la Vallée;Vingtaine du Coin Hatain;Vingtaine du Coin Motier,"Vingtaine Bas de la Vallée|(49.19584680,-2.15669220);Vingtaine du Coin Hatain|(49.22074360,-2.12697490);Vingtaine du Coin Motier|(49.22490170,-2.13965400)"
+Jersey,JE,St Martin,Vingtaine de Faldouet,Saint Helier,,,49.20322040,-2.05269720,Vingtaine de Faldouet;Vingtaine de la Quéruée;Vingtaine de Rozel,"Vingtaine de Faldouet|(49.20322040,-2.05269720);Vingtaine de la Quéruée|(49.21499100,-2.05603630);Vingtaine de Rozel|(49.23569500,-2.05048470)"
+Jersey,JE,St Mary,Vingtaine du Nord,Saint Helier,,,49.24426390,-2.18082260,Vingtaine du Nord;Vingtaine du Sud,"Vingtaine du Nord|(49.24426390,-2.18082260);Vingtaine du Sud|(49.23404250,-2.16730840)"
+Jersey,JE,St Ouen,Cueillette de Grantez,Saint Helier,,,49.23123970,-2.22339030,Cueillette de Grantez;Cueillette de Léoville;Cueillette de Millais,"Cueillette de Grantez|(49.23123970,-2.22339030);Cueillette de Léoville|(49.23803240,-2.22634870);Cueillette de Millais|(49.24085370,-2.24330420)"
+Jersey,JE,St Peter,Grande Vingtaine,Saint Helier,,,49.21065500,-2.19606360,Grande Vingtaine;Vingtaine des Augerez;Vingtaine du Coin Varin,"Grande Vingtaine|(49.21065500,-2.19606360);Vingtaine des Augerez|(49.20776790,-2.18629780);Vingtaine du Coin Varin|(49.21451950,-2.18722550)"
+Jersey,JE,St Saviour,Vingtaine de la Grande Longueville,Saint Helier,,,49.18786710,-2.07502150,Vingtaine de la Grande Longueville;Vingtaine de la Petite Longueville;Vingtaine de Maufant,"Vingtaine de la Grande Longueville|(49.18786710,-2.07502150);Vingtaine de la Petite Longueville|(49.18090340,-2.08121620);Vingtaine de Maufant|(49.20822960,-2.10060600)"
+Jersey,JE,Trinity,Vingtaine de la Croiserie,Saint Helier,,,49.21646930,-2.09164410,Vingtaine de la Croiserie;Vingtaine de la Ville-à-l'Évêque;Vingtaine de Rozel,"Vingtaine de la Croiserie|(49.21646930,-2.09164410);Vingtaine de la Ville-à-l'Évêque|(49.23176480,-2.12236840);Vingtaine de Rozel|(49.23842870,-2.06704060)"
+Jordan,JO,Ajloun,‘Ajlūn,Amman,,,32.33326000,35.75279000,‘Ajlūn;‘Anjarah;‘Ayn Jannah,"‘Ajlūn|(32.33326000,35.75279000);‘Anjarah|(32.30630000,35.75653000);‘Ayn Jannah|(32.33466000,35.76370000)"
+Jordan,JO,Amman,Amman,Amman,,,31.95522000,35.94503000,Al Jīzah;Al Jubayhah;Amman,"Al Jīzah|(31.69893000,35.95530000);Al Jubayhah|(32.01071000,35.89802000);Amman|(31.95522000,35.94503000)"
+Jordan,JO,Aqaba,Aqaba,Amman,,,29.52667000,35.00778000,Aqaba;Tala Bay,"Aqaba|(29.52667000,35.00778000);Tala Bay|(29.40842000,34.97918000)"
+Jordan,JO,Balqa,Al Karāmah,Amman,,,31.95439000,35.58033000,Al Karāmah;As Salţ;Yarqā,"Al Karāmah|(31.95439000,35.58033000);As Salţ|(32.03917000,35.72722000);Yarqā|(31.97583000,35.69638000)"
+Jordan,JO,Irbid,Irbid,Amman,,,32.55556000,35.85000000,Ar Ramthā;Ash Shajarah;Aţ Ţayyibah,"Ar Ramthā|(32.55873000,36.00816000);Ash Shajarah|(32.64391000,35.94175000);Aţ Ţayyibah|(32.54304000,35.71756000)"
+Jordan,JO,Jerash,Al Kittah,Amman,,,32.27685000,35.84114000,Al Kittah;Balīlā;Burmā,"Al Kittah|(32.27685000,35.84114000);Balīlā|(32.39109000,35.93832000);Burmā|(32.21930000,35.78507000)"
+Jordan,JO,Karak,‘Ayy,Amman,,,31.13371000,35.64375000,‘Ayy;‘Izrā;Adir,"‘Ayy|(31.13371000,35.64375000);‘Izrā|(31.15889000,35.69278000);Adir|(31.20217000,35.76155000)"
+Jordan,JO,Ma'an,Ma'an,Amman,,,30.19624000,35.73405000,Al Jafr;Al Quwayrah;Ash Shawbak,"Al Jafr|(30.31840000,36.17775000);Al Quwayrah|(29.80045000,35.31160000);Ash Shawbak|(30.52134000,35.57135000)"
+Jordan,JO,Madaba,Mādabā,Amman,,,31.71599000,35.79392000,Mādabā,"Mādabā|(31.71599000,35.79392000)"
+Jordan,JO,Mafraq,Mafraq,Amman,,,32.34289000,36.20804000,Al Ḩamrā’;Mafraq;Rehab,"Al Ḩamrā’|(32.44017000,36.15265000);Mafraq|(32.34289000,36.20804000);Rehab|(32.32341000,36.09087000)"
+Jordan,JO,Tafilah,Aţ Ţafīlah,Amman,,,30.83752000,35.60442000,Aţ Ţafīlah;Buşayrā,"Aţ Ţafīlah|(30.83752000,35.60442000);Buşayrā|(30.73256000,35.60943000)"
+Jordan,JO,Zarqa,Zarqa,Amman,,,32.07275000,36.08796000,Al Azraq ash Shamālī;Russeifa;Zarqa,"Al Azraq ash Shamālī|(31.88209000,36.83017000);Russeifa|(32.01778000,36.04639000);Zarqa|(32.07275000,36.08796000)"
+Kazakhstan,KZ,Abai,,Astana,,,,,,
+Kazakhstan,KZ,Akmola,Akkol,Astana,,,51.99374000,70.94704000,Akkol;Akkol’;Aksu,"Akkol|(51.99374000,70.94704000);Akkol’|(53.29617000,69.59997000);Aksu|(52.44422000,71.95761000)"
+Kazakhstan,KZ,Aktobe,Aktobe,Astana,,,50.27969000,57.20718000,Aktobe;Batamshinskiy;Bayganin,"Aktobe|(50.27969000,57.20718000);Batamshinskiy|(50.56022000,58.27715000);Bayganin|(48.68975000,55.87512000)"
+Kazakhstan,KZ,Almaty,Bakanas,Astana,,,44.80838000,76.27214000,Bakanas;Balpyk Bī;Burunday,"Bakanas|(44.80838000,76.27214000);Balpyk Bī|(44.90225000,78.23157000);Burunday|(43.35567000,76.85477000)"
+Kazakhstan,KZ,Almaty,Almaty,Astana,,,43.25667000,76.92861000,Almaty,"Almaty|(43.25667000,76.92861000)"
+Kazakhstan,KZ,Astana,Nur-Sultan,Astana,,,51.18010000,71.44598000,Nur-Sultan,"Nur-Sultan|(51.18010000,71.44598000)"
+Kazakhstan,KZ,Atyrau,Atyrau,Astana,,,47.11667000,51.88333000,Akkol’;Atyrau;Balykshi,"Akkol’|(48.77177000,53.18580000);Atyrau|(47.11667000,51.88333000);Balykshi|(47.06667000,51.86667000)"
+Kazakhstan,KZ,East Kazakhstan,Altayskiy,Astana,,,50.24593000,82.36252000,Altayskiy;Aqtoghay;Asūbulaq,"Altayskiy|(50.24593000,82.36252000);Aqtoghay|(46.95000000,79.66667000);Asūbulaq|(49.55688000,83.06355000)"
+Kazakhstan,KZ,Jambyl,Aqbaqay,Astana,,,45.00000000,72.78333000,Aqbaqay;Chu;Georgiyevka,"Aqbaqay|(45.00000000,72.78333000);Chu|(43.60334000,73.75919000);Georgiyevka|(43.03882000,74.71287000)"
+Kazakhstan,KZ,Jetisu,,Astana,,,,,,
+Kazakhstan,KZ,Karaganda,Abay,Astana,,,49.63575000,72.86164000,Abay;Abay Qalasy;Aksu-Ayuly,"Abay|(49.63575000,72.86164000);Abay Qalasy|(49.63333000,72.88333000);Aksu-Ayuly|(48.76788000,73.67272000)"
+Kazakhstan,KZ,Kostanay,Kostanay,Astana,,,53.21435000,63.62463000,Arkalyk;Ayat;Borovskoy,"Arkalyk|(50.24915000,66.92027000);Ayat|(52.83554000,62.52078000);Borovskoy|(53.79270000,64.18268000)"
+Kazakhstan,KZ,Kyzylorda,Kyzylorda,Astana,,,44.85278000,65.50917000,Aral;Ayteke Bi;Belköl,"Aral|(46.80000000,61.66667000);Ayteke Bi|(45.84607000,62.15264000);Belköl|(44.81162000,65.58796000)"
+Kazakhstan,KZ,Mangystau,Aktau,Astana,,,43.65000000,51.16667000,Aktau;Baūtīno;Beyneu,"Aktau|(43.65000000,51.16667000);Baūtīno|(44.54479000,50.24629000);Beyneu|(45.31667000,55.20000000)"
+Kazakhstan,KZ,North Kazakhstan,Birlestik,Astana,,,53.58414000,68.35382000,Birlestik;Bishkul;Bulayevo,"Birlestik|(53.58414000,68.35382000);Bishkul|(54.77763000,69.09951000);Bulayevo|(54.90596000,70.44155000)"
+Kazakhstan,KZ,Pavlodar,Pavlodar,Astana,,,52.28333000,76.96667000,Aksu;Bayanaul;Belogor’ye,"Aksu|(52.04023000,76.92748000);Bayanaul|(50.79304000,75.70123000);Belogor’ye|(51.52983000,77.47146000)"
+Kazakhstan,KZ,Shymkent,,Astana,,,,,,
+Kazakhstan,KZ,Turkistan,Arys,Astana,,,42.43015000,68.80870000,Arys;Ashchysay;Asyqata,"Arys|(42.43015000,68.80870000);Ashchysay|(43.55370000,68.89792000);Asyqata|(40.89460000,68.36430000)"
+Kazakhstan,KZ,Ulytau,,Astana,,,,,,
+Kazakhstan,KZ,West Kazakhstan,Aqsay,Astana,,,51.16810000,52.99782000,Aqsay;Burlin;Chapaev,"Aqsay|(51.16810000,52.99782000);Burlin|(51.42724000,52.71392000);Chapaev|(50.20000000,51.16667000)"
+Kenya,KE,Baringo,Baringo,Nairobi,EMEA,14,0.46667000,35.96667000,Baringo;Eldama Ravine;Kabarnet,"Baringo|(0.46667000,35.96667000);Eldama Ravine|(0.05196000,35.72734000);Kabarnet|(0.49194000,35.74303000)"
+Kenya,KE,Bomet,Sotik,Nairobi,EMEA,14,-0.69069000,35.11102000,Sotik;Sotik Post,"Sotik|(-0.69069000,35.11102000);Sotik Post|(-0.78129000,35.34156000)"
+Kenya,KE,Bungoma,Bungoma,Nairobi,EMEA,14,0.56350000,34.56055000,Bungoma;Malikisi;Webuye,"Bungoma|(0.56350000,34.56055000);Malikisi|(0.67694000,34.42167000);Webuye|(0.60040000,34.77119000)"
+Kenya,KE,Busia,Busia,Nairobi,EMEA,14,0.46005000,34.11169000,Busia;Luanda;Lugulu,"Busia|(0.46005000,34.11169000);Luanda|(0.31354000,34.07146000);Lugulu|(0.39337000,34.30399000)"
+Kenya,KE,Elgeyo-Marakwet,Chebiemit,Nairobi,EMEA,14,1.05000000,35.40000000,Chebiemit;Chepkorio;Chesoi,"Chebiemit|(1.05000000,35.40000000);Chepkorio|(0.38330000,35.45000000);Chesoi|(1.15000000,35.65000000)"
+Kenya,KE,Embu,Embu,Nairobi,EMEA,14,-0.53987000,37.45743000,Embu,"Embu|(-0.53987000,37.45743000)"
+Kenya,KE,Garissa,Garissa,Nairobi,EMEA,14,-0.45275000,39.64601000,Garissa,"Garissa|(-0.45275000,39.64601000)"
+Kenya,KE,Homa Bay,Homa Bay,Nairobi,EMEA,14,-0.52731000,34.45714000,Homa Bay;Oyugis;Rachuonyo District,"Homa Bay|(-0.52731000,34.45714000);Oyugis|(-0.50974000,34.73067000);Rachuonyo District|(-0.44000000,34.73900000)"
+Kenya,KE,Isiolo,Isiolo,Nairobi,EMEA,14,0.35462000,37.58218000,Isiolo,"Isiolo|(0.35462000,37.58218000)"
+Kenya,KE,Kajiado,Kajiado,Nairobi,EMEA,14,-1.85238000,36.77683000,Kajiado;Magadi;Ngong,"Kajiado|(-1.85238000,36.77683000);Magadi|(-1.90122000,36.28700000);Ngong|(-1.35270000,36.66990000)"
+Kenya,KE,Kakamega,Kakamega,Nairobi,EMEA,14,0.28422000,34.75229000,Butere;Kakamega;Mumias,"Butere|(0.20694000,34.49006000);Kakamega|(0.28422000,34.75229000);Mumias|(0.33474000,34.48796000)"
+Kenya,KE,Kericho,Kericho,Nairobi,EMEA,14,-0.36774000,35.28314000,Kericho;Kipkelion;Litein,"Kericho|(-0.36774000,35.28314000);Kipkelion|(-0.19982000,35.46735000);Litein|(-0.58249000,35.18969000)"
+Kenya,KE,Kiambu,Kiambu,Nairobi,EMEA,14,-1.17139000,36.83556000,Kiambu;Kikuyu;Limuru,"Kiambu|(-1.17139000,36.83556000);Kikuyu|(-1.24627000,36.66291000);Limuru|(-1.11360000,36.64205000)"
+Kenya,KE,Kilifi,Kilifi,Nairobi,EMEA,14,-3.63045000,39.84992000,Iten;Kapsowar;Kilifi,"Iten|(0.67028000,35.50806000);Kapsowar|(0.97890000,35.55854000);Kilifi|(-3.63045000,39.84992000)"
+Kenya,KE,Kirinyaga,Kerugoya,Nairobi,EMEA,14,-0.49887000,37.28031000,Kerugoya;Sagana,"Kerugoya|(-0.49887000,37.28031000);Sagana|(-0.66806000,37.20875000)"
+Kenya,KE,Kisii,Kisii,Nairobi,EMEA,14,-0.68174000,34.76666000,Kisii;Ogembo,"Kisii|(-0.68174000,34.76666000);Ogembo|(-0.80116000,34.72579000)"
+Kenya,KE,Kisumu,Kisumu,Nairobi,EMEA,14,-0.10221000,34.76171000,Ahero;Kisumu;Muhoroni,"Ahero|(-0.17359000,34.91890000);Kisumu|(-0.10221000,34.76171000);Muhoroni|(-0.15816000,35.19645000)"
+Kenya,KE,Kitui,Kitui,Nairobi,EMEA,14,-1.36696000,38.01055000,Kitui;Mwingi,"Kitui|(-1.36696000,38.01055000);Mwingi|(-0.93605000,38.05955000)"
+Kenya,KE,Kwale,Kwale,Nairobi,EMEA,14,-4.17375000,39.45206000,Gazi;Kinango;Kwale,"Gazi|(-4.42402000,39.50588000);Kinango|(-4.13723000,39.31528000);Kwale|(-4.17375000,39.45206000)"
+Kenya,KE,Laikipia,Nanyuki,Nairobi,EMEA,14,0.00624000,37.07398000,Nanyuki;Nyahururu;Rumuruti,"Nanyuki|(0.00624000,37.07398000);Nyahururu|(0.03813000,36.36339000);Rumuruti|(0.27250000,36.53806000)"
+Kenya,KE,Lamu,Lamu,Nairobi,EMEA,14,-2.27169000,40.90201000,Lamu;Witu,"Lamu|(-2.27169000,40.90201000);Witu|(-2.38892000,40.43827000)"
+Kenya,KE,Machakos,Machakos,Nairobi,EMEA,14,-1.52233000,37.26521000,Athi River;Kangundo;Konza,"Athi River|(-1.45630000,36.97826000);Kangundo|(-1.30342000,37.34813000);Konza|(-1.73947000,37.13195000)"
+Kenya,KE,Makueni,Makueni Boma,Nairobi,EMEA,14,-1.80388000,37.62405000,Makueni Boma;Mtito Andei;Wote,"Makueni Boma|(-1.80388000,37.62405000);Mtito Andei|(-2.68987000,38.16687000);Wote|(-1.78079000,37.62882000)"
+Kenya,KE,Mandera,Mandera,Nairobi,EMEA,14,3.93726000,41.85688000,Mandera,"Mandera|(3.93726000,41.85688000)"
+Kenya,KE,Marsabit,Marsabit,Nairobi,EMEA,14,2.33468000,37.99086000,Marsabit;Moyale,"Marsabit|(2.33468000,37.99086000);Moyale|(3.52661000,39.05610000)"
+Kenya,KE,Meru,Meru,Nairobi,EMEA,14,0.04626000,37.65587000,Maua;Meru,"Maua|(0.23320000,37.94086000);Meru|(0.04626000,37.65587000)"
+Kenya,KE,Migori,Migori,Nairobi,EMEA,14,-1.06343000,34.47313000,Kihancha;Migori,"Kihancha|(-1.19347000,34.61967000);Migori|(-1.06343000,34.47313000)"
+Kenya,KE,Mombasa,Mombasa,Nairobi,EMEA,14,-4.05466000,39.66359000,Mombasa,"Mombasa|(-4.05466000,39.66359000)"
+Kenya,KE,Murang'a,Kangema,Nairobi,EMEA,14,-0.68553000,36.96463000,Kangema;Karuri;Maragua,"Kangema|(-0.68553000,36.96463000);Karuri|(-0.70000000,37.18333000);Maragua|(-0.79602000,37.13292000)"
+Kenya,KE,Nairobi City,Nairobi,Nairobi,EMEA,14,-1.28333000,36.81667000,Nairobi;Pumwani,"Nairobi|(-1.28333000,36.81667000);Pumwani|(-1.28333000,36.85000000)"
+Kenya,KE,Nakuru,Nakuru,Nairobi,EMEA,14,-0.30719000,36.07225000,Kijabe;Molo;Naivasha,"Kijabe|(-0.93334000,36.57233000);Molo|(-0.24849000,35.73194000);Naivasha|(-0.71383000,36.43261000)"
+Kenya,KE,Nandi,Kapsabet,Nairobi,EMEA,14,0.20387000,35.10500000,Kapsabet;Nandi Hills,"Kapsabet|(0.20387000,35.10500000);Nandi Hills|(0.10366000,35.18426000)"
+Kenya,KE,Narok,Narok,Nairobi,EMEA,14,-1.08083000,35.87111000,Narok,"Narok|(-1.08083000,35.87111000)"
+Kenya,KE,Nyamira,Nyamira,Nairobi,EMEA,14,-0.56333000,34.93583000,Keroka;Nyamira,"Keroka|(-0.77612000,34.94678000);Nyamira|(-0.56333000,34.93583000)"
+Kenya,KE,Nyandarua,Ol Kalou,Nairobi,EMEA,14,-0.27088000,36.37917000,Ol Kalou,"Ol Kalou|(-0.27088000,36.37917000)"
+Kenya,KE,Nyeri,Nyeri,Nairobi,EMEA,14,-0.42013000,36.94759000,Naro Moru;Nyeri;Othaya,"Naro Moru|(-0.16357000,37.01773000);Nyeri|(-0.42013000,36.94759000);Othaya|(-0.54655000,36.93178000)"
+Kenya,KE,Samburu,Maralal,Nairobi,EMEA,14,1.09667000,36.69806000,Maralal,"Maralal|(1.09667000,36.69806000)"
+Kenya,KE,Siaya,Siaya,Nairobi,EMEA,14,0.06070000,34.28806000,Bondo;Siaya;Yala,"Bondo|(0.23522000,34.28086000);Siaya|(0.06070000,34.28806000);Yala|(0.09438000,34.53602000)"
+Kenya,KE,Taita–Taveta,Bura,Nairobi,EMEA,14,-3.50000000,38.30000000,Bura;Chala;Maktau,"Bura|(-3.50000000,38.30000000);Chala|(-3.38330000,37.68330000);Maktau|(-3.40000000,38.13330000)"
+Kenya,KE,Tana River,Hola,Nairobi,EMEA,14,-1.48256000,40.03341000,Hola;Kipini,"Hola|(-1.48256000,40.03341000);Kipini|(-2.52565000,40.52620000)"
+Kenya,KE,Tharaka-Nithi,Chuka,Nairobi,EMEA,14,-0.33316000,37.64587000,Chuka,"Chuka|(-0.33316000,37.64587000)"
+Kenya,KE,Trans Nzoia,Kitale,Nairobi,EMEA,14,1.01572000,35.00622000,Kitale,"Kitale|(1.01572000,35.00622000)"
+Kenya,KE,Turkana,Lodwar,Nairobi,EMEA,14,3.11988000,35.59642000,Lodwar,"Lodwar|(3.11988000,35.59642000)"
+Kenya,KE,Uasin Gishu,Eldoret,Nairobi,EMEA,14,0.52036000,35.26993000,Eldoret,"Eldoret|(0.52036000,35.26993000)"
+Kenya,KE,Vihiga,Chavakali,Nairobi,EMEA,14,0.11670000,34.70000000,Chavakali;Esabalu;Gambogi,"Chavakali|(0.11670000,34.70000000);Esabalu|(0.01670000,34.61670000);Gambogi|(0.08330000,34.80000000)"
+Kenya,KE,Wajir,Wajir,Nairobi,EMEA,14,1.74710000,40.05732000,Wajir,"Wajir|(1.74710000,40.05732000)"
+Kenya,KE,West Pokot,Chepareria,Nairobi,EMEA,14,1.30583000,35.20365000,Chepareria;Kapenguria;Taveta,"Chepareria|(1.30583000,35.20365000);Kapenguria|(1.23889000,35.11194000);Taveta|(-3.39879000,37.68336000)"
+Kiribati,KI,Gilbert,Abaiang,Tarawa,,,1.85293000,172.94369000,Abaiang;Abemama;Ambo Village,"Abaiang|(1.85293000,172.94369000);Abemama|(0.40000000,173.86667000);Ambo Village|(1.35317000,173.04259000)"
+Kiribati,KI,Line,Banana Village,Tarawa,,,1.98329000,-157.36526000,Banana Village;Kiritimati;London Village,"Banana Village|(1.98329000,-157.36526000);Kiritimati|(1.94000000,-157.47500000);London Village|(1.98487000,-157.47502000)"
+Kiribati,KI,Phoenix,Kanton,Tarawa,,,-2.81000000,-171.67800000,Kanton,"Kanton|(-2.81000000,-171.67800000)"
+Kosovo,XK,Ferizaj,,Pristina,,,,,,
+Kosovo,XK,Gjakove,,Pristina,,,,,,
+Kosovo,XK,Gjilan,,Pristina,,,,,,
+Kosovo,XK,Mitrovica,,Pristina,,,,,,
+Kosovo,XK,Peja,,Pristina,,,,,,
+Kosovo,XK,Pristina,,Pristina,,,,,,
+Kosovo,XK,Prizren,,Pristina,,,,,,
+Kuwait,KW,Al Ahmadi,Al Aḩmadī,Kuwait City,,,29.07694000,48.08389000,Al Aḩmadī;Al Faḩāḩīl;Al Finţās,"Al Aḩmadī|(29.07694000,48.08389000);Al Faḩāḩīl|(29.08250000,48.13028000);Al Finţās|(29.17389000,48.12111000)"
+Kuwait,KW,Al Asimah,Ad Dasmah,Kuwait City,,,29.36500000,48.00139000,Ad Dasmah;Ar Rābiyah;Ash Shāmīyah,"Ad Dasmah|(29.36500000,48.00139000);Ar Rābiyah|(29.29500000,47.93306000);Ash Shāmīyah|(29.34722000,47.96167000)"
+Kuwait,KW,Al Farwaniyah,Al Farwānīyah,Kuwait City,,,29.27750000,47.95861000,Al Farwānīyah;Janūb as Surrah,"Al Farwānīyah|(29.27750000,47.95861000);Janūb as Surrah|(29.26917000,47.97806000)"
+Kuwait,KW,Al Jahra,Al Jahrā’,Kuwait City,,,29.33750000,47.65806000,Al Jahrā’,"Al Jahrā’|(29.33750000,47.65806000)"
+Kuwait,KW,Hawalli,Ar Rumaythīyah,Kuwait City,,,29.31167000,48.07417000,Ar Rumaythīyah;As Sālimīyah;Bayān,"Ar Rumaythīyah|(29.31167000,48.07417000);As Sālimīyah|(29.33389000,48.07611000);Bayān|(29.30320000,48.04881000)"
+Kuwait,KW,Mubarak Al-Kabeer,Abu Al Hasaniya,Kuwait City,,,29.19076000,48.11355000,Abu Al Hasaniya;Abu Fatira;Al Funayţīs,"Abu Al Hasaniya|(29.19076000,48.11355000);Abu Fatira|(29.19746000,48.10278000);Al Funayţīs|(29.22528000,48.10167000)"
+Kyrgyzstan,KG,Batken,Batken,Bishkek,,,40.06259000,70.81939000,Aydarken;Batken;Iradan,"Aydarken|(39.94319000,71.34184000);Batken|(40.06259000,70.81939000);Iradan|(40.26667000,72.10000000)"
+Kyrgyzstan,KG,Bishkek,Bishkek,Bishkek,,,42.87000000,74.59000000,Bishkek,"Bishkek|(42.87000000,74.59000000)"
+Kyrgyzstan,KG,Chuy,Alamudunskiy Rayon,Bishkek,,,42.81985000,74.59398000,Alamudunskiy Rayon;Belovodskoye;Chuyskiy Rayon,"Alamudunskiy Rayon|(42.81985000,74.59398000);Belovodskoye|(42.82944000,74.10830000);Chuyskiy Rayon|(42.66667000,75.33333000)"
+Kyrgyzstan,KG,Issyk-Kul,Ak-Suu,Bishkek,,,42.49948000,78.52702000,Ak-Suu;Balykchy;Cholpon-Ata,"Ak-Suu|(42.49948000,78.52702000);Balykchy|(42.46017000,76.18709000);Cholpon-Ata|(42.64944000,77.08225000)"
+Kyrgyzstan,KG,Jalal-Abad,Jalal-Abad,Bishkek,,,40.93333000,73.00000000,Ala-Buka;Bazar-Korgon;Jalal-Abad,"Ala-Buka|(41.40806000,71.46306000);Bazar-Korgon|(41.03760000,72.74586000);Jalal-Abad|(40.93333000,73.00000000)"
+Kyrgyzstan,KG,Naryn,Naryn,Bishkek,,,41.42866000,75.99111000,At-Bashi;Jumgal;Naryn,"At-Bashi|(41.16951000,75.80099000);Jumgal|(41.94924000,74.40566000);Naryn|(41.42866000,75.99111000)"
+Kyrgyzstan,KG,Osh,,Bishkek,,,,,,
+Kyrgyzstan,KG,Osh,Osh,Bishkek,,,40.52828000,72.79850000,Chong-Alay District;Daroot-Korgon;Kara Kulja,"Chong-Alay District|(39.47614000,72.33017000);Daroot-Korgon|(39.55274000,72.20518000);Kara Kulja|(40.64095000,73.49411000)"
+Kyrgyzstan,KG,Talas,Talas,Bishkek,,,42.52277000,72.24274000,Kara-Buurinskiy Rayon;Talas;Talasskiy Rayon,"Kara-Buurinskiy Rayon|(42.50000000,71.41667000);Talas|(42.52277000,72.24274000);Talasskiy Rayon|(42.18647000,72.69408000)"
+Laos,LA,Attapeu,Attapeu,Vientiane,,,14.81071000,106.83184000,Attapeu;Muang Phouvong;Muang Samakhixai,"Attapeu|(14.81071000,106.83184000);Muang Phouvong|(14.56821000,107.01087000);Muang Samakhixai|(14.80539000,106.78164000)"
+Laos,LA,Bokeo,Ban Houakhoua,Vientiane,,,20.24670000,100.45401000,Ban Houakhoua;Ban Houayxay;Muang Houayxay,"Ban Houakhoua|(20.24670000,100.45401000);Ban Houayxay|(20.27000000,100.41780000);Muang Houayxay|(20.38763000,100.62687000)"
+Laos,LA,Bolikhamsai,Ban Nahin,Vientiane,,,18.24253000,104.21281000,Ban Nahin;Pakxan,"Ban Nahin|(18.24253000,104.21281000);Pakxan|(18.39420000,103.66110000)"
+Laos,LA,Champasak,Champasak,Vientiane,,,14.89204000,105.87787000,Champasak;Muang Bachiangchaleunsook;Muang Champasak,"Champasak|(14.89204000,105.87787000);Muang Bachiangchaleunsook|(15.24426000,105.96716000);Muang Champasak|(14.85704000,105.75334000)"
+Laos,LA,Houaphanh,Xam Neua,Vientiane,,,20.40764000,104.06560000,Xam Neua;Xam Nua,"Xam Neua|(20.40764000,104.06560000);Xam Nua|(20.41640000,104.04500000)"
+Laos,LA,Khammouane,Muang Thakhèk,Vientiane,,,17.40880000,104.82639000,Muang Thakhèk;Thakhèk,"Muang Thakhèk|(17.40880000,104.82639000);Thakhèk|(17.41027000,104.83068000)"
+Laos,LA,Luang Namtha,Luang Namtha,Vientiane,,,20.94860000,101.40188000,Luang Namtha;Muang Louang Namtha,"Luang Namtha|(20.94860000,101.40188000);Muang Louang Namtha|(21.00424000,101.44785000)"
+Laos,LA,Luang Prabang,Luang Prabang,Vientiane,,,19.88601000,102.13503000,Luang Prabang,"Luang Prabang|(19.88601000,102.13503000)"
+Laos,LA,Oudomxay,Muang Xay,Vientiane,,,20.69229000,101.98368000,Muang Xay,"Muang Xay|(20.69229000,101.98368000)"
+Laos,LA,Phongsaly,Phôngsali,Vientiane,,,21.68080000,102.10030000,Phôngsali,"Phôngsali|(21.68080000,102.10030000)"
+Laos,LA,Sainyabuli,Sainyabuli,Vientiane,,,19.25756000,101.71032000,Sainyabuli,"Sainyabuli|(19.25756000,101.71032000)"
+Laos,LA,Salavan,Salavan,Vientiane,,,15.71652000,106.41744000,Muang Khôngxédôn;Muang Lakhonphéng;Muang Laongam,"Muang Khôngxédôn|(15.54626000,105.77051000);Muang Lakhonphéng|(15.83308000,105.59745000);Muang Laongam|(15.47745000,106.14111000)"
+Laos,LA,Savannakhet,Savannakhet,Vientiane,,,16.57030000,104.76220000,Kaysone Phomvihane;Muang Alsaphangthong;Muang Atsaphan,"Kaysone Phomvihane|(16.54943000,104.82339000);Muang Alsaphangthong|(16.72645000,105.39326000);Muang Atsaphan|(16.94740000,105.40290000)"
+Laos,LA,Sekong,Ban Thatèng,Vientiane,,,15.43317000,106.38272000,Ban Thatèng;Lamam;Muang Dakchung,"Ban Thatèng|(15.43317000,106.38272000);Lamam|(15.41705000,106.69461000);Muang Dakchung|(15.38199000,107.31847000)"
+Laos,LA,Vientiane,Muang Phôn-Hông,Vientiane,,,18.49530000,102.41530000,Muang Phôn-Hông;Vangviang,"Muang Phôn-Hông|(18.49530000,102.41530000);Vangviang|(18.92350000,102.44784000)"
+Laos,LA,Vientiane,Vientiane,Vientiane,,,17.96667000,102.60000000,Vientiane,"Vientiane|(17.96667000,102.60000000)"
+Laos,LA,Xaisomboun,Anouvong district,Vientiane,,,18.89731000,103.09274000,Anouvong district;Longchaeng;Muang Longxan,"Anouvong district|(18.89731000,103.09274000);Longchaeng|(18.89394000,103.14274000);Muang Longxan|(18.61782000,102.88079000)"
+Laos,LA,Xiangkhouang,Muang Phônsavan,Vientiane,,,19.44940000,103.19170000,Muang Phônsavan,"Muang Phônsavan|(19.44940000,103.19170000)"
+Latvia,LV,Ādaži,Carnikava,Riga,,,57.12935000,24.28423000,Carnikava,"Carnikava|(57.12935000,24.28423000)"
+Latvia,LV,Aizkraukle,Aizkraukle,Riga,,,56.60477000,25.25534000,Aizkraukle;Jaunjelgava;Koknese,"Aizkraukle|(56.60477000,25.25534000);Jaunjelgava|(56.61319000,25.08316000);Koknese|(56.65163000,25.43637000)"
+Latvia,LV,Alūksne,Alūksne,Riga,,,57.42162000,27.04662000,Alūksne,"Alūksne|(57.42162000,27.04662000)"
+Latvia,LV,Augšdaugava,Daugavpils,Riga,,,55.88333000,26.53333000,Daugavpils;Ilūkste,"Daugavpils|(55.88333000,26.53333000);Ilūkste|(55.97754000,26.29655000)"
+Latvia,LV,Balvi,Balvi,Riga,,,57.13130000,27.26583000,Baltinava;Balvi;Rugāji,"Baltinava|(56.94394000,27.64401000);Balvi|(57.13130000,27.26583000);Rugāji|(57.00325000,27.13371000)"
+Latvia,LV,Bauska,Bauska,Riga,,,56.40794000,24.19443000,Bauska;Iecava;Pilsrundāle,"Bauska|(56.40794000,24.19443000);Iecava|(56.59766000,24.20763000);Pilsrundāle|(56.41812000,24.01625000)"
+Latvia,LV,Cēsis,Cēsis,Riga,,,57.31188000,25.27456000,Cēsis;Līgatne;Priekuļi,"Cēsis|(57.31188000,25.27456000);Līgatne|(57.23429000,25.04059000);Priekuļi|(57.31500000,25.36147000)"
+Latvia,LV,Daugavpils,,Riga,,,,,,
+Latvia,LV,Dienvidkurzemes,Aizpute,Riga,,,56.72108000,21.60156000,Aizpute;Grobiņa;Lieģi,"Aizpute|(56.72108000,21.60156000);Grobiņa|(56.53521000,21.16782000);Lieģi|(56.58173000,21.33399000)"
+Latvia,LV,Dobele,Dobele,Riga,,,56.62372000,23.27510000,Auce;Dobele;Tērvete,"Auce|(56.45981000,22.90169000);Dobele|(56.62372000,23.27510000);Tērvete|(56.47989000,23.38895000)"
+Latvia,LV,Gulbene,Gulbene,Riga,,,57.17767000,26.75291000,Gulbene,"Gulbene|(57.17767000,26.75291000)"
+Latvia,LV,Jēkabpils,Jēkabpils,Riga,,,56.49903000,25.85735000,Aknīste;Jēkabpils;Krustpils,"Aknīste|(56.16152000,25.74783000);Jēkabpils|(56.49903000,25.85735000);Krustpils|(56.51068000,25.86117000)"
+Latvia,LV,Jelgava,Ozolnieki,Riga,,,56.68986000,23.77610000,Ozolnieki;Tīreļi,"Ozolnieki|(56.68986000,23.77610000);Tīreļi|(56.83991000,23.58902000)"
+Latvia,LV,Jelgava,Jelgava,Riga,,,56.65000000,23.71278000,Jelgava,"Jelgava|(56.65000000,23.71278000)"
+Latvia,LV,Jūrmala,Jūrmala,Riga,,,56.96800000,23.77038000,Jūrmala,"Jūrmala|(56.96800000,23.77038000)"
+Latvia,LV,Ķekava,Ķekava,Riga,,,56.82662000,24.23000000,Baldone;Baloži;Ķekava,"Baldone|(56.74451000,24.40078000);Baloži|(56.87643000,24.11825000);Ķekava|(56.82662000,24.23000000)"
+Latvia,LV,Krāslava,Krāslava,Riga,,,55.89514000,27.16799000,Dagda;Krāslava,"Dagda|(56.09512000,27.53723000);Krāslava|(55.89514000,27.16799000)"
+Latvia,LV,Kuldīga,Kuldīga,Riga,,,56.97399000,21.95721000,Alsunga;Kuldīga;Skrunda,"Alsunga|(56.98194000,21.55938000);Kuldīga|(56.97399000,21.95721000);Skrunda|(56.67749000,22.01649000)"
+Latvia,LV,Liepāja,Liepāja,Riga,,,56.50474000,21.01085000,Karosta;Liepāja,"Karosta|(56.55128000,21.01287000);Liepāja|(56.50474000,21.01085000)"
+Latvia,LV,Limbaži,Limbaži,Riga,,,57.51287000,24.71941000,Ainaži;Aloja;Limbaži,"Ainaži|(57.86348000,24.35853000);Aloja|(57.76723000,24.87743000);Limbaži|(57.51287000,24.71941000)"
+Latvia,LV,Līvāni,Līvāni,Riga,,,56.35431000,26.17579000,Līvāni,"Līvāni|(56.35431000,26.17579000)"
+Latvia,LV,Ludza,Ludza,Riga,,,56.53958000,27.71891000,Cibla;Kārsava;Ludza,"Cibla|(56.54980000,27.88370000);Kārsava|(56.78405000,27.68829000);Ludza|(56.53958000,27.71891000)"
+Latvia,LV,Madona,Madona,Riga,,,56.85329000,26.21698000,Cesvaine;Ērgļi;Lubāna,"Cesvaine|(56.96754000,26.30764000);Ērgļi|(56.89752000,25.63668000);Lubāna|(56.90425000,26.71606000)"
+Latvia,LV,Mārupe,Mārupe,Riga,,,56.90544000,24.05113000,Mārupe;Piņķi,"Mārupe|(56.90544000,24.05113000);Piņķi|(56.94189000,23.91365000)"
+Latvia,LV,Ogre,Ogre,Riga,,,56.81620000,24.61401000,Ikšķile;Jumprava;Ķegums,"Ikšķile|(56.83399000,24.49679000);Jumprava|(56.67613000,24.97210000);Ķegums|(56.74510000,24.72439000)"
+Latvia,LV,Olaine,Olaine,Riga,,,56.79472000,23.93580000,Olaine,"Olaine|(56.79472000,23.93580000)"
+Latvia,LV,Preiļi,Preiļi,Riga,,,56.29444000,26.72459000,Aglona;Jaunaglona;Preiļi,"Aglona|(56.13274000,27.00682000);Jaunaglona|(56.16066000,27.00714000);Preiļi|(56.29444000,26.72459000)"
+Latvia,LV,Rēzekne,Rēzekne,Riga,,,56.51028000,27.34000000,Rēzekne,"Rēzekne|(56.51028000,27.34000000)"
+Latvia,LV,Rēzekne,Viļāni,Riga,,,56.55253000,26.92449000,Viļāni,"Viļāni|(56.55253000,26.92449000)"
+Latvia,LV,Riga,Riga,Riga,,,56.94600000,24.10589000,Bolderaja;Daugavgrīva;Jaunciems,"Bolderaja|(57.03132000,24.05571000);Daugavgrīva|(57.04315000,24.03613000);Jaunciems|(57.03910000,24.17413000)"
+Latvia,LV,Ropaži,Ropaži,Riga,,,56.97470000,24.63295000,Garkalne;Ropaži;Ulbroka,"Garkalne|(57.04486000,24.41951000);Ropaži|(56.97470000,24.63295000);Ulbroka|(56.93630000,24.30387000)"
+Latvia,LV,Salaspils,Salaspils,Riga,,,56.86014000,24.36544000,Salaspils,"Salaspils|(56.86014000,24.36544000)"
+Latvia,LV,Saldus,Saldus,Riga,,,56.66363000,22.48807000,Brocēni;Saldus,"Brocēni|(56.67890000,22.56945000);Saldus|(56.66363000,22.48807000)"
+Latvia,LV,Saulkrasti,Saulkrasti,Riga,,,57.26224000,24.41471000,Saulkrasti,"Saulkrasti|(57.26224000,24.41471000)"
+Latvia,LV,Sigulda,Sigulda,Riga,,,57.15375000,24.85953000,Inčukalns;Mālpils;Sigulda,"Inčukalns|(57.09867000,24.68630000);Mālpils|(57.01010000,24.95783000);Sigulda|(57.15375000,24.85953000)"
+Latvia,LV,Smiltene,Smiltene,Riga,,,57.42444000,25.90164000,Ape;Rauna;Smiltene,"Ape|(57.53928000,26.69291000);Rauna|(57.33173000,25.60947000);Smiltene|(57.42444000,25.90164000)"
+Latvia,LV,Talsi,Talsi,Riga,,,57.24562000,22.58137000,Dundaga;Roja;Sabile,"Dundaga|(57.50498000,22.35041000);Roja|(57.50146000,22.80881000);Sabile|(57.04577000,22.57261000)"
+Latvia,LV,Tukums,Tukums,Riga,,,56.96764000,23.15554000,Engure;Jaunpils;Kandava,"Engure|(57.16061000,23.22527000);Jaunpils|(56.73137000,23.01247000);Kandava|(57.04087000,22.77466000)"
+Latvia,LV,Valka,Valka,Riga,,,57.77520000,26.01013000,Valka,"Valka|(57.77520000,26.01013000)"
+Latvia,LV,Valmiera,Valmiera,Riga,,,57.54108000,25.42751000,Kocēni;Mazsalaca;Mūrmuiža,"Kocēni|(57.52057000,25.33821000);Mazsalaca|(57.86329000,25.05475000);Mūrmuiža|(57.47312000,25.49174000)"
+Latvia,LV,Varakļāni,Varakļāni,Riga,,,56.60826000,26.75377000,Varakļāni,"Varakļāni|(56.60826000,26.75377000)"
+Latvia,LV,Ventspils,Ventspils,Riga,,,57.38988000,21.57288000,Ventspils,"Ventspils|(57.38988000,21.57288000)"
+Latvia,LV,Ventspils,Piltene,Riga,,,57.22426000,21.67439000,Piltene,"Piltene|(57.22426000,21.67439000)"
+Lebanon,LB,Akkar,Caza de Aakkar,Beirut,,,34.53333000,36.16667000,Caza de Aakkar,"Caza de Aakkar|(34.53333000,36.16667000)"
+Lebanon,LB,Baalbek-Hermel,Baalbek,Beirut,,,34.00583000,36.21806000,Baalbek;Caza de Baalbek,"Baalbek|(34.00583000,36.21806000);Caza de Baalbek|(34.09822000,36.27157000)"
+Lebanon,LB,Beirut,Beirut,Beirut,,,33.89332000,35.50157000,Beirut;Ra’s Bayrūt,"Beirut|(33.89332000,35.50157000);Ra’s Bayrūt|(33.90000000,35.48333000)"
+Lebanon,LB,Beqaa,Aanjar,Beirut,,,33.72778000,35.93111000,Aanjar;Zahlé,"Aanjar|(33.72778000,35.93111000);Zahlé|(33.84675000,35.90203000)"
+Lebanon,LB,Mount Lebanon,Baabda,Beirut,,,33.83389000,35.54417000,Baabda;Bhamdoun;Bhamdoûn el Mhatta,"Baabda|(33.83389000,35.54417000);Bhamdoun|(33.79500000,35.65111000);Bhamdoûn el Mhatta|(33.80861000,35.65972000)"
+Lebanon,LB,Nabatieh,Ain Ebel,Beirut,,,33.11023000,35.40251000,Ain Ebel;Caza de Bent Jbaïl;Caza de Nabatîyé,"Ain Ebel|(33.11023000,35.40251000);Caza de Bent Jbaïl|(33.15964000,35.41137000);Caza de Nabatîyé|(33.39435000,35.44483000)"
+Lebanon,LB,North,Batroûn,Beirut,,,34.25528000,35.65806000,Batroûn;Bcharré;Tripoli,"Batroûn|(34.25528000,35.65806000);Bcharré|(34.25083000,36.01056000);Tripoli|(34.43352000,35.84415000)"
+Lebanon,LB,South,En Nâqoûra,Beirut,,,33.11806000,35.13972000,En Nâqoûra;Ghazieh;Sidon,"En Nâqoûra|(33.11806000,35.13972000);Ghazieh|(33.51750000,35.36889000);Sidon|(33.55751000,35.37148000)"
+Lesotho,LS,Berea,Teyateyaneng,Maseru,EMEA,18,-29.14719000,27.74895000,Teyateyaneng,"Teyateyaneng|(-29.14719000,27.74895000)"
+Lesotho,LS,Butha-Buthe,Butha-Buthe,Maseru,EMEA,18,-28.76659000,28.24937000,Butha-Buthe,"Butha-Buthe|(-28.76659000,28.24937000)"
+Lesotho,LS,Leribe,Leribe,Maseru,EMEA,18,-28.87185000,28.04501000,Leribe;Maputsoe,"Leribe|(-28.87185000,28.04501000);Maputsoe|(-28.88660000,27.89915000)"
+Lesotho,LS,Mafeteng,Mafeteng,Maseru,EMEA,18,-29.82299000,27.23744000,Mafeteng,"Mafeteng|(-29.82299000,27.23744000)"
+Lesotho,LS,Maseru,Maseru,Maseru,EMEA,18,-29.31667000,27.48333000,Maseru;Nako,"Maseru|(-29.31667000,27.48333000);Nako|(-29.61667000,27.76667000)"
+Lesotho,LS,Mohale's Hoek,Mohale’s Hoek,Maseru,EMEA,18,-30.15137000,27.47691000,Mohale’s Hoek,"Mohale’s Hoek|(-30.15137000,27.47691000)"
+Lesotho,LS,Mokhotlong,Mokhotlong,Maseru,EMEA,18,-29.28939000,29.06751000,Mokhotlong,"Mokhotlong|(-29.28939000,29.06751000)"
+Lesotho,LS,Qacha's Nek,Qacha’s Nek,Maseru,EMEA,18,-30.11537000,28.68936000,Qacha’s Nek,"Qacha’s Nek|(-30.11537000,28.68936000)"
+Lesotho,LS,Quthing,Quthing,Maseru,EMEA,18,-30.40001000,27.70027000,Quthing,"Quthing|(-30.40001000,27.70027000)"
+Lesotho,LS,Thaba-Tseka,Thaba-Tseka,Maseru,EMEA,18,-29.52204000,28.60840000,Thaba-Tseka,"Thaba-Tseka|(-29.52204000,28.60840000)"
+Liberia,LR,Bomi,Tubmanburg,Monrovia,,,6.87064000,-10.82110000,Tubmanburg,"Tubmanburg|(6.87064000,-10.82110000)"
+Liberia,LR,Bong,Gbarnga,Monrovia,,,6.99543000,-9.47122000,Gbarnga,"Gbarnga|(6.99543000,-9.47122000)"
+Liberia,LR,Gbarpolu,Bopolu,Monrovia,,,7.06667000,-10.48750000,Bopolu,"Bopolu|(7.06667000,-10.48750000)"
+Liberia,LR,Grand Bassa,Buchanan,Monrovia,,,5.87693000,-10.04964000,Buchanan,"Buchanan|(5.87693000,-10.04964000)"
+Liberia,LR,Grand Cape Mount,Robertsport,Monrovia,,,6.75329000,-11.36710000,Robertsport,"Robertsport|(6.75329000,-11.36710000)"
+Liberia,LR,Grand Gedeh,Zwedru,Monrovia,,,6.06846000,-8.13559000,Zwedru,"Zwedru|(6.06846000,-8.13559000)"
+Liberia,LR,Grand Kru,Barclayville,Monrovia,,,4.67443000,-8.23306000,Barclayville,"Barclayville|(4.67443000,-8.23306000)"
+Liberia,LR,Lofa,Voinjama,Monrovia,,,8.42194000,-9.74778000,Voinjama,"Voinjama|(8.42194000,-9.74778000)"
+Liberia,LR,Margibi,Kakata,Monrovia,,,6.53104000,-10.35368000,Kakata,"Kakata|(6.53104000,-10.35368000)"
+Liberia,LR,Maryland,Harper,Monrovia,,,4.37820000,-7.71081000,Harper,"Harper|(4.37820000,-7.71081000)"
+Liberia,LR,Montserrado,Bensonville,Monrovia,,,6.44716000,-10.61283000,Bensonville;Monrovia,"Bensonville|(6.44716000,-10.61283000);Monrovia|(6.30054000,-10.79690000)"
+Liberia,LR,Nimba,Ganta,Monrovia,,,7.30222000,-8.53083000,Ganta;New Yekepa;Sanniquellie,"Ganta|(7.30222000,-8.53083000);New Yekepa|(7.57944000,-8.53778000);Sanniquellie|(7.36215000,-8.71326000)"
+Liberia,LR,River Cess,Cestos City,Monrovia,,,5.45683000,-9.58167000,Cestos City,"Cestos City|(5.45683000,-9.58167000)"
+Liberia,LR,River Gee,Fish Town,Monrovia,,,5.19739000,-7.87579000,Fish Town,"Fish Town|(5.19739000,-7.87579000)"
+Liberia,LR,Sinoe,Greenville,Monrovia,,,5.01133000,-9.03880000,Greenville,"Greenville|(5.01133000,-9.03880000)"
+Libya,LY,Al Wahat,Ajdabiya,Tripolis,,,30.75545000,20.22625000,Ajdabiya;Al Burayqah;Awjilah,"Ajdabiya|(30.75545000,20.22625000);Al Burayqah|(30.40624000,19.57386000);Awjilah|(29.10806000,21.28694000)"
+Libya,LY,Benghazi,Benghazi,Tripolis,,,32.11486000,20.06859000,Benghazi;Qaryat Sulūq,"Benghazi|(32.11486000,20.06859000);Qaryat Sulūq|(31.66818000,20.25205000)"
+Libya,LY,Derna,Al Qubbah,Tripolis,,,32.75684000,22.24106000,Al Qubbah;Darnah,"Al Qubbah|(32.75684000,22.24106000);Darnah|(32.76704000,22.63669000)"
+Libya,LY,Ghat,Ghat,Tripolis,,,24.96334000,10.18003000,Ghat,"Ghat|(24.96334000,10.18003000)"
+Libya,LY,Jabal al Akhdar,Al Bayḑā’,Tripolis,,,32.76272000,21.75506000,Al Bayḑā’,"Al Bayḑā’|(32.76272000,21.75506000)"
+Libya,LY,Jabal al Gharbi,Gharyan,Tripolis,,,32.17222000,13.02028000,Gharyan;Giado;Mizdah,"Gharyan|(32.17222000,13.02028000);Giado|(31.95506000,12.02901000);Mizdah|(31.44934000,12.98530000)"
+Libya,LY,Jafara,Al ‘Azīzīyah,Tripolis,,,32.53194000,13.01750000,Al ‘Azīzīyah,"Al ‘Azīzīyah|(32.53194000,13.01750000)"
+Libya,LY,Jufra,Hūn,Tripolis,,,29.12684000,15.94772000,Hūn;Waddān,"Hūn|(29.12684000,15.94772000);Waddān|(29.16140000,16.13904000)"
+Libya,LY,Kufra,Al Jawf,Tripolis,,,24.19890000,23.29093000,Al Jawf;At Tāj,"Al Jawf|(24.19890000,23.29093000);At Tāj|(24.20487000,23.28570000)"
+Libya,LY,Marj,Al Abyār,Tripolis,,,32.19000000,20.59653000,Al Abyār;Al Marj;Tūkrah,"Al Abyār|(32.19000000,20.59653000);Al Marj|(32.49257000,20.82909000);Tūkrah|(32.53414000,20.57911000)"
+Libya,LY,Misrata,Bani Walid,Tripolis,,,31.74554000,13.98354000,Bani Walid;Mişrātah;Zliten,"Bani Walid|(31.74554000,13.98354000);Mişrātah|(32.37535000,15.09254000);Zliten|(32.46739000,14.56874000)"
+Libya,LY,Murqub,Al Khums,Tripolis,,,32.64861000,14.26191000,Al Khums;Masallātah;Tarhuna,"Al Khums|(32.64861000,14.26191000);Masallātah|(32.61667000,14.00000000);Tarhuna|(32.43501000,13.63320000)"
+Libya,LY,Murzuq,Murzuq,Tripolis,,,25.91552000,13.91839000,Al Qaţrūn;Murzuq,"Al Qaţrūn|(24.95139000,14.64861000);Murzuq|(25.91552000,13.91839000)"
+Libya,LY,Nalut,Ghadāmis,Tripolis,,,30.13366000,9.50072000,Ghadāmis;Nālūt,"Ghadāmis|(30.13366000,9.50072000);Nālūt|(31.86848000,10.98120000)"
+Libya,LY,Nuqat al Khams,Al Ajaylat,Tripolis,,,32.75718000,12.37633000,Al Ajaylat;Zalţan;Zuwārah,"Al Ajaylat|(32.75718000,12.37633000);Zalţan|(32.94699000,11.86668000);Zuwārah|(32.93120000,12.08199000)"
+Libya,LY,Sabha,Al Jadīd,Tripolis,,,27.05000000,14.40000000,Al Jadīd;Sabhā,"Al Jadīd|(27.05000000,14.40000000);Sabhā|(27.03766000,14.42832000)"
+Libya,LY,Sirte,Sirte,Tripolis,,,31.20892000,16.58866000,Qasr Abu Hadi;Sirte,"Qasr Abu Hadi|(31.05926000,16.65905000);Sirte|(31.20892000,16.58866000)"
+Libya,LY,Tripoli,Tripoli,Tripolis,,,32.88743000,13.18733000,Tagiura;Tripoli,"Tagiura|(32.88167000,13.35056000);Tripoli|(32.88743000,13.18733000)"
+Libya,LY,Wadi al Hayaa,Ubari,Tripolis,,,26.59034000,12.77511000,Ubari,"Ubari|(26.59034000,12.77511000)"
+Libya,LY,Wadi al Shatii,Brak,Tripolis,,,27.54956000,14.27139000,Brak;Idrī,"Brak|(27.54956000,14.27139000);Idrī|(27.44707000,13.05173000)"
+Libya,LY,Zawiya,Zawiya,Tripolis,,,32.75222000,12.72778000,Az Zāwīyah;Şabrātah;Şurmān,"Az Zāwīyah|(32.75710000,12.72764000);Şabrātah|(32.79335000,12.48845000);Şurmān|(32.75668000,12.57159000)"
+Liechtenstein,LI,Balzers,Balzers,Vaduz,,,47.06665000,9.50251000,Balzers,"Balzers|(47.06665000,9.50251000)"
+Liechtenstein,LI,Eschen,Eschen,Vaduz,,,47.21071000,9.52223000,Eschen,"Eschen|(47.21071000,9.52223000)"
+Liechtenstein,LI,Gamprin,Gamprin,Vaduz,,,47.22038000,9.50935000,Gamprin,"Gamprin|(47.22038000,9.50935000)"
+Liechtenstein,LI,Mauren,Mauren,Vaduz,,,47.21805000,9.54420000,Mauren,"Mauren|(47.21805000,9.54420000)"
+Liechtenstein,LI,Planken,Planken,Vaduz,,,47.18516000,9.54437000,Planken,"Planken|(47.18516000,9.54437000)"
+Liechtenstein,LI,Ruggell,Ruggell,Vaduz,,,47.23799000,9.52540000,Ruggell,"Ruggell|(47.23799000,9.52540000)"
+Liechtenstein,LI,Schaan,Schaan,Vaduz,,,47.16498000,9.50867000,Schaan,"Schaan|(47.16498000,9.50867000)"
+Liechtenstein,LI,Schellenberg,Schellenberg,Vaduz,,,47.23123000,9.54678000,Schellenberg,"Schellenberg|(47.23123000,9.54678000)"
+Liechtenstein,LI,Triesen,Triesen,Vaduz,,,47.10752000,9.52815000,Triesen,"Triesen|(47.10752000,9.52815000)"
+Liechtenstein,LI,Triesenberg,Triesenberg,Vaduz,,,47.11815000,9.54197000,Triesenberg,"Triesenberg|(47.11815000,9.54197000)"
+Liechtenstein,LI,Vaduz,Vaduz,Vaduz,,,47.14151000,9.52154000,Vaduz,"Vaduz|(47.14151000,9.52154000)"
+Lithuania,LT,Akmenė,,Vilnius,,,,,,
+Lithuania,LT,Alytus,Alytus,Vilnius,,,54.39635000,24.04142000,Alytus;Daugai;Druskininkai,"Alytus|(54.39635000,24.04142000);Daugai|(54.36667000,24.33333000);Druskininkai|(54.01573000,23.98703000)"
+Lithuania,LT,Alytus,,Vilnius,,,,,,
+Lithuania,LT,Anykščiai,,Vilnius,,,,,,
+Lithuania,LT,Birštonas,,Vilnius,,,,,,
+Lithuania,LT,Biržai,,Vilnius,,,,,,
+Lithuania,LT,Druskininkai,,Vilnius,,,,,,
+Lithuania,LT,Elektrėnai,,Vilnius,,,,,,
+Lithuania,LT,Ignalina,,Vilnius,,,,,,
+Lithuania,LT,Jonava,,Vilnius,,,,,,
+Lithuania,LT,Joniškis,,Vilnius,,,,,,
+Lithuania,LT,Jurbarkas,,Vilnius,,,,,,
+Lithuania,LT,Kaišiadorys,,Vilnius,,,,,,
+Lithuania,LT,Kalvarija,,Vilnius,,,,,,
+Lithuania,LT,Kaunas,Kaunas,Vilnius,,,54.90272000,23.90961000,Akademija (Kaunas);Aleksotas;Ariogala,"Akademija (Kaunas)|(54.89640000,23.82411000);Aleksotas|(54.88037000,23.90842000);Ariogala|(55.26200000,23.47700000)"
+Lithuania,LT,Kaunas,,Vilnius,,,,,,
+Lithuania,LT,Kazlų Rūda,,Vilnius,,,,,,
+Lithuania,LT,Kėdainiai,,Vilnius,,,,,,
+Lithuania,LT,Kelmė,,Vilnius,,,,,,
+Lithuania,LT,Klaipėda,,Vilnius,,,,,,
+Lithuania,LT,Klaipėda,Klaipėda,Vilnius,,,55.71667000,21.11667000,Gargždai;Klaipėda;Kretinga,"Gargždai|(55.70951000,21.39441000);Klaipėda|(55.71667000,21.11667000);Kretinga|(55.88880000,21.24448000)"
+Lithuania,LT,Kretinga,,Vilnius,,,,,,
+Lithuania,LT,Kupiškis,,Vilnius,,,,,,
+Lithuania,LT,Lazdijai,,Vilnius,,,,,,
+Lithuania,LT,Marijampolė,Marijampolė,Vilnius,,,54.55991000,23.35412000,Gelgaudiškis;Kalvarija;Kalvarija Municipality,"Gelgaudiškis|(55.07688000,22.97699000);Kalvarija|(54.41700000,23.22300000);Kalvarija Municipality|(54.41468000,23.22484000)"
+Lithuania,LT,Marijampolė,,Vilnius,,,,,,
+Lithuania,LT,Mažeikiai,,Vilnius,,,,,,
+Lithuania,LT,Molėtai,,Vilnius,,,,,,
+Lithuania,LT,Neringa,,Vilnius,,,,,,
+Lithuania,LT,Pagėgiai,,Vilnius,,,,,,
+Lithuania,LT,Pakruojis,,Vilnius,,,,,,
+Lithuania,LT,Palanga,,Vilnius,,,,,,
+Lithuania,LT,Panevėžys,,Vilnius,,,,,,
+Lithuania,LT,Panevėžys,Panevėžys,Vilnius,,,55.73333000,24.35000000,Birzai;Juodupė;Kupiskis,"Birzai|(56.20000000,24.75000000);Juodupė|(56.08700000,25.60700000);Kupiskis|(55.84027000,24.97976000)"
+Lithuania,LT,Pasvalys,,Vilnius,,,,,,
+Lithuania,LT,Plungė,,Vilnius,,,,,,
+Lithuania,LT,Prienai,,Vilnius,,,,,,
+Lithuania,LT,Radviliškis,,Vilnius,,,,,,
+Lithuania,LT,Raseiniai,,Vilnius,,,,,,
+Lithuania,LT,Rietavas,,Vilnius,,,,,,
+Lithuania,LT,Rokiškis,,Vilnius,,,,,,
+Lithuania,LT,Šakiai,,Vilnius,,,,,,
+Lithuania,LT,Šalčininkai,,Vilnius,,,,,,
+Lithuania,LT,Šiauliai,,Vilnius,,,,,,
+Lithuania,LT,Šiauliai,Šiauliai,Vilnius,,,55.93333000,23.31667000,Akmenė;Joniškis;Kelmė,"Akmenė|(56.25000000,22.75000000);Joniškis|(56.23333000,23.61667000);Kelmė|(55.63333000,22.93333000)"
+Lithuania,LT,Šilalė ,,Vilnius,,,,,,
+Lithuania,LT,Šilutė,,Vilnius,,,,,,
+Lithuania,LT,Širvintos,,Vilnius,,,,,,
+Lithuania,LT,Skuodas,,Vilnius,,,,,,
+Lithuania,LT,Švenčionys,,Vilnius,,,,,,
+Lithuania,LT,Tauragė,Būgai,Vilnius,,,55.41387000,22.60894000,Būgai;Jurbarkas;Pagėgiai,"Būgai|(55.41387000,22.60894000);Jurbarkas|(55.10859000,22.79885000);Pagėgiai|(55.13400000,21.90446000)"
+Lithuania,LT,Tauragė,,Vilnius,,,,,,
+Lithuania,LT,Telšiai,Mazeikiai,Vilnius,,,56.31667000,22.33333000,Mazeikiai;Plateliai;Plunge,"Mazeikiai|(56.31667000,22.33333000);Plateliai|(56.04657000,21.81615000);Plunge|(55.91139000,21.84417000)"
+Lithuania,LT,Telšiai,,Vilnius,,,,,,
+Lithuania,LT,Trakai,,Vilnius,,,,,,
+Lithuania,LT,Ukmergė,,Vilnius,,,,,,
+Lithuania,LT,Utena,,Vilnius,,,,,,
+Lithuania,LT,Utena,Utena,Vilnius,,,55.49764000,25.59918000,Anyksciai;Dūkštas;Ignalina,"Anyksciai|(55.52557000,25.10264000);Dūkštas|(55.52200000,26.32100000);Ignalina|(55.35000000,26.16667000)"
+Lithuania,LT,Varėna,,Vilnius,,,,,,
+Lithuania,LT,Vilkaviškis,,Vilnius,,,,,,
+Lithuania,LT,Vilnius,Vilnius,Vilnius,,,54.68916000,25.27980000,Aukstadvaris;Baltoji Vokė;Eišiškės,"Aukstadvaris|(54.57946000,24.52683000);Baltoji Vokė|(54.60002000,25.19318000);Eišiškės|(54.17414000,24.99917000)"
+Lithuania,LT,Vilnius,,Vilnius,,,,,,
+Lithuania,LT,Visaginas,,Vilnius,,,,,,
+Lithuania,LT,Zarasai,,Vilnius,,,,,,
+Luxembourg,LU,Capellen,Capellen,Luxembourg,,,49.64500000,5.99083000,Bascharage;Bridel;Capellen,"Bascharage|(49.56727000,5.90730000);Bridel|(49.65579000,6.07999000);Capellen|(49.64500000,5.99083000)"
+Luxembourg,LU,Clervaux,Clervaux,Luxembourg,,,50.05472000,6.03139000,Clervaux;Hosingen;Parc Hosingen,"Clervaux|(50.05472000,6.03139000);Hosingen|(50.01218000,6.09089000);Parc Hosingen|(49.99744000,6.09067000)"
+Luxembourg,LU,Diekirch,Diekirch,Luxembourg,,,49.86778000,6.15583000,Bettendorf;Bourscheid;Commune de la Vallée de l’Ernz,"Bettendorf|(49.87667000,6.21806000);Bourscheid|(49.90862000,6.06750000);Commune de la Vallée de l’Ernz|(49.82149000,6.21746000)"
+Luxembourg,LU,Echternach,Echternach,Luxembourg,,,49.81212000,6.41846000,Beaufort;Bech;Berdorf,"Beaufort|(49.83583000,6.29167000);Bech|(49.75260000,6.36379000);Berdorf|(49.82051000,6.34945000)"
+Luxembourg,LU,Esch-sur-Alzette,Esch-sur-Alzette,Luxembourg,,,49.49583000,5.98056000,Aspelt;Belvaux;Bergem,"Aspelt|(49.52278000,6.22472000);Belvaux|(49.51014000,5.92414000);Bergem|(49.52500000,6.04222000)"
+Luxembourg,LU,Grevenmacher,Grevenmacher,Luxembourg,,,49.67751000,6.44022000,Betzdorf;Biwer;Flaxweiler,"Betzdorf|(49.68333000,6.35000000);Biwer|(49.70605000,6.37201000);Flaxweiler|(49.66602000,6.34321000)"
+Luxembourg,LU,Luxembourg ,Luxembourg,Luxembourg,,,49.61167000,6.13000000,Alzingen;Béreldange;Bertrange,"Alzingen|(49.56500000,6.16361000);Béreldange|(49.65507000,6.11874000);Bertrange|(49.61111000,6.05000000)"
+Luxembourg,LU,Mersch,Mersch,Luxembourg,,,49.74889000,6.10611000,Bissen;Boevange-sur-Attert;Colmar,"Bissen|(49.78733000,6.06540000);Boevange-sur-Attert|(49.77256000,6.01532000);Colmar|(49.81028000,6.09722000)"
+Luxembourg,LU,Redange,Beckerich,Luxembourg,,,49.73056000,5.88722000,Beckerich;Bettborn;Commune de Préizerdaul,"Beckerich|(49.73056000,5.88722000);Bettborn|(49.79528000,5.94111000);Commune de Préizerdaul|(49.80114000,5.93299000)"
+Luxembourg,LU,Remich,Remich,Luxembourg,,,49.54500000,6.36694000,Bous;Dalheim;Lenningen,"Bous|(49.55389000,6.32917000);Dalheim|(49.54083000,6.25972000);Lenningen|(49.59861000,6.36806000)"
+Luxembourg,LU,Vianden,Vianden,Luxembourg,,,49.93500000,6.20889000,Putscheid;Tandel;Vianden,"Putscheid|(49.96083000,6.14306000);Tandel|(49.89750000,6.18333000);Vianden|(49.93500000,6.20889000)"
+Luxembourg,LU,Wiltz,Wiltz,Luxembourg,,,49.96547000,5.93390000,Bavigne;Boulaide;Esch-sur-Sûre,"Bavigne|(49.92194000,5.84944000);Boulaide|(49.88778000,5.81639000);Esch-sur-Sûre|(49.91139000,5.93639000)"
+Madagascar,MG,Antananarivo,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Antsiranana,Ampasimanolotra,Antananarivo,EMEA,14,-18.81667000,49.06667000,Ampasimanolotra;Andovoranto;Mahanoro,"Ampasimanolotra|(-18.81667000,49.06667000);Andovoranto|(-18.95443000,49.10940000);Mahanoro|(-19.90000000,48.80000000)"
+Madagascar,MG,Fianarantsoa,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Mahajanga,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Toamasina,,Antananarivo,EMEA,14,,,,
+Madagascar,MG,Toliara,,Antananarivo,EMEA,14,,,,
+Malawi,MW,Balaka,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Blantyre,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Central,Chipoka,Lilongwe,EMEA,14,-13.99329000,34.51566000,Chipoka;Dedza;Dedza District,"Chipoka|(-13.99329000,34.51566000);Dedza|(-14.37790000,34.33322000);Dedza District|(-14.26273000,34.18559000)"
+Malawi,MW,Chikwawa,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Chiradzulu,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Chitipa,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Dedza,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Dowa,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Karonga,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Kasungu,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Likoma,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Lilongwe,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Machinga,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mangochi,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mchinji,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mulanje,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mwanza,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Mzimba,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Neno,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Nkhata Bay,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Nkhotakota,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Northern,Chitipa,Lilongwe,EMEA,14,-9.70237000,33.26969000,Chitipa;Chitipa District;Karonga,"Chitipa|(-9.70237000,33.26969000);Chitipa District|(-9.92727000,33.42541000);Karonga|(-9.93333000,33.93333000)"
+Malawi,MW,Nsanje,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Ntcheu,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Ntchisi,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Phalombe,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Rumphi,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Salima,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Southern,Balaka,Lilongwe,EMEA,14,-14.97928000,34.95575000,Balaka;Balaka District;Blantyre,"Balaka|(-14.97928000,34.95575000);Balaka District|(-15.04839000,35.05910000);Blantyre|(-15.78499000,35.00854000)"
+Malawi,MW,Thyolo,,Lilongwe,EMEA,14,,,,
+Malawi,MW,Zomba,,Lilongwe,EMEA,14,,,,
+Malaysia,MY,Johor,Bakri,Kuala Lumpur,,,2.04410000,102.65270000,Bakri;Batu Pahat;Buloh Kasap,"Bakri|(2.04410000,102.65270000);Batu Pahat|(1.85480000,102.93250000);Buloh Kasap|(2.55360000,102.76400000)"
+Malaysia,MY,Kedah,Alor Setar,Kuala Lumpur,,,6.12104000,100.36014000,Alor Setar;Ayer Hangat;Bedong,"Alor Setar|(6.12104000,100.36014000);Ayer Hangat|(6.42062000,99.82199000);Bedong|(5.72743000,100.50876000)"
+Malaysia,MY,Kelantan,Gua Musang,Kuala Lumpur,,,4.88441000,101.96857000,Gua Musang;Kampong Kadok;Kampong Pangkal Kalong,"Gua Musang|(4.88441000,101.96857000);Kampong Kadok|(6.00000000,102.25000000);Kampong Pangkal Kalong|(5.91667000,102.21667000)"
+Malaysia,MY,Kuala Lumpur,Kuala Lumpur,Kuala Lumpur,,,3.14120000,101.68653000,Kuala Lumpur,"Kuala Lumpur|(3.14120000,101.68653000)"
+Malaysia,MY,Labuan,Labuan,Kuala Lumpur,,,5.28028000,115.24750000,Labuan,"Labuan|(5.28028000,115.24750000)"
+Malaysia,MY,Malacca,Malacca,Kuala Lumpur,,,2.19600000,102.24050000,Alor Gajah;Batu Berendam;Bemban,"Alor Gajah|(2.38040000,102.20890000);Batu Berendam|(2.24870000,102.24600000);Bemban|(2.26840000,102.37460000)"
+Malaysia,MY,Negeri Sembilan,Bahau,Kuala Lumpur,,,2.80790000,102.40490000,Bahau;Kampung Baharu Nilai;Kuala Pilah,"Bahau|(2.80790000,102.40490000);Kampung Baharu Nilai|(2.80330000,101.79720000);Kuala Pilah|(2.73890000,102.24870000)"
+Malaysia,MY,Pahang,Bentong Town,Kuala Lumpur,,,3.52229000,101.90866000,Bentong Town;Jerantut;Kampung Bukit Tinggi Bentong,"Bentong Town|(3.52229000,101.90866000);Jerantut|(3.93600000,102.36260000);Kampung Bukit Tinggi Bentong|(3.34944000,101.82631000)"
+Malaysia,MY,Penang,Batu Feringgi,Kuala Lumpur,,,5.47090000,100.24529000,Batu Feringgi;Bukit Mertajam;Butterworth,"Batu Feringgi|(5.47090000,100.24529000);Bukit Mertajam|(5.36301000,100.46670000);Butterworth|(5.39910000,100.36382000)"
+Malaysia,MY,Perak,Bagan Serai,Kuala Lumpur,,,5.01080000,100.54101000,Bagan Serai;Batu Gajah;Bidur,"Bagan Serai|(5.01080000,100.54101000);Batu Gajah|(4.46916000,101.04107000);Bidur|(4.11667000,101.28333000)"
+Malaysia,MY,Perlis,Kangar,Kuala Lumpur,,,6.44140000,100.19862000,Kangar;Kuala Perlis;Pantai Cenang,"Kangar|(6.44140000,100.19862000);Kuala Perlis|(6.40000000,100.13333000);Pantai Cenang|(6.29369000,99.72786000)"
+Malaysia,MY,Putrajaya,Putrajaya,Kuala Lumpur,,,2.93527000,101.69112000,Putrajaya,"Putrajaya|(2.93527000,101.69112000)"
+Malaysia,MY,Sabah,Bandar Labuan,Kuala Lumpur,,,5.28883000,115.26924000,Bandar Labuan;Beaufort;Donggongon,"Bandar Labuan|(5.28883000,115.26924000);Beaufort|(5.34730000,115.74550000);Donggongon|(5.90702000,116.10146000)"
+Malaysia,MY,Sarawak,Bintulu,Kuala Lumpur,,,3.16667000,113.03333000,Bintulu;Data Kakus;Kapit,"Bintulu|(3.16667000,113.03333000);Data Kakus|(2.65465000,113.62249000);Kapit|(1.99546000,112.93254000)"
+Malaysia,MY,Selangor,Ampang,Kuala Lumpur,,,3.15000000,101.76667000,Ampang;Bagan Pulau Ketam;Banting,"Ampang|(3.15000000,101.76667000);Bagan Pulau Ketam|(3.01667000,101.26667000);Banting|(2.81360000,101.50185000)"
+Malaysia,MY,Terengganu,Cukai,Kuala Lumpur,,,4.25000000,103.41667000,Cukai;Jertih;Kampung Kuala Besut,"Cukai|(4.25000000,103.41667000);Jertih|(5.73360000,102.48970000);Kampung Kuala Besut|(5.83297000,102.55061000)"
+Maldives,MV,Addu,Hithadhoo,Male,,,-0.60000000,73.08333000,Hithadhoo;Meedhoo,"Hithadhoo|(-0.60000000,73.08333000);Meedhoo|(-0.58333000,73.23333000)"
+Maldives,MV,Alif Alif,,Male,,,,,,
+Maldives,MV,Alif Dhaal,,Male,,,,,,
+Maldives,MV,Central,,Male,,,,,,
+Maldives,MV,Dhaalu,Kudahuvadhoo,Male,,,2.67075000,72.89437000,Kudahuvadhoo,"Kudahuvadhoo|(2.67075000,72.89437000)"
+Maldives,MV,Faafu,,Male,,,,,,
+Maldives,MV,Gaafu Alif,Viligili,Male,,,0.75906000,73.43296000,Viligili,"Viligili|(0.75906000,73.43296000)"
+Maldives,MV,Gaafu Dhaalu,Thinadhoo,Male,,,0.53060000,72.99969000,Thinadhoo,"Thinadhoo|(0.53060000,72.99969000)"
+Maldives,MV,Gnaviyani,Fuvahmulah,Male,,,-0.29878000,73.42403000,Fuvahmulah,"Fuvahmulah|(-0.29878000,73.42403000)"
+Maldives,MV,Haa Alif,Dhidhdhoo,Male,,,6.88744000,73.11402000,Dhidhdhoo,"Dhidhdhoo|(6.88744000,73.11402000)"
+Maldives,MV,Haa Dhaalu,Kulhudhuffushi,Male,,,6.62207000,73.06998000,Kulhudhuffushi,"Kulhudhuffushi|(6.62207000,73.06998000)"
+Maldives,MV,Kaafu,Guraidhoo,Male,,,3.90045000,73.46623000,Guraidhoo;Hulhumale;Maafushi,"Guraidhoo|(3.90045000,73.46623000);Hulhumale|(4.21169000,73.54008000);Maafushi|(3.94231000,73.49070000)"
+Maldives,MV,Laamu,Fonadhoo,Male,,,1.83243000,73.50257000,Fonadhoo,"Fonadhoo|(1.83243000,73.50257000)"
+Maldives,MV,Lhaviyani,Naifaru,Male,,,5.44438000,73.36571000,Naifaru,"Naifaru|(5.44438000,73.36571000)"
+Maldives,MV,Malé,,Male,,,,,,
+Maldives,MV,Meemu,Muli,Male,,,2.91667000,73.56667000,Muli,"Muli|(2.91667000,73.56667000)"
+Maldives,MV,Noonu,Manadhoo,Male,,,5.76687000,73.41360000,Manadhoo,"Manadhoo|(5.76687000,73.41360000)"
+Maldives,MV,North Central,,Male,,,,,,
+Maldives,MV,Raa,Ugoofaaru,Male,,,5.66812000,73.03017000,Ugoofaaru,"Ugoofaaru|(5.66812000,73.03017000)"
+Maldives,MV,Shaviyani,Funadhoo,Male,,,6.15091000,73.29013000,Funadhoo,"Funadhoo|(6.15091000,73.29013000)"
+Maldives,MV,South,,Male,,,,,,
+Maldives,MV,South Central,Mahibadhoo,Male,,,3.75713000,72.96893000,Mahibadhoo,"Mahibadhoo|(3.75713000,72.96893000)"
+Maldives,MV,Thaa,Veymandoo,Male,,,2.18772000,73.09556000,Veymandoo,"Veymandoo|(2.18772000,73.09556000)"
+Maldives,MV,Upper South,,Male,,,,,,
+Maldives,MV,Vaavu,Felidhoo,Male,,,3.47182000,73.54699000,Felidhoo,"Felidhoo|(3.47182000,73.54699000)"
+Mali,ML,Bamako,Bamako,Bamako,EMEA,11,12.65000000,-8.00000000,Bamako,"Bamako|(12.65000000,-8.00000000)"
+Mali,ML,Gao,Gao,Bamako,EMEA,11,16.27167000,-0.04472000,Ansongo;Cercle de Bourem;Gao,"Ansongo|(15.65970000,0.50220000);Cercle de Bourem|(17.71192000,-0.34284000);Gao|(16.27167000,-0.04472000)"
+Mali,ML,Kayes,Kayes,Bamako,EMEA,11,14.44693000,-11.44448000,Bafoulabé;Kayes;Kita,"Bafoulabé|(13.80650000,-10.83210000);Kayes|(14.44693000,-11.44448000);Kita|(13.03490000,-9.48950000)"
+Mali,ML,Kidal,Kidal,Bamako,EMEA,11,18.44111000,1.40778000,Abeïbara;Cercle d’Abeïbara;Kidal,"Abeïbara|(19.11667000,1.75000000);Cercle d’Abeïbara|(19.48878000,2.20025000);Kidal|(18.44111000,1.40778000)"
+Mali,ML,Koulikoro,Koulikoro,Bamako,EMEA,11,12.86273000,-7.55985000,Banamba;Kangaba;Kati,"Banamba|(13.54773000,-7.44808000);Kangaba|(11.93333000,-8.41667000);Kati|(12.74409000,-8.07257000)"
+Mali,ML,Ménaka,,Bamako,EMEA,11,,,,
+Mali,ML,Mopti,Mopti,Bamako,EMEA,11,14.48430000,-4.18296000,Bandiagara;Djénné;Douentza,"Bandiagara|(14.35005000,-3.61038000);Djénné|(13.90608000,-4.55332000);Douentza|(15.00155000,-2.94978000)"
+Mali,ML,Ségou,Ségou,Bamako,EMEA,11,13.43170000,-6.21570000,Baroueli;Cercle de San;Ké-Macina,"Baroueli|(13.07489000,-6.57171000);Cercle de San|(13.17895000,-5.01617000);Ké-Macina|(13.96410000,-5.35791000)"
+Mali,ML,Sikasso,Sikasso,Bamako,EMEA,11,11.31755000,-5.66654000,Bougouni;Kolondiéba;Koutiala,"Bougouni|(11.41769000,-7.48323000);Kolondiéba|(11.08943000,-6.89290000);Koutiala|(12.39173000,-5.46421000)"
+Mali,ML,Taoudénit,,Bamako,EMEA,11,,,,
+Mali,ML,Tombouctou,Araouane,Bamako,EMEA,11,18.90476000,-3.52649000,Araouane;Cercle de Goundam;Dire,"Araouane|(18.90476000,-3.52649000);Cercle de Goundam|(18.60035000,-4.99306000);Dire|(16.28017000,-3.31302000)"
+Malta,MT,Attard,Attard,Valletta,,,35.88972000,14.44250000,Attard,"Attard|(35.88972000,14.44250000)"
+Malta,MT,Balzan,Balzan,Valletta,,,35.90028000,14.45500000,Balzan,"Balzan|(35.90028000,14.45500000)"
+Malta,MT,Birgu,Birgu (Vittoriosa),Valletta,,,35.89222000,14.51833000,Birgu (Vittoriosa),"Birgu (Vittoriosa)|(35.89222000,14.51833000)"
+Malta,MT,Birkirkara,Birkirkara,Valletta,,,35.89722000,14.46111000,Birkirkara;Fleur De Lys;Swatar,"Birkirkara|(35.89722000,14.46111000);Fleur De Lys|(35.89530000,14.46560000);Swatar|(35.89877800,14.47659200)"
+Malta,MT,Birżebbuġa,Birżebbuġa,Valletta,,,35.82583000,14.52694000,Birżebbuġa;Ħal Far,"Birżebbuġa|(35.82583000,14.52694000);Ħal Far|(35.81134900,14.51068600)"
+Malta,MT,Cospicua,Cospicua,Valletta,,,35.88556000,14.52750000,Cospicua,"Cospicua|(35.88556000,14.52750000)"
+Malta,MT,Dingli,Dingli,Valletta,,,35.86139000,14.38222000,Dingli,"Dingli|(35.86139000,14.38222000)"
+Malta,MT,Fgura,Fgura,Valletta,,,35.87028000,14.51333000,Fgura,"Fgura|(35.87028000,14.51333000)"
+Malta,MT,Floriana,Floriana,Valletta,,,35.89583000,14.50833000,Floriana,"Floriana|(35.89583000,14.50833000)"
+Malta,MT,Fontana,Fontana,Valletta,,,36.03750000,14.23611000,Fontana,"Fontana|(36.03750000,14.23611000)"
+Malta,MT,Għajnsielem,Għajnsielem,Valletta,,,36.02639000,14.28500000,Għajnsielem;Ħal Għargħur,"Għajnsielem|(36.02639000,14.28500000);Ħal Għargħur|(35.92409000,14.45118000)"
+Malta,MT,Għarb,,Valletta,,,,,,
+Malta,MT,Għargħur,Ħal Għaxaq,Valletta,,,35.84889000,14.51667000,Ħal Għaxaq,"Ħal Għaxaq|(35.84889000,14.51667000)"
+Malta,MT,Għasri,Gudja,Valletta,,,35.84917000,14.50306000,Gudja,"Gudja|(35.84917000,14.50306000)"
+Malta,MT,Għaxaq,Gżira,Valletta,,,35.90583000,14.48806000,Gżira,"Gżira|(35.90583000,14.48806000)"
+Malta,MT,Gudja,,Valletta,,,,,,
+Malta,MT,Gżira,Għarb,Valletta,,,36.06000000,14.20889000,Għarb,"Għarb|(36.06000000,14.20889000)"
+Malta,MT,Ħamrun,Ħamrun,Valletta,,,35.88472000,14.48444000,Blata l' Bajda;Ħamrun,"Blata l' Bajda|(35.88750000,14.49861100);Ħamrun|(35.88472000,14.48444000)"
+Malta,MT,Iklin,L-Iklin,Valletta,,,35.90414000,14.45415000,L-Iklin,"L-Iklin|(35.90414000,14.45415000)"
+Malta,MT,Kalkara,Imġarr,Valletta,,,35.92056000,14.36639000,Imġarr;Mġarr,"Imġarr|(35.92056000,14.36639000);Mġarr|(36.02528000,14.29500000)"
+Malta,MT,Kerċem,Mqabba,Valletta,,,35.84763000,14.46824000,Mqabba,"Mqabba|(35.84763000,14.46824000)"
+Malta,MT,Kirkop,Kirkop,Valletta,,,35.84222000,14.48528000,Imsida;Kirkop,"Imsida|(35.89250000,14.48278000);Kirkop|(35.84222000,14.48528000)"
+Malta,MT,Lija,Ħal Lija,Valletta,,,35.90056000,14.44639000,Ħal Lija;Imtarfa,"Ħal Lija|(35.90056000,14.44639000);Imtarfa|(35.89333000,14.39889000)"
+Malta,MT,Luqa,Ħal Luqa,Valletta,,,35.85889000,14.48861000,Ħal Luqa;Ħal Safi;Senglea,"Ħal Luqa|(35.85889000,14.48861000);Ħal Safi|(35.83333300,14.48500000);Senglea|(35.88750000,14.51694000)"
+Malta,MT,Marsa,Kalkara,Valletta,,,35.88917000,14.53278000,Kalkara,"Kalkara|(35.88917000,14.53278000)"
+Malta,MT,Marsaskala,Marsaskala,Valletta,,,35.86220000,14.56701000,Kerċem;Marsaskala,"Kerċem|(36.04194000,14.22667000);Marsaskala|(35.86220000,14.56701000)"
+Malta,MT,Marsaxlokk,Marsaxlokk,Valletta,,,35.84194000,14.54306000,Marsaxlokk,"Marsaxlokk|(35.84194000,14.54306000)"
+Malta,MT,Mdina,,Valletta,,,,,,
+Malta,MT,Mellieħa,Manikata,Valletta,,,35.94000000,14.35333000,Manikata,"Manikata|(35.94000000,14.35333000)"
+Malta,MT,Mġarr,Marsa,Valletta,,,35.87917000,14.49528000,Marsa,"Marsa|(35.87917000,14.49528000)"
+Malta,MT,Mosta,Bidnija,Valletta,,,35.92694400,14.39833300,Bidnija,"Bidnija|(35.92694400,14.39833300)"
+Malta,MT,Mqabba,,Valletta,,,,,,
+Malta,MT,Msida,Mellieħa,Valletta,,,35.95639000,14.36222000,Mellieħa,"Mellieħa|(35.95639000,14.36222000)"
+Malta,MT,Mtarfa,,Valletta,,,,,,
+Malta,MT,Munxar,Munxar,Valletta,,,36.03000000,14.23333000,Munxar,"Munxar|(36.03000000,14.23333000)"
+Malta,MT,Nadur,Nadur,Valletta,,,36.03778000,14.29417000,Nadur,"Nadur|(36.03778000,14.29417000)"
+Malta,MT,Naxxar,Naxxar,Valletta,,,35.91361000,14.44361000,Baħar iċ-Ċagħaq;Magħtab;Naxxar,"Baħar iċ-Ċagħaq|(35.93878700,14.45372500);Magħtab|(35.94500000,14.44000000);Naxxar|(35.91361000,14.44361000)"
+Malta,MT,Paola,Paola,Valletta,,,35.87306000,14.49889000,Paola,"Paola|(35.87306000,14.49889000)"
+Malta,MT,Pembroke,Pembroke,Valletta,,,35.93056000,14.47639000,Pembroke,"Pembroke|(35.93056000,14.47639000)"
+Malta,MT,Pietà,Pietà,Valletta,,,35.89472000,14.49500000,Pietà,"Pietà|(35.89472000,14.49500000)"
+Malta,MT,Qala,Qala,Valletta,,,36.03611000,14.30944000,Qala,"Qala|(36.03611000,14.30944000)"
+Malta,MT,Qormi,Qormi,Valletta,,,35.87601000,14.47200000,Qormi,"Qormi|(35.87601000,14.47200000)"
+Malta,MT,Qrendi,Qrendi,Valletta,,,35.83472000,14.45833000,Qrendi,"Qrendi|(35.83472000,14.45833000)"
+Malta,MT,Rabat,Baħrija,Valletta,,,35.89472200,14.34833300,Baħrija;Binġemma,"Baħrija|(35.89472200,14.34833300);Binġemma|(35.90277800,14.37777800)"
+Malta,MT,San Ġwann,San Ġiljan (St. Julian's),Valletta,,,35.91839000,14.48977000,San Ġiljan (St. Julian's),"San Ġiljan (St. Julian's)|(35.91839000,14.48977000)"
+Malta,MT,San Lawrenz,San Lawrenz,Valletta,,,36.05556000,14.20361000,San Lawrenz,"San Lawrenz|(36.05556000,14.20361000)"
+Malta,MT,Sannat,Sannat,Valletta,,,36.02444000,14.24278000,San Pawl il-Baħar;Sannat,"San Pawl il-Baħar|(35.95064000,14.41561000);Sannat|(36.02444000,14.24278000)"
+Malta,MT,Santa Luċija,Santa Venera,Valletta,,,35.89083000,14.47417000,Santa Venera,"Santa Venera|(35.89083000,14.47417000)"
+Malta,MT,Santa Venera,,Valletta,,,,,,
+Malta,MT,Senglea,Imdina,Valletta,,,35.88694000,14.40250000,Imdina,"Imdina|(35.88694000,14.40250000)"
+Malta,MT,Siġġiewi,Siġġiewi,Valletta,,,35.85556000,14.43639000,Siġġiewi,"Siġġiewi|(35.85556000,14.43639000)"
+Malta,MT,Sliema,Sliema,Valletta,,,35.91250000,14.50194000,Sliema,"Sliema|(35.91250000,14.50194000)"
+Malta,MT,St. Julian's,Paceville,Valletta,,,35.92370000,14.49140000,Paceville;San Ġwann,"Paceville|(35.92370000,14.49140000);San Ġwann|(35.90556000,14.47611000)"
+Malta,MT,St. Paul's Bay,Buġibba,Valletta,,,35.94916700,14.41166700,Buġibba;Burmarrad;Mosta,"Buġibba|(35.94916700,14.41166700);Burmarrad|(35.93490000,14.41430000);Mosta|(35.90917000,14.42556000)"
+Malta,MT,Swieqi,Swieqi,Valletta,,,35.92250000,14.48000000,Madliena;Swieqi,"Madliena|(35.93333300,14.46666700);Swieqi|(35.92250000,14.48000000)"
+Malta,MT,Ta' Xbiex,Ta’ Xbiex,Valletta,,,35.89917000,14.49444000,Ta’ Xbiex,"Ta’ Xbiex|(35.89917000,14.49444000)"
+Malta,MT,Tarxien,Ħal Tarxien,Valletta,,,35.86583000,14.51500000,Ħal Tarxien,"Ħal Tarxien|(35.86583000,14.51500000)"
+Malta,MT,Valletta,Valletta,Valletta,,,35.89972000,14.51472000,Valletta,"Valletta|(35.89972000,14.51472000)"
+Malta,MT,Victoria,Victoria,Valletta,,,36.04444000,14.23972000,Rabat;Victoria,"Rabat|(35.88152000,14.39872000);Victoria|(36.04444000,14.23972000)"
+Malta,MT,Xagħra,Xagħra,Valletta,,,36.05000000,14.26444000,Xagħra,"Xagħra|(36.05000000,14.26444000)"
+Malta,MT,Xewkija,Xewkija,Valletta,,,36.03278000,14.25806000,Xewkija,"Xewkija|(36.03278000,14.25806000)"
+Malta,MT,Xgħajra,Xgħajra,Valletta,,,35.88556000,14.54750000,Xgħajra,"Xgħajra|(35.88556000,14.54750000)"
+Malta,MT,Żabbar,Żabbar,Valletta,,,35.87611000,14.53500000,Żabbar,"Żabbar|(35.87611000,14.53500000)"
+Malta,MT,Żebbuġ Gozo,Ħaż-Żebbuġ,Valletta,,,35.87194000,14.44111000,Ħaż-Żebbuġ,"Ħaż-Żebbuġ|(35.87194000,14.44111000)"
+Malta,MT,Żebbuġ Malta,Żebbuġ,Valletta,,,36.07222000,14.23583000,Żebbuġ,"Żebbuġ|(36.07222000,14.23583000)"
+Malta,MT,Żejtun,Żejtun,Valletta,,,35.85583000,14.53306000,Żejtun,"Żejtun|(35.85583000,14.53306000)"
+Malta,MT,Żurrieq,Żurrieq,Valletta,,,35.83111000,14.47417000,Żurrieq,"Żurrieq|(35.83111000,14.47417000)"
+Man (Isle of),IM,Ayre,Andreas,"Douglas, Isle of Man",,,54.36841400,-4.52114630,Andreas;Bride;Lezayre,"Andreas|(54.36841400,-4.52114630);Bride|(54.38316570,-4.40803560);Lezayre|(54.29621930,-4.53110150)"
+Man (Isle of),IM,Garff,Lonan,"Douglas, Isle of Man",,,54.22104520,-4.50103060,Lonan;Maughold;Onchan,"Lonan|(54.22104520,-4.50103060);Maughold|(54.25494540,-4.51223490);Onchan|(54.19815080,-4.54908980)"
+Man (Isle of),IM,Glenfaba,German,"Douglas, Isle of Man",,,54.21871450,-4.70652730,German,"German|(54.21871450,-4.70652730)"
+Man (Isle of),IM,Michael,Michael,"Douglas, Isle of Man",,,54.27427780,-4.64273250,Ballaugh;Jurby;Michael,"Ballaugh|(54.30481210,-4.62075260);Jurby|(54.35905280,-4.54065860);Michael|(54.27427780,-4.64273250)"
+Man (Isle of),IM,Middle,Braddan,"Douglas, Isle of Man",,,54.16328280,-4.52585060,Braddan;Marown;Santon,"Braddan|(54.16328280,-4.52585060);Marown|(54.18462420,-4.64952180);Santon|(54.12054890,-4.64937750)"
+Man (Isle of),IM,Rushen,Rushen,"Douglas, Isle of Man",,,54.09084920,-4.84149820,Arbory;Malew;Rushen,"Arbory|(54.10878070,-4.83564540);Malew|(54.11180490,-4.80138270);Rushen|(54.09084920,-4.84149820)"
+Marshall Islands,MH,Ralik,,Majuro,,,,,,
+Marshall Islands,MH,Ratak,,Majuro,,,,,,
+Martinique,MQ,Fort-de-France,Fort-de-France,Fort-de-France,EMEA,29,14.64924180,-61.10984450,Fort-de-France;Le Lamentin;Saint-Joseph,"Fort-de-France|(14.64924180,-61.10984450);Le Lamentin|(14.62308620,-61.03347490);Saint-Joseph|(14.68353400,-61.08186620)"
+Martinique,MQ,La Trinité,La Trinité,Fort-de-France,EMEA,29,14.73804150,-61.02929560,Basse-Pointe;Grand'Rivière;Gros-Morne,"Basse-Pointe|(14.84097080,-61.16485230);Grand'Rivière|(14.84696630,-61.20427640);Gros-Morne|(14.70841840,-61.11271220)"
+Martinique,MQ,Le Marin,Le Marin,Fort-de-France,EMEA,29,14.48221690,-60.90011410,Ducos;Le Diamant;Le François,"Ducos|(14.57854420,-61.00973860);Le Diamant|(14.47680040,-61.05973840);Le François|(14.60928850,-60.97999110)"
+Martinique,MQ,Saint-Pierre,Saint-Pierre,Fort-de-France,EMEA,29,14.77167190,-61.21475010,Bellefontaine;Case-Pilote;Fonds-Saint-Denis,"Bellefontaine|(14.67474760,-61.16653080);Case-Pilote|(14.65933990,-61.15026120);Fonds-Saint-Denis|(14.72275460,-61.16189190)"
+Mauritania,MR,Adrar,Atar,Nouakchott,,,20.51770000,-13.04857000,Atar;Azougui;Chingueṭṭi,"Atar|(20.51770000,-13.04857000);Azougui|(20.56764000,-13.11191000);Chingueṭṭi|(20.46300000,-12.36200000)"
+Mauritania,MR,Assaba,Barkéwol,Nouakchott,,,16.64039000,-12.49849000,Barkéwol;Kiffa,"Barkéwol|(16.64039000,-12.49849000);Kiffa|(16.62073000,-11.40208000)"
+Mauritania,MR,Brakna,’Elb el Jmel,Nouakchott,,,17.01050000,-13.97102000,’Elb el Jmel;Aleg;Bofal,"’Elb el Jmel|(17.01050000,-13.97102000);Aleg|(17.05314000,-13.91312000);Bofal|(16.41666667,-13.80000000)"
+Mauritania,MR,Dakhlet Nouadhibou,Cansado,Nouakchott,,,20.85333333,-17.03250000,Cansado;Iouik;Nouadhibou,"Cansado|(20.85333333,-17.03250000);Iouik|(19.84944444,-16.33083333);Nouadhibou|(20.94188000,-17.03842000)"
+Mauritania,MR,Gorgol,Kaédi,Nouakchott,,,16.15027000,-13.50370000,Kaédi,"Kaédi|(16.15027000,-13.50370000)"
+Mauritania,MR,Guidimaka,Sélibaby,Nouakchott,,,15.15846000,-12.18430000,Sélibaby,"Sélibaby|(15.15846000,-12.18430000)"
+Mauritania,MR,Hodh Ech Chargui,Diade,Nouakchott,,,16.23333333,-7.41666667,Diade;Kataouane;Néma,"Diade|(16.23333333,-7.41666667);Kataouane|(16.06888889,-6.49888889);Néma|(16.61702000,-7.25649000)"
+Mauritania,MR,Hodh El Gharbi,Aioun,Nouakchott,,,16.66140000,-9.61490000,Aioun;Ayoun el Atrous;Togba,"Aioun|(16.66140000,-9.61490000);Ayoun el Atrous|(16.66666667,-9.61666667);Togba|(17.40000000,-10.36666667)"
+Mauritania,MR,Inchiri,Akjoujt,Nouakchott,,,19.74657000,-14.38531000,Akjoujt,"Akjoujt|(19.74657000,-14.38531000)"
+Mauritania,MR,Nouakchott-Nord,Dar-Naim,Nouakchott,,,18.03333333,-15.96666667,Dar-Naim;Teyarett;Toujouonine,"Dar-Naim|(18.03333333,-15.96666667);Teyarett|(18.12895720,-15.93778340);Toujouonine|(18.07169000,-15.90311000)"
+Mauritania,MR,Nouakchott-Ouest,Ksar,Nouakchott,,,18.10490330,-15.96443370,Ksar;Sebkha;Tevragh-Zeina,"Ksar|(18.10490330,-15.96443370);Sebkha|(18.07555556,-16.00194444);Tevragh-Zeina|(18.11011000,-15.99931000)"
+Mauritania,MR,Nouakchott-Sud,Arafat,Nouakchott,,,18.04639000,-15.97194000,Arafat;Riyad,"Arafat|(18.04639000,-15.97194000);Riyad|(18.00784270,-15.97404000)"
+Mauritania,MR,Tagant,Moudjeria,Nouakchott,,,17.97955140,-13.39795340,Moudjeria;Tichit;Tijigja,"Moudjeria|(17.97955140,-13.39795340);Tichit|(18.49686260,-12.12199350);Tijigja|(18.51647870,-12.98264760)"
+Mauritania,MR,Tiris Zemmour,Ain Ben Tili,Nouakchott,,,25.99444444,-9.55333333,Ain Ben Tili;Chegga;Fderîck,"Ain Ben Tili|(25.99444444,-9.55333333);Chegga|(25.37194444,-5.78666667);Fderîck|(22.67777778,-12.70750000)"
+Mauritania,MR,Trarza,Legat,Nouakchott,,,16.75000000,-14.83333333,Legat;Rosso;Tékane,"Legat|(16.75000000,-14.83333333);Rosso|(16.51378000,-15.80503000);Tékane|(16.60175000,-15.34866000)"
+Mauritius,MU,Agalega Islands,Vingt Cinq,Port Louis,,,-10.38803000,56.61795000,Vingt Cinq,"Vingt Cinq|(-10.38803000,56.61795000)"
+Mauritius,MU,Black River,Black River,Port Louis,,,-20.32047900,57.40372500,Albion;Bambous;Black River,"Albion|(-20.20814000,57.40766000);Bambous|(-20.25667000,57.40611000);Black River|(-20.32047900,57.40372500)"
+Mauritius,MU,Flacq,Bel Air,Port Louis,,,-20.25849300,57.75498700,Bel Air;Bel Air Rivière Sèche;Bon Accueil,"Bel Air|(-20.25849300,57.75498700);Bel Air Rivière Sèche|(-20.25777000,57.74976000);Bon Accueil|(-20.17083000,57.65639000)"
+Mauritius,MU,Grand Port,Bambous Virieux,Port Louis,,,-20.34278000,57.75750000,Bambous Virieux;Beau Vallon;Bois des Amourettes,"Bambous Virieux|(-20.34278000,57.75750000);Beau Vallon|(-20.41889000,57.69528000);Bois des Amourettes|(-20.36306000,57.73111000)"
+Mauritius,MU,Moka,Moka,Port Louis,,,-20.21889000,57.49583000,Camp Thorel;Dagotière;Dubreuil,"Camp Thorel|(-20.21472000,57.61611000);Dagotière|(-20.24476000,57.56188000);Dubreuil|(-20.30132000,57.59861000)"
+Mauritius,MU,Pamplemousses,Pamplemousses,Port Louis,,,-20.10389000,57.57028000,Arsenal;Calebasses;Congomah,"Arsenal|(-20.10556000,57.53528000);Calebasses|(-20.11167000,57.55389000);Congomah|(-20.14889000,57.59083000)"
+Mauritius,MU,Plaines Wilhems,Beau Bassin,Port Louis,,,-20.22538700,57.47145500,Beau Bassin;Beau Bassin-Rose Hill;Belle Terre,"Beau Bassin|(-20.22538700,57.47145500);Beau Bassin-Rose Hill|(-20.23325000,57.46609000);Belle Terre|(-20.26948370,57.51655530)"
+Mauritius,MU,Port Louis,Port Louis,Port Louis,,,-20.16194000,57.49889000,Bell Village;Caudan Waterfront;China Town,"Bell Village|(-20.17049700,57.48618400);Caudan Waterfront|(-20.16089880,57.49772560);China Town|(-20.15879700,57.50678900)"
+Mauritius,MU,Rivière du Rempart,Rivière du Rempart,Port Louis,,,-20.10306000,57.68472000,Amaury;Amitié Gokoola;Cap Malheureux,"Amaury|(-20.13083000,57.65917000);Amitié Gokoola|(-20.10688300,57.65472800);Cap Malheureux|(-19.98417000,57.61417000)"
+Mauritius,MU,Rodrigues Island,Baie aux Huîtres,Port Louis,,,-19.69444000,63.40833000,Baie aux Huîtres;Port Mathurin,"Baie aux Huîtres|(-19.69444000,63.40833000);Port Mathurin|(-19.68333000,63.41667000)"
+Mauritius,MU,Saint Brandon Islands,Cargados Carajos,Port Louis,,,-16.60329000,59.65851000,Cargados Carajos,"Cargados Carajos|(-16.60329000,59.65851000)"
+Mauritius,MU,Savanne,Baie Du Cap,Port Louis,,,-20.48664400,57.37881500,Baie Du Cap;Bel Ombre;Benares,"Baie Du Cap|(-20.48664400,57.37881500);Bel Ombre|(-20.50191900,57.42550700);Benares|(-20.48440700,57.58871700)"
+Mayotte,YT,Acoua,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Bandraboua,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Bandrélé,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Boueni,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Chiconi,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Chirongui,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Dembeni,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Dzaoudzi,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Kani Keli,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Koungou,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,M'Tsangamouji,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Mamoudzou,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Mtsamboro,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Ouangani,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Pamandzi,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Sada,,Mamoudzou,EMEA,14,,,,
+Mayotte,YT,Tsingoni,,Mamoudzou,EMEA,14,,,,
+Mexico,MX,Aguascalientes,Aguascalientes,Ciudad de México,,,21.88333000,-102.30000000,Aguascalientes;Arboledas Paso Blanco [Fraccionamiento];Arellano,"Aguascalientes|(21.88333000,-102.30000000);Arboledas Paso Blanco [Fraccionamiento]|(21.96361000,-102.30194000);Arellano|(21.80106000,-102.27384000)"
+Mexico,MX,Baja California,Alfonso Garzón [Granjas Familiares],Ciudad de México,,,32.54667000,-116.61722000,Alfonso Garzón [Granjas Familiares];Benito García (El Zorrillo);Benito Juárez,"Alfonso Garzón [Granjas Familiares]|(32.54667000,-116.61722000);Benito García (El Zorrillo)|(31.67111000,-116.51139000);Benito Juárez|(32.56852000,-114.99422000)"
+Mexico,MX,Baja California Sur,Bahía Asunción,Ciudad de México,,,27.14231000,-114.29582000,Bahía Asunción;Bahía Tortugas;Cabo San Lucas,"Bahía Asunción|(27.14231000,-114.29582000);Bahía Tortugas|(27.69056000,-114.89660000);Cabo San Lucas|(22.89088000,-109.91238000)"
+Mexico,MX,Campeche,Campeche,Ciudad de México,,,19.84386000,-90.52554000,Abelardo L. Rodríguez;Alfredo V. Bonfil;Altamira de Zináparo,"Abelardo L. Rodríguez|(18.72842000,-90.90456000);Alfredo V. Bonfil|(19.53032000,-90.18214000);Altamira de Zináparo|(18.58208000,-90.25610000)"
+Mexico,MX,Chiapas,1ra. Sección de Izapa,Ciudad de México,,,14.92083000,-92.17083000,1ra. Sección de Izapa;2da. Sección de Medio Monte;Abasolo,"1ra. Sección de Izapa|(14.92083000,-92.17083000);2da. Sección de Medio Monte|(14.88194000,-92.18444000);Abasolo|(16.82140000,-92.21611000)"
+Mexico,MX,Chihuahua,Chihuahua,Ciudad de México,,,28.82669000,-106.19876000,Abdenago C. García;Adolfo López Mateos;Ahumada,"Abdenago C. García|(29.98937000,-107.55210000);Adolfo López Mateos|(28.46667000,-107.30000000);Ahumada|(30.48174000,-106.48832000)"
+Mexico,MX,Ciudad de México,Ciudad de México,Ciudad de México,,,19.42847000,-99.12766000,Álvaro Obregón;Azcapotzalco;Benito Juarez,"Álvaro Obregón|(19.37496000,-99.21976000);Azcapotzalco|(19.48698000,-99.18594000);Benito Juarez|(19.39840000,-99.15766000)"
+Mexico,MX,Coahuila de Zaragoza,Abasolo,Ciudad de México,,,27.18219000,-101.42757000,Abasolo;Agua Nueva;Albia,"Abasolo|(27.18219000,-101.42757000);Agua Nueva|(25.18934000,-101.08840000);Albia|(25.66537000,-103.36253000)"
+Mexico,MX,Colima,Alcaraces,Ciudad de México,,,19.36433000,-103.57676000,Alcaraces;Armería;Augusto Gómez Villanueva,"Alcaraces|(19.36433000,-103.57676000);Armería|(18.95554000,-103.98357000);Augusto Gómez Villanueva|(19.02154000,-104.00156000)"
+Mexico,MX,Durango,Abasolo,Ciudad de México,,,25.31145000,-104.65580000,Abasolo;Álvaro Obregón;Antonio Amaro,"Abasolo|(25.31145000,-104.65580000);Álvaro Obregón|(25.51417000,-103.50500000);Antonio Amaro|(24.27684000,-104.01873000)"
+Mexico,MX,Estado de México,Acachuén,Ciudad de México,,,19.84715000,-102.09272000,Acachuén;Acalpican de Morelos;Acambay,"Acachuén|(19.84715000,-102.09272000);Acalpican de Morelos|(18.01854000,-102.34033000);Acambay|(19.95522000,-99.84428000)"
+Mexico,MX,Guanajuato,Guanajuato,Ciudad de México,,,21.01858000,-101.25910000,Abasolo;Acámbaro;Adjuntas del Río,"Abasolo|(20.44997000,-101.53073000);Acámbaro|(20.03085000,-100.72194000);Adjuntas del Río|(21.11667000,-100.86806000)"
+Mexico,MX,Guerrero,10 de Abril,Ciudad de México,,,16.82917000,-99.74083000,10 de Abril;Acahuizotla;Acalco,"10 de Abril|(16.82917000,-99.74083000);Acahuizotla|(17.36054000,-99.46759000);Acalco|(17.50575000,-99.16670000)"
+Mexico,MX,Hidalgo,Acahuasco,Ciudad de México,,,20.96254000,-98.59656000,Acahuasco;Acatepec;Acatlán,"Acahuasco|(20.96254000,-98.59656000);Acatepec|(20.95367000,-98.27373000);Acatlán|(20.14562000,-98.43959000)"
+Mexico,MX,Jalisco,Acatlán de Juárez Municipality,Ciudad de México,,,20.42416667,-103.60138889,Acatlán de Juárez Municipality;Acueducto Fraccionamiento;Agua Bermeja,"Acatlán de Juárez Municipality|(20.42416667,-103.60138889);Acueducto Fraccionamiento|(19.47917000,-103.31806000);Agua Bermeja|(20.66750000,-102.97056000)"
+Mexico,MX,Michoacán de Ocampo,Acuitzio,Ciudad de México,,,19.47178000,-101.32921000,Acuitzio;Acuítzio del Canje;Agostitlán,"Acuitzio|(19.47178000,-101.32921000);Acuítzio del Canje|(19.49585000,-101.33321000);Agostitlán|(19.53818000,-100.61849000)"
+Mexico,MX,Morelos,Abelardo L. Rodríguez,Ciudad de México,,,18.73750000,-98.98528000,Abelardo L. Rodríguez;Acamilpa;Achichipico,"Abelardo L. Rodríguez|(18.73750000,-98.98528000);Acamilpa|(18.71695000,-99.15724000);Achichipico|(18.94861000,-98.82611000)"
+Mexico,MX,Nayarit,Acaponeta,Ciudad de México,,,22.49396000,-105.36369000,Acaponeta;Ahuacatlán;Amapa,"Acaponeta|(22.49396000,-105.36369000);Ahuacatlán|(21.05405000,-104.48398000);Amapa|(21.78359000,-105.25482000)"
+Mexico,MX,Nuevo León,Agualeguas,Ciudad de México,,,26.31362000,-99.53728000,Agualeguas;Agualeguas Nuevo León;Alberto Villarreal,"Agualeguas|(26.31362000,-99.53728000);Agualeguas Nuevo León|(26.31083333,-99.53916667);Alberto Villarreal|(25.94389000,-100.41167000)"
+Mexico,MX,Oaxaca,Oaxaca,Ciudad de México,,,17.06542000,-96.72365000,Acatlán de Pérez Figueroa;Agua del Espino;Ahuehuetitlán,"Acatlán de Pérez Figueroa|(18.53973000,-96.60568000);Agua del Espino|(16.59095000,-96.80204000);Ahuehuetitlán|(17.67130000,-98.32024000)"
+Mexico,MX,Puebla,Puebla,Ciudad de México,,,19.03793000,-98.20346000,18 de Marzo;Acajete;Acateno,"18 de Marzo|(18.96889000,-98.16028000);Acajete|(19.11154000,-97.95231000);Acateno|(20.11324000,-97.22710000)"
+Mexico,MX,Querétaro,Querétaro,Ciudad de México,,,20.72105000,-100.44738000,Agua Azul;Agua Fría;Agua Zarca,"Agua Azul|(20.60271000,-100.20472000);Agua Fría|(21.15304000,-99.80638000);Agua Zarca|(21.22003000,-99.09075000)"
+Mexico,MX,Quintana Roo,Akumal,Ciudad de México,,,20.39693000,-87.31444000,Akumal;Alfredo V. Bonfil;Álvaro Obregón,"Akumal|(20.39693000,-87.31444000);Alfredo V. Bonfil|(21.08776000,-86.84706000);Álvaro Obregón|(18.29900000,-88.65145000)"
+Mexico,MX,San Luis Potosí,San Luis Potosí,Ciudad de México,,,22.14982000,-100.97916000,Agua Buena;Agua Señora;Ahualulco del Sonido Trece,"Agua Buena|(21.95791000,-99.39416000);Agua Señora|(22.23750000,-101.04222000);Ahualulco del Sonido Trece|(22.40019000,-101.16614000)"
+Mexico,MX,Sinaloa,Sinaloa,Ciudad de México,,,25.94103000,-108.09076000,Adolfo López Mateos (El Tamarindo);Adolfo Ruiz Cortines;Agua Caliente Grande (De Gastélum),"Adolfo López Mateos (El Tamarindo)|(24.89639000,-107.63278000);Adolfo Ruiz Cortines|(25.70275000,-108.71975000);Agua Caliente Grande (De Gastélum)|(26.53762000,-108.34814000)"
+Mexico,MX,Sonora,31 de Octubre,Ciudad de México,,,27.29583000,-110.03750000,31 de Octubre;Aconchi;Aduana del Sásabe,"31 de Octubre|(27.29583000,-110.03750000);Aconchi|(29.82628000,-110.22492000);Aduana del Sásabe|(31.47076000,-111.54608000)"
+Mexico,MX,Tabasco,Acachapan y Colmena 3ra. Sección,Ciudad de México,,,18.04858000,-92.77750000,Acachapan y Colmena 3ra. Sección;Álvaro Obregón (Santa Cruz);Álvaro Obregón 2da. Sección (El Lechugal),"Acachapan y Colmena 3ra. Sección|(18.04858000,-92.77750000);Álvaro Obregón (Santa Cruz)|(18.39422000,-92.79982000);Álvaro Obregón 2da. Sección (El Lechugal)|(18.39287000,-92.79119000)"
+Mexico,MX,Tamaulipas,Abasolo,Ciudad de México,,,24.05844000,-98.37333000,Abasolo;Aldama;Alfredo V. Bonfil,"Abasolo|(24.05844000,-98.37333000);Aldama|(22.92157000,-98.07519000);Alfredo V. Bonfil|(25.56203000,-98.23952000)"
+Mexico,MX,Tlaxcala,Tlaxcala,Ciudad de México,,,19.31905000,-98.19982000,Acopinalco del Peñón;Acuamanala;Acuitlapilco,"Acopinalco del Peñón|(19.65929000,-98.16299000);Acuamanala|(19.22361000,-98.20056000);Acuitlapilco|(19.27333000,-98.23542000)"
+Mexico,MX,Veracruz de Ignacio de la Llave,Abasolo del Valle,Ciudad de México,,,17.78306000,-95.54556000,Abasolo del Valle;Abrevadero;Acajete,"Abasolo del Valle|(17.78306000,-95.54556000);Abrevadero|(18.28222000,-95.21444000);Acajete|(19.56815000,-97.03333000)"
+Mexico,MX,Yucatán,Abala,Ciudad de México,,,20.64745000,-89.68094000,Abala;Acanceh;Akil,"Abala|(20.64745000,-89.68094000);Acanceh|(20.81269000,-89.45295000);Akil|(20.26547000,-89.34787000)"
+Mexico,MX,Zacatecas,Zacatecas,Ciudad de México,,,22.76843000,-102.58141000,Agua Gorda;Altamira;Apozol,"Agua Gorda|(22.10669000,-101.92182000);Altamira|(23.38173000,-102.98674000);Apozol|(21.46952000,-103.09076000)"
+Micronesia,FM,Chuuk,Eot Municipality,Palikir,,,7.38540000,151.73920000,Eot Municipality;Ettal Municipality;Fananu Municipality,"Eot Municipality|(7.38540000,151.73920000);Ettal Municipality|(5.59200000,153.56000000);Fananu Municipality|(8.55811000,151.90822000)"
+Micronesia,FM,Kosrae,Lelu Municipality,Palikir,,,5.34865000,163.01917000,Lelu Municipality;Malem Municipality;Tafunsak Municipality,"Lelu Municipality|(5.34865000,163.01917000);Malem Municipality|(5.27507000,163.01685000);Tafunsak Municipality|(5.34993000,162.96965000)"
+Micronesia,FM,Pohnpei,Kitti Municipality,Palikir,,,6.82490000,158.16081000,Kitti Municipality;Kolonia;Kolonia Municipality,"Kitti Municipality|(6.82490000,158.16081000);Kolonia|(6.96400000,158.20620000);Kolonia Municipality|(6.96400000,158.20580000)"
+Micronesia,FM,Yap,Colonia,Palikir,,,9.51638000,138.12167000,Colonia;Dalipebinaw Municipality;Fais,"Colonia|(9.51638000,138.12167000);Dalipebinaw Municipality|(9.52229000,138.08540000);Fais|(9.76600000,140.52000000)"
+Moldova,MD,Anenii Noi,Anenii Noi,Chisinau,,,46.87839000,29.23483000,Anenii Noi;Varniţa,"Anenii Noi|(46.87839000,29.23483000);Varniţa|(46.86606000,29.46636000)"
+Moldova,MD,Bălți,Bălţi,Chisinau,,,47.76314000,27.92932000,Bălţi,"Bălţi|(47.76314000,27.92932000)"
+Moldova,MD,Basarabeasca,Basarabeasca,Chisinau,,,46.33170000,28.96365000,Basarabeasca,"Basarabeasca|(46.33170000,28.96365000)"
+Moldova,MD,Bender,Bender,Chisinau,,,46.83156000,29.47769000,Bender,"Bender|(46.83156000,29.47769000)"
+Moldova,MD,Briceni,Briceni,Chisinau,,,48.36289000,27.07787000,Briceni,"Briceni|(48.36289000,27.07787000)"
+Moldova,MD,Cahul,Cahul,Chisinau,,,45.90425000,28.19929000,Cahul;Giurgiuleşti,"Cahul|(45.90425000,28.19929000);Giurgiuleşti|(45.48167000,28.19722000)"
+Moldova,MD,Călărași,Călăraşi,Chisinau,,,47.25560000,28.30987000,Călăraşi,"Călăraşi|(47.25560000,28.30987000)"
+Moldova,MD,Cantemir,Cantemir,Chisinau,,,46.27743000,28.20270000,Cantemir;Iargara;Vişniovca,"Cantemir|(46.27743000,28.20270000);Iargara|(46.42520000,28.42676000);Vişniovca|(46.33260000,28.44797000)"
+Moldova,MD,Căușeni,Căuşeni,Chisinau,,,46.63674000,29.41114000,Căuşeni;Chiţcani,"Căuşeni|(46.63674000,29.41114000);Chiţcani|(46.78296000,29.61682000)"
+Moldova,MD,Chișinău,Chisinau,Chisinau,,,47.00556000,28.85750000,Chisinau;Ciorescu;Cricova,"Chisinau|(47.00556000,28.85750000);Ciorescu|(47.13000000,28.88937000);Cricova|(47.13835000,28.86156000)"
+Moldova,MD,Cimișlia,Cimişlia,Chisinau,,,46.52685000,28.76441000,Cimişlia,"Cimişlia|(46.52685000,28.76441000)"
+Moldova,MD,Criuleni,Criuleni,Chisinau,,,47.21307000,29.15926000,Criuleni,"Criuleni|(47.21307000,29.15926000)"
+Moldova,MD,Dondușeni,Briceni,Chisinau,,,48.35628000,27.70293000,Briceni;Donduşeni,"Briceni|(48.35628000,27.70293000);Donduşeni|(48.24268000,27.61010000)"
+Moldova,MD,Drochia,Drochia,Chisinau,,,48.03555000,27.81293000,Drochia,"Drochia|(48.03555000,27.81293000)"
+Moldova,MD,Dubăsari,Cocieri,Chisinau,,,47.30170000,29.11755000,Cocieri;Ustia,"Cocieri|(47.30170000,29.11755000);Ustia|(47.25524000,29.12406000)"
+Moldova,MD,Edineț,Edineţ,Chisinau,,,48.17215000,27.30337000,Edineţ,"Edineţ|(48.17215000,27.30337000)"
+Moldova,MD,Fălești,Fălești,Chisinau,,,47.57667000,27.71264000,Fălești,"Fălești|(47.57667000,27.71264000)"
+Moldova,MD,Florești,Floreşti,Chisinau,,,47.89137000,28.29312000,Floreşti;Ghindești;Mărculeşti,"Floreşti|(47.89137000,28.29312000);Ghindești|(47.85482000,28.37679000);Mărculeşti|(47.86897000,28.24109000)"
+Moldova,MD,Gagauzia,Bugeac,Chisinau,,,46.36554000,28.66250000,Bugeac;Ceadîr-Lunga;Comrat,"Bugeac|(46.36554000,28.66250000);Ceadîr-Lunga|(46.06169000,28.83078000);Comrat|(46.29456000,28.65650000)"
+Moldova,MD,Glodeni,Glodeni,Chisinau,,,47.77513000,27.51891000,Glodeni,"Glodeni|(47.77513000,27.51891000)"
+Moldova,MD,Hîncești,Dancu,Chisinau,,,46.75818000,28.20716000,Dancu;Hînceşti,"Dancu|(46.75818000,28.20716000);Hînceşti|(46.83047000,28.59064000)"
+Moldova,MD,Ialoveni,Ialoveni,Chisinau,,,46.94346000,28.78233000,Ialoveni,"Ialoveni|(46.94346000,28.78233000)"
+Moldova,MD,Nisporeni,Nisporeni,Chisinau,,,47.08159000,28.17138000,Nisporeni,"Nisporeni|(47.08159000,28.17138000)"
+Moldova,MD,Ocnița,Ocniţa,Chisinau,,,48.38274000,27.43805000,Ocniţa;Otaci,"Ocniţa|(48.38274000,27.43805000);Otaci|(48.43285000,27.79912000)"
+Moldova,MD,Orhei,Orhei,Chisinau,,,47.38494000,28.82446000,Orhei,"Orhei|(47.38494000,28.82446000)"
+Moldova,MD,Rezina,Rezina,Chisinau,,,47.74928000,28.96583000,Rezina;Saharna,"Rezina|(47.74928000,28.96583000);Saharna|(47.69107000,28.97458000)"
+Moldova,MD,Rîșcani,Rîşcani,Chisinau,,,47.94792000,27.56376000,Rîşcani,"Rîşcani|(47.94792000,27.56376000)"
+Moldova,MD,Sîngerei,Sîngerei,Chisinau,,,47.63632000,28.14296000,Bilicenii Vechi;Biruinţa;Sîngerei,"Bilicenii Vechi|(47.65580000,28.04734000);Biruinţa|(47.81353000,28.07004000);Sîngerei|(47.63632000,28.14296000)"
+Moldova,MD,Șoldănești,Şoldăneşti,Chisinau,,,47.81608000,28.79718000,Şoldăneşti,"Şoldăneşti|(47.81608000,28.79718000)"
+Moldova,MD,Soroca,Soroca,Chisinau,,,48.15659000,28.28489000,Soroca,"Soroca|(48.15659000,28.28489000)"
+Moldova,MD,Ștefan Vodă,Ştefan Vodă,Chisinau,,,46.51287000,29.66193000,Ştefan Vodă,"Ştefan Vodă|(46.51287000,29.66193000)"
+Moldova,MD,Strășeni,Strășeni,Chisinau,,,47.14216000,28.60774000,Bucovăţ;Strășeni,"Bucovăţ|(47.19064000,28.45802000);Strășeni|(47.14216000,28.60774000)"
+Moldova,MD,Taraclia,Taraclia,Chisinau,,,45.90273000,28.66816000,Taraclia;Tvardița,"Taraclia|(45.90273000,28.66816000);Tvardița|(46.14826000,28.96491000)"
+Moldova,MD,Telenești,Mîndreşti,Chisinau,,,47.50525000,28.27687000,Mîndreşti;Teleneşti,"Mîndreşti|(47.50525000,28.27687000);Teleneşti|(47.50110000,28.36536000)"
+Moldova,MD,Transnistria,Camenca,Chisinau,,,48.03233000,28.69899000,Camenca;Crasnoe;Dnestrovsc,"Camenca|(48.03233000,28.69899000);Crasnoe|(46.64844000,29.80403000);Dnestrovsc|(46.61640000,29.91926000)"
+Moldova,MD,Ungheni,Ungheni,Chisinau,,,47.21079000,27.80047000,Ungheni,"Ungheni|(47.21079000,27.80047000)"
+Monaco,MC,La Colle,,Monaco,,,,,,
+Monaco,MC,La Condamine,,Monaco,,,,,,
+Monaco,MC,Moneghetti,,Monaco,,,,,,
+Mongolia,MN,Arkhangai,Tsetserleg,Ulan Bator,,,47.47500000,101.45417000,Tsetserleg,"Tsetserleg|(47.47500000,101.45417000)"
+Mongolia,MN,Bayan-Ölgii,Altay,Ulan Bator,,,48.29359000,89.51488000,Altay;Ölgii;Tsengel,"Altay|(48.29359000,89.51488000);Ölgii|(48.96833000,89.96250000);Tsengel|(48.94314000,89.14358000)"
+Mongolia,MN,Bayankhongor,Bayanhongor,Ulan Bator,,,46.19444000,100.71806000,Bayanhongor,"Bayanhongor|(46.19444000,100.71806000)"
+Mongolia,MN,Bulgan,Bulgan,Ulan Bator,,,48.81250000,103.53472000,Bulgan,"Bulgan|(48.81250000,103.53472000)"
+Mongolia,MN,Darkhan-Uul,Darhan,Ulan Bator,,,49.48667000,105.92278000,Darhan,"Darhan|(49.48667000,105.92278000)"
+Mongolia,MN,Dornod,Choibalsan,Ulan Bator,,,48.07257000,114.53264000,Choibalsan;Ereencav,"Choibalsan|(48.07257000,114.53264000);Ereencav|(49.88070000,115.72526000)"
+Mongolia,MN,Dornogovi,,Ulan Bator,,,,,,
+Mongolia,MN,Dundgovi,Mandalgovi,Ulan Bator,,,45.76250000,106.27083000,Mandalgovi,"Mandalgovi|(45.76250000,106.27083000)"
+Mongolia,MN,Govi-Altai,Altai,Ulan Bator,,,46.37222000,96.25833000,Altai,"Altai|(46.37222000,96.25833000)"
+Mongolia,MN,Govisümber,Choyr,Ulan Bator,,,46.36111000,108.36111000,Choyr,"Choyr|(46.36111000,108.36111000)"
+Mongolia,MN,Khentii,Undurkhaan,Ulan Bator,,,47.31944000,110.65556000,Undurkhaan,"Undurkhaan|(47.31944000,110.65556000)"
+Mongolia,MN,Khovd,Khovd,Ulan Bator,,,48.00556000,91.64194000,Khovd;Möst;Üyönch,"Khovd|(48.00556000,91.64194000);Möst|(46.67712000,92.78521000);Üyönch|(46.04786000,92.02612000)"
+Mongolia,MN,Khövsgöl,Hanh,Ulan Bator,,,51.50265000,100.66395000,Hanh;Murun-kuren;Tsengel,"Hanh|(51.50265000,100.66395000);Murun-kuren|(49.63417000,100.16250000);Tsengel|(49.47833000,100.88944000)"
+Mongolia,MN,Ömnögovi,Dalandzadgad,Ulan Bator,,,43.57083000,104.42500000,Dalandzadgad;Hanhongor;Nomgon Sum,"Dalandzadgad|(43.57083000,104.42500000);Hanhongor|(43.77345000,104.47998000);Nomgon Sum|(42.41462000,105.05640000)"
+Mongolia,MN,Orkhon,Erdenet,Ulan Bator,,,49.03333000,104.08333000,Erdenet,"Erdenet|(49.03333000,104.08333000)"
+Mongolia,MN,Övörkhangai,Arvayheer,Ulan Bator,,,46.26389000,102.77500000,Arvayheer;Harhorin;Hovd,"Arvayheer|(46.26389000,102.77500000);Harhorin|(47.19753000,102.82379000);Hovd|(44.67024000,102.17491000)"
+Mongolia,MN,Selenge,Dzüünharaa,Ulan Bator,,,48.85229000,106.45786000,Dzüünharaa;Sühbaatar,"Dzüünharaa|(48.85229000,106.45786000);Sühbaatar|(50.23139000,106.20778000)"
+Mongolia,MN,Sükhbaatar,Baruun-Urt,Ulan Bator,,,46.68056000,113.27917000,Baruun-Urt,"Baruun-Urt|(46.68056000,113.27917000)"
+Mongolia,MN,Töv,Centipede,Ulan Bator,,,47.70693000,106.95276000,Centipede;Dzuunmod;Möngönmorĭt,"Centipede|(47.70693000,106.95276000);Dzuunmod|(47.70694000,106.95278000);Möngönmorĭt|(48.19504000,108.48295000)"
+Mongolia,MN,Ulaanbaatar,Ulaanbaatar,Ulan Bator,,,47.89153170,106.73672220,Ulaanbaatar,"Ulaanbaatar|(47.89153170,106.73672220)"
+Mongolia,MN,Uvs,Ulaangom,Ulan Bator,,,49.98111000,92.06667000,Ulaangom,"Ulaangom|(49.98111000,92.06667000)"
+Mongolia,MN,Zavkhan,Uliastay,Ulan Bator,,,47.74167000,96.84444000,Uliastay,"Uliastay|(47.74167000,96.84444000)"
+Montenegro,ME,Andrijevica,Andrijevica,Podgorica,,,42.73389000,19.79194000,Andrijevica,"Andrijevica|(42.73389000,19.79194000)"
+Montenegro,ME,Bar,Bar,Podgorica,,,42.09306000,19.10028000,Bar;Stari Bar;Šušanj,"Bar|(42.09306000,19.10028000);Stari Bar|(42.09700000,19.13600000);Šušanj|(42.11556000,19.08833000)"
+Montenegro,ME,Berane,Berane,Podgorica,,,42.84250000,19.87333000,Berane,"Berane|(42.84250000,19.87333000)"
+Montenegro,ME,Bijelo Polje,Bijelo Polje,Podgorica,,,43.03834000,19.74758000,Bijelo Polje,"Bijelo Polje|(43.03834000,19.74758000)"
+Montenegro,ME,Budva,Budva,Podgorica,,,42.28639000,18.84000000,Budva;Petrovac na Moru,"Budva|(42.28639000,18.84000000);Petrovac na Moru|(42.20556000,18.94250000)"
+Montenegro,ME,Danilovgrad,Danilovgrad,Podgorica,,,42.55384000,19.14608000,Danilovgrad;Spuž,"Danilovgrad|(42.55384000,19.14608000);Spuž|(42.51500000,19.19500000)"
+Montenegro,ME,Gusinje,Gusinje,Podgorica,,,42.56194000,19.83389000,Gusinje,"Gusinje|(42.56194000,19.83389000)"
+Montenegro,ME,Kolašin,Kolašin,Podgorica,,,42.82229000,19.51653000,Kolašin,"Kolašin|(42.82229000,19.51653000)"
+Montenegro,ME,Kotor,Kotor,Podgorica,,,42.42067000,18.76825000,Dobrota;Kotor;Prčanj,"Dobrota|(42.45417000,18.76833000);Kotor|(42.42067000,18.76825000);Prčanj|(42.45750000,18.74222000)"
+Montenegro,ME,Mojkovac,Mojkovac,Podgorica,,,42.96044000,19.58330000,Mojkovac,"Mojkovac|(42.96044000,19.58330000)"
+Montenegro,ME,Nikšić,Nikšić,Podgorica,,,42.77310000,18.94446000,Nikšić,"Nikšić|(42.77310000,18.94446000)"
+Montenegro,ME,Old Royal Capital Cetinje,Cetinje,Podgorica,,,42.39063000,18.91417000,Cetinje,"Cetinje|(42.39063000,18.91417000)"
+Montenegro,ME,Petnjica,,Podgorica,,,,,,
+Montenegro,ME,Plav,Plav,Podgorica,,,42.59694000,19.94556000,Plav,"Plav|(42.59694000,19.94556000)"
+Montenegro,ME,Pljevlja,Pljevlja,Podgorica,,,43.35670000,19.35843000,Pljevlja,"Pljevlja|(43.35670000,19.35843000)"
+Montenegro,ME,Plužine,Plužine,Podgorica,,,43.15278000,18.83944000,Plužine,"Plužine|(43.15278000,18.83944000)"
+Montenegro,ME,Podgorica,Podgorica,Podgorica,,,42.44111000,19.26361000,Golubovci;Goričani;Mataguži,"Golubovci|(42.33500000,19.23111000);Goričani|(42.33222000,19.21194000);Mataguži|(42.32361000,19.27278000)"
+Montenegro,ME,Rožaje,Rožaje,Podgorica,,,42.83299000,20.16652000,Rožaje,"Rožaje|(42.83299000,20.16652000)"
+Montenegro,ME,Šavnik,Šavnik,Podgorica,,,42.95639000,19.09667000,Šavnik,"Šavnik|(42.95639000,19.09667000)"
+Montenegro,ME,Tivat,Tivat,Podgorica,,,42.43639000,18.69611000,Tivat,"Tivat|(42.43639000,18.69611000)"
+Montenegro,ME,Ulcinj,Ulcinj,Podgorica,,,41.92936000,19.22436000,Ulcinj,"Ulcinj|(41.92936000,19.22436000)"
+Montenegro,ME,Žabljak,Žabljak,Podgorica,,,43.15423000,19.12325000,Žabljak,"Žabljak|(43.15423000,19.12325000)"
+Montserrat,MS,Saint Anthony,,Plymouth,EMEA,29,,,,
+Montserrat,MS,Saint Georges,,Plymouth,EMEA,29,,,,
+Montserrat,MS,Saint Peter,,Plymouth,EMEA,29,,,,
+Morocco,MA,Agadir-Ida-Ou-Tanane,,Rabat,,,,,,
+Morocco,MA,Al Haouz,,Rabat,,,,,,
+Morocco,MA,Al Hoceïma,,Rabat,,,,,,
+Morocco,MA,Aousserd (EH),,Rabat,,,,,,
+Morocco,MA,Assa-Zag (EH-partial),Agadir,Rabat,,,30.42018000,-9.59815000,Agadir;Agadir Melloul;Agadir-Ida-ou-Tnan,"Agadir|(30.42018000,-9.59815000);Agadir Melloul|(30.22492000,-7.79601000);Agadir-Ida-ou-Tnan|(30.58333000,-9.50000000)"
+Morocco,MA,Azilal,,Rabat,,,,,,
+Morocco,MA,Béni Mellal,,Rabat,,,,,,
+Morocco,MA,Béni Mellal-Khénifra,,Rabat,,,,,,
+Morocco,MA,Benslimane,,Rabat,,,,,,
+Morocco,MA,Berkane,,Rabat,,,,,,
+Morocco,MA,Berrechid,,Rabat,,,,,,
+Morocco,MA,Boujdour (EH),,Rabat,,,,,,
+Morocco,MA,Boulemane,,Rabat,,,,,,
+Morocco,MA,Casablanca,,Rabat,,,,,,
+Morocco,MA,Casablanca-Settat,Azemmour,Rabat,,,33.28952000,-8.34250000,Azemmour;Benslimane;Berrechid,"Azemmour|(33.28952000,-8.34250000);Benslimane|(33.50000000,-7.16667000);Berrechid|(33.26553000,-7.58754000)"
+Morocco,MA,Chefchaouen,,Rabat,,,,,,
+Morocco,MA,Chichaoua,,Rabat,,,,,,
+Morocco,MA,Chtouka-Ait Baha,,Rabat,,,,,,
+Morocco,MA,Dakhla-Oued Ed-Dahab (EH),,Rabat,,,,,,
+Morocco,MA,Drâa-Tafilalet,Agdz,Rabat,,,30.69356000,-6.44628000,Agdz;Alnif;Aoufous,"Agdz|(30.69356000,-6.44628000);Alnif|(31.11411000,-5.17154000);Aoufous|(31.68000000,-4.17000000)"
+Morocco,MA,Driouch,,Rabat,,,,,,
+Morocco,MA,El Hajeb,,Rabat,,,,,,
+Morocco,MA,El Jadida,,Rabat,,,,,,
+Morocco,MA,El Kelâa des Sraghna,,Rabat,,,,,,
+Morocco,MA,Errachidia,,Rabat,,,,,,
+Morocco,MA,Es-Semara (EH-partial),,Rabat,,,,,,
+Morocco,MA,Essaouira,,Rabat,,,,,,
+Morocco,MA,Fahs-Anjra,,Rabat,,,,,,
+Morocco,MA,Fès,,Rabat,,,,,,
+Morocco,MA,Fès-Meknès,Aïn Leuh,Rabat,,,33.28984000,-5.33863000,Aïn Leuh;Aknoul;Almis Marmoucha,"Aïn Leuh|(33.28984000,-5.33863000);Aknoul|(34.65371000,-3.86754000);Almis Marmoucha|(33.32000000,-4.18000000)"
+Morocco,MA,Figuig,,Rabat,,,,,,
+Morocco,MA,Fquih Ben Salah,,Rabat,,,,,,
+Morocco,MA,Guelmim,,Rabat,,,,,,
+Morocco,MA,Guelmim-Oued Noun (EH-partial),Assa-Zag,Rabat,,,28.16667000,-9.41667000,Assa-Zag;Guelmim;Sidi Ifni,"Assa-Zag|(28.16667000,-9.41667000);Guelmim|(28.75000000,-10.00000000);Sidi Ifni|(29.37719000,-10.17111000)"
+Morocco,MA,Guercif,,Rabat,,,,,,
+Morocco,MA,Ifrane,,Rabat,,,,,,
+Morocco,MA,Inezgane-Ait Melloul,,Rabat,,,,,,
+Morocco,MA,Jerada,,Rabat,,,,,,
+Morocco,MA,Kénitra,Arbaoua,Rabat,,,34.90239000,-5.94871000,Arbaoua;Had Kourt;Kenitra,"Arbaoua|(34.90239000,-5.94871000);Had Kourt|(34.61588000,-5.74040000);Kenitra|(34.26101000,-6.58020000)"
+Morocco,MA,Khémisset,,Rabat,,,,,,
+Morocco,MA,Khénifra,Aguelmous,Rabat,,,33.16139000,-5.84626000,Aguelmous;Al Fqih Ben Çalah;Azilal,"Aguelmous|(33.16139000,-5.84626000);Al Fqih Ben Çalah|(32.50213000,-6.68771000);Azilal|(31.96156000,-6.57109000)"
+Morocco,MA,Khouribga,,Rabat,,,,,,
+Morocco,MA,L'Oriental,Ahfir,Rabat,,,34.95368000,-2.10027000,Ahfir;Aïn Beni Mathar;Al Aaroui,"Ahfir|(34.95368000,-2.10027000);Aïn Beni Mathar|(34.00970000,-2.03238000);Al Aaroui|(35.01090000,-3.00938000)"
+Morocco,MA,Laâyoune (EH),,Rabat,,,,,,
+Morocco,MA,Laâyoune-Sakia El Hamra (EH-partial),Akhfennir,Rabat,,,28.09455000,-12.05157000,Akhfennir;Boujdour;Es-Semara,"Akhfennir|(28.09455000,-12.05157000);Boujdour|(25.66172000,-13.68419000);Es-Semara|(27.75000000,-11.00000000)"
+Morocco,MA,Larache,,Rabat,,,,,,
+Morocco,MA,M’diq-Fnideq,,Rabat,,,,,,
+Morocco,MA,Marrakech,,Rabat,,,,,,
+Morocco,MA,Marrakesh-Safi,,Rabat,,,,,,
+Morocco,MA,Médiouna,,Rabat,,,,,,
+Morocco,MA,Meknès,,Rabat,,,,,,
+Morocco,MA,Midelt,,Rabat,,,,,,
+Morocco,MA,Mohammadia,,Rabat,,,,,,
+Morocco,MA,Moulay Yacoub,,Rabat,,,,,,
+Morocco,MA,Nador,,Rabat,,,,,,
+Morocco,MA,Nouaceur,,Rabat,,,,,,
+Morocco,MA,Ouarzazate,,Rabat,,,,,,
+Morocco,MA,Oued Ed-Dahab (EH),Aousserd,Rabat,,,21.91977000,-15.02068000,Aousserd;Imlili;Oued-Ed-Dahab,"Aousserd|(21.91977000,-15.02068000);Imlili|(22.65580000,-15.60719000);Oued-Ed-Dahab|(23.64201000,-14.44934000)"
+Morocco,MA,Ouezzane,,Rabat,,,,,,
+Morocco,MA,Oujda-Angad,,Rabat,,,,,,
+Morocco,MA,Rabat,,Rabat,,,,,,
+Morocco,MA,Rabat-Salé-Kénitra,,Rabat,,,,,,
+Morocco,MA,Rehamna,,Rabat,,,,,,
+Morocco,MA,Safi,Safi,Rabat,,,32.16667000,-8.83333000,Abadou;Adassil;Al-Haouz,"Abadou|(31.57917000,-7.31308000);Adassil|(31.10783000,-8.49083000);Al-Haouz|(31.34083000,-7.91076000)"
+Morocco,MA,Salé,,Rabat,,,,,,
+Morocco,MA,Sefrou,,Rabat,,,,,,
+Morocco,MA,Settat,,Rabat,,,,,,
+Morocco,MA,Sidi Bennour,,Rabat,,,,,,
+Morocco,MA,Sidi Ifni,,Rabat,,,,,,
+Morocco,MA,Sidi Kacem,,Rabat,,,,,,
+Morocco,MA,Sidi Slimane,,Rabat,,,,,,
+Morocco,MA,Skhirate-Témara,,Rabat,,,,,,
+Morocco,MA,Souss-Massa,,Rabat,,,,,,
+Morocco,MA,Tan-Tan (EH-partial),,Rabat,,,,,,
+Morocco,MA,Tanger-Assilah,,Rabat,,,,,,
+Morocco,MA,Tanger-Tétouan-Al Hoceïma,Al Hoceïma,Rabat,,,35.25165000,-3.93723000,Al Hoceïma;Al-Hoceima;Asilah,"Al Hoceïma|(35.25165000,-3.93723000);Al-Hoceima|(35.00000000,-4.25000000);Asilah|(35.46522000,-6.03415000)"
+Morocco,MA,Taounate,,Rabat,,,,,,
+Morocco,MA,Taourirt,,Rabat,,,,,,
+Morocco,MA,Tarfaya (EH-partial),,Rabat,,,,,,
+Morocco,MA,Taroudannt,,Rabat,,,,,,
+Morocco,MA,Tata,,Rabat,,,,,,
+Morocco,MA,Taza,,Rabat,,,,,,
+Morocco,MA,Tétouan,,Rabat,,,,,,
+Morocco,MA,Tinghir,,Rabat,,,,,,
+Morocco,MA,Tiznit,,Rabat,,,,,,
+Morocco,MA,Youssoufia,,Rabat,,,,,,
+Morocco,MA,Zagora,,Rabat,,,,,,
+Mozambique,MZ,Cabo Delgado,Chiure,Maputo,EMEA,14,-13.46665000,39.70317000,Chiure;Mocímboa;Montepuez,"Chiure|(-13.46665000,39.70317000);Mocímboa|(-11.31667000,40.35000000);Montepuez|(-13.12556000,38.99972000)"
+Mozambique,MZ,Gaza,Chibuto,Maputo,EMEA,14,-24.68667000,33.53056000,Chibuto;Chokwé;Macia,"Chibuto|(-24.68667000,33.53056000);Chokwé|(-24.53333000,32.98333000);Macia|(-25.02694000,33.09889000)"
+Mozambique,MZ,Inhambane,Inhambane,Maputo,EMEA,14,-23.86500000,35.38333000,Inhambane;Maxixe,"Inhambane|(-23.86500000,35.38333000);Maxixe|(-23.85972000,35.34722000)"
+Mozambique,MZ,Manica,Chimoio,Maputo,EMEA,14,-19.11639000,33.48333000,Chimoio,"Chimoio|(-19.11639000,33.48333000)"
+Mozambique,MZ,Maputo,Boane District,Maputo,EMEA,14,-26.02900000,32.38900000,Boane District;Concelho de Matola;Magude District,"Boane District|(-26.02900000,32.38900000);Concelho de Matola|(-25.83472000,32.49516000);Magude District|(-25.02389000,32.65150000)"
+Mozambique,MZ,Maputo,Maputo,Maputo,EMEA,14,-25.96553000,32.58322000,KaTembe;Maputo,"KaTembe|(-26.02985000,32.53204000);Maputo|(-25.96553000,32.58322000)"
+Mozambique,MZ,Nampula,Nampula,Maputo,EMEA,14,-15.11646000,39.26660000,António Enes;Ilha de Moçambique;Mutuáli,"António Enes|(-16.23250000,39.90861000);Ilha de Moçambique|(-15.03417000,40.73583000);Mutuáli|(-14.87056000,37.00444000)"
+Mozambique,MZ,Niassa,Cuamba,Maputo,EMEA,14,-14.80306000,36.53722000,Cuamba;Lichinga;Mandimba,"Cuamba|(-14.80306000,36.53722000);Lichinga|(-13.31278000,35.24056000);Mandimba|(-14.35250000,35.65056000)"
+Mozambique,MZ,Sofala,Beira,Maputo,EMEA,14,-19.84361000,34.83889000,Beira;Dondo;Nhamatanda District,"Beira|(-19.84361000,34.83889000);Dondo|(-19.60944000,34.74306000);Nhamatanda District|(-19.34900000,34.26800000)"
+Mozambique,MZ,Tete,Tete,Maputo,EMEA,14,-16.15639000,33.58667000,Tete,"Tete|(-16.15639000,33.58667000)"
+Mozambique,MZ,Zambezia,Alto Molócuè,Maputo,EMEA,14,-15.64932000,37.66384000,Alto Molócuè;Chinde;Quelimane,"Alto Molócuè|(-15.64932000,37.66384000);Chinde|(-18.58111000,36.45861000);Quelimane|(-17.87861000,36.88833000)"
+Myanmar,MM,Ayeyarwady,Bogale,Nay Pyi Taw,,,16.29415000,95.39742000,Bogale;Hinthada;Kyaiklat,"Bogale|(16.29415000,95.39742000);Hinthada|(17.64944000,95.45705000);Kyaiklat|(16.44502000,95.72373000)"
+Myanmar,MM,Bago,Bago,Nay Pyi Taw,,,17.33521000,96.48135000,Bago;Letpandan;Nyaunglebin,"Bago|(17.33521000,96.48135000);Letpandan|(17.78664000,95.75076000);Nyaunglebin|(17.95363000,96.72247000)"
+Myanmar,MM,Chin,Falam,Nay Pyi Taw,,,22.91335000,93.67779000,Falam;Hakha,"Falam|(22.91335000,93.67779000);Hakha|(22.64452000,93.61076000)"
+Myanmar,MM,Kachin,Bhamo,Nay Pyi Taw,,,24.25256000,97.23357000,Bhamo;Myitkyina,"Bhamo|(24.25256000,97.23357000);Myitkyina|(25.38327000,97.39637000)"
+Myanmar,MM,Kayah,Loikaw,Nay Pyi Taw,,,19.67798000,97.20975000,Loikaw,"Loikaw|(19.67798000,97.20975000)"
+Myanmar,MM,Kayin,Dellok,Nay Pyi Taw,,,16.04072000,97.91773000,Dellok;Hpa-An;Klonhtoug,"Dellok|(16.04072000,97.91773000);Hpa-An|(16.88953000,97.63482000);Klonhtoug|(15.95411000,98.43250000)"
+Myanmar,MM,Magway,Magway,Nay Pyi Taw,,,20.14956000,94.93246000,Chauk;Magway;Minbu,"Chauk|(20.89921000,94.81784000);Magway|(20.14956000,94.93246000);Minbu|(20.18059000,94.87595000)"
+Myanmar,MM,Mandalay,Mandalay,Nay Pyi Taw,,,21.97473000,96.08359000,Kyaukse;Mandalay;Meiktila,"Kyaukse|(21.60560000,96.13508000);Mandalay|(21.97473000,96.08359000);Meiktila|(20.87776000,95.85844000)"
+Myanmar,MM,Mon State,Kyaikkami,Nay Pyi Taw,,,16.07686000,97.56388000,Kyaikkami;Kyaikto;Martaban,"Kyaikkami|(16.07686000,97.56388000);Kyaikto|(17.30858000,97.01124000);Martaban|(16.52834000,97.61570000)"
+Myanmar,MM,Naypyidaw,Nay Pyi Taw,Nay Pyi Taw,,,19.74500000,96.12972000,Nay Pyi Taw;Pyinmana,"Nay Pyi Taw|(19.74500000,96.12972000);Pyinmana|(19.73810000,96.20742000)"
+Myanmar,MM,Rakhine,Sittwe,Nay Pyi Taw,,,20.14624000,92.89835000,Sittwe,"Sittwe|(20.14624000,92.89835000)"
+Myanmar,MM,Sagaing,Sagaing,Nay Pyi Taw,,,21.87870000,95.97965000,Mawlaik;Monywa;Sagaing,"Mawlaik|(23.64254000,94.40478000);Monywa|(22.10856000,95.13583000);Sagaing|(21.87870000,95.97965000)"
+Myanmar,MM,Shan,Lashio,Nay Pyi Taw,,,22.93590000,97.74980000,Lashio;Tachilek;Taunggyi,"Lashio|(22.93590000,97.74980000);Tachilek|(20.44750000,99.88083000);Taunggyi|(20.78919000,97.03776000)"
+Myanmar,MM,Tanintharyi,Dawei,Nay Pyi Taw,,,14.08230000,98.19151000,Dawei;Kawthoung;Myeik,"Dawei|(14.08230000,98.19151000);Kawthoung|(9.98238000,98.55034000);Myeik|(12.43954000,98.60028000)"
+Myanmar,MM,Yangon,Yangon,Nay Pyi Taw,,,16.80528000,96.15611000,Kanbe;Kayan;Syriam,"Kanbe|(16.70728000,96.00168000);Kayan|(16.90802000,96.56037000);Syriam|(16.76887000,96.24503000)"
+Namibia,NAN,Erongo,Arandis,Windhoek,,,-22.41667000,14.96667000,Arandis;Hentiesbaai;Karibib,"Arandis|(-22.41667000,14.96667000);Hentiesbaai|(-22.11667000,14.28333000);Karibib|(-21.93333000,15.83333000)"
+Namibia,NAN,Hardap,Aranos,Windhoek,,,-24.13333000,19.11667000,Aranos;Hoachanas;Maltahöhe,"Aranos|(-24.13333000,19.11667000);Hoachanas|(-23.91667000,18.05000000);Maltahöhe|(-24.83333000,16.98333000)"
+Namibia,NAN,Karas,Bethanie,Windhoek,,,-26.48333000,17.15000000,Bethanie;Karasburg;Keetmanshoop,"Bethanie|(-26.48333000,17.15000000);Karasburg|(-28.01667000,18.75000000);Keetmanshoop|(-26.58333000,18.13333000)"
+Namibia,NAN,Kavango East,Rundu,Windhoek,,,-17.93333000,19.76667000,Rundu,"Rundu|(-17.93333000,19.76667000)"
+Namibia,NAN,Kavango West,,Windhoek,,,,,,
+Namibia,NAN,Khomas,Katutura,Windhoek,,,-22.52306000,17.06028000,Katutura;Windhoek,"Katutura|(-22.52306000,17.06028000);Windhoek|(-22.55941000,17.08323000)"
+Namibia,NAN,Kunene,Epupa Constituency,Windhoek,,,-17.00388000,13.24825000,Epupa Constituency;Khorixas;Khorixas Constituency,"Epupa Constituency|(-17.00388000,13.24825000);Khorixas|(-20.36667000,14.96667000);Khorixas Constituency|(-20.36792000,14.95996000)"
+Namibia,NAN,Ohangwena,Oshikango,Windhoek,,,-17.40000000,15.88333000,Oshikango,"Oshikango|(-17.40000000,15.88333000)"
+Namibia,NAN,Omaheke,Gobabis,Windhoek,,,-22.45000000,18.96667000,Gobabis,"Gobabis|(-22.45000000,18.96667000)"
+Namibia,NAN,Omusati,Okahao,Windhoek,,,-17.88758000,15.06677000,Okahao;Ongandjera;Outapi,"Okahao|(-17.88758000,15.06677000);Ongandjera|(-17.88333000,15.06667000);Outapi|(-17.50000000,14.98333000)"
+Namibia,NAN,Oshana,Ondangwa,Windhoek,,,-17.91667000,15.95000000,Ondangwa;Ongwediva;Oshakati,"Ondangwa|(-17.91667000,15.95000000);Ongwediva|(-17.78333000,15.76667000);Oshakati|(-17.78833000,15.70436000)"
+Namibia,NAN,Oshikoto,Omuthiya,Windhoek,,,-18.36463000,16.58146000,Omuthiya;Tsumeb,"Omuthiya|(-18.36463000,16.58146000);Tsumeb|(-19.23333000,17.71667000)"
+Namibia,NAN,Otjozondjupa,Grootfontein,Windhoek,,,-19.56667000,18.11667000,Grootfontein;Okahandja;Okakarara,"Grootfontein|(-19.56667000,18.11667000);Okahandja|(-21.98333000,16.91667000);Okakarara|(-20.58333000,17.43333000)"
+Namibia,NAN,Zambezi,Bagani,Windhoek,,,-18.11065000,21.61645000,Bagani;Katima Mulilo,"Bagani|(-18.11065000,21.61645000);Katima Mulilo|(-17.50000000,24.26667000)"
+Nauru,NR,Aiwo,Arijejen,Yaren,,,-0.52545000,166.91247000,Arijejen,"Arijejen|(-0.52545000,166.91247000)"
+Nauru,NR,Anabar,Anabar,Yaren,,,-0.50845000,166.95326000,Anabar,"Anabar|(-0.50845000,166.95326000)"
+Nauru,NR,Anetan,,Yaren,,,,,,
+Nauru,NR,Anibare,,Yaren,,,,,,
+Nauru,NR,Baiti,Baiti,Yaren,,,-0.50803000,166.92945000,Baiti,"Baiti|(-0.50803000,166.92945000)"
+Nauru,NR,Boe,,Yaren,,,,,,
+Nauru,NR,Buada,,Yaren,,,,,,
+Nauru,NR,Denigomodu,,Yaren,,,,,,
+Nauru,NR,Ewa,,Yaren,,,,,,
+Nauru,NR,Ijuw,Ijuw,Yaren,,,-0.52100000,166.95813000,Ijuw,"Ijuw|(-0.52100000,166.95813000)"
+Nauru,NR,Meneng,Menen,Yaren,,,-0.54539000,166.94871000,Menen,"Menen|(-0.54539000,166.94871000)"
+Nauru,NR,Nibok,,Yaren,,,,,,
+Nauru,NR,Uaboe,Uaboe,Yaren,,,-0.51393000,166.92384000,Uaboe,"Uaboe|(-0.51393000,166.92384000)"
+Nauru,NR,Yaren,Yaren,Yaren,,,-0.55085000,166.92520000,Yaren,"Yaren|(-0.55085000,166.92520000)"
+Nepal,NP,Bagmati,Bhaktapur,Kathmandu,,,27.67743440,85.40386700,Bhaktapur;Chitwan;Dhading,"Bhaktapur|(27.67743440,85.40386700);Chitwan|(27.61953620,84.02793400);Dhading|(28.00725840,84.28464170)"
+Nepal,NP,Gandaki,Baglung ,Kathmandu,,,28.27711640,83.54353530,Baglung;Gorkha;Kaski,"Baglung|(28.27711640,83.54353530);Gorkha|(28.27346270,84.14877700);Kaski|(28.34572360,83.65987310)"
+Nepal,NP,Karnali,Dailekh ,Kathmandu,,,28.88480530,81.33871970,Dailekh;Dolpa;Humla,"Dailekh|(28.88480530,81.33871970);Dolpa|(29.21372390,82.37667750);Humla|(30.02557030,81.21732030)"
+Nepal,NP,Koshi,Bhojpur,Kathmandu,,,27.16432030,86.97399080,Bhojpur;Dhankuta;Ilam,"Bhojpur|(27.16432030,86.97399080);Dhankuta|(26.98445610,87.24311290);Ilam|(26.89856010,87.88160070)"
+Nepal,NP,Lumbini,Arghakhanchi ,Kathmandu,,,27.93234540,82.70966110,Arghakhanchi;Banke;Bardiya,"Arghakhanchi|(27.93234540,82.70966110);Banke|(28.09593710,81.51662830);Bardiya|(28.37201670,81.08316830)"
+Nepal,NP,Madhesh,Bara ,Kathmandu,,,27.10766310,84.73878940,Bara;Dhanusha;Mahottari,"Bara|(27.10766310,84.73878940);Dhanusha|(26.85112570,85.72433070);Mahottari|(26.88439340,85.21963240)"
+Nepal,NP,Sudurpashchim,Achham ,Kathmandu,,,29.06759620,80.97452850,Achham;Baitadi;Bajhang,"Achham|(29.06759620,80.97452850);Baitadi|(29.50832630,80.24534200);Bajhang|(29.72211100,80.49591420)"
+Netherlands,NL,Drenthe,Aalden,Amsterdam,,,52.79000000,6.71806000,Aalden;Angelslo;Annen,"Aalden|(52.79000000,6.71806000);Angelslo|(52.78090000,6.92645000);Annen|(53.05750000,6.71944000)"
+Netherlands,NL,Flevoland,Almere Stad,Amsterdam,,,52.37025000,5.21413000,Almere Stad;Biddinghuizen;Dronten,"Almere Stad|(52.37025000,5.21413000);Biddinghuizen|(52.45500000,5.69306000);Dronten|(52.52500000,5.71806000)"
+Netherlands,NL,Friesland,Akkrum,Amsterdam,,,53.05024000,5.83087000,Akkrum;Aldeboarn;Aldlân-Oost,"Akkrum|(53.05024000,5.83087000);Aldeboarn|(53.05000000,5.90000000);Aldlân-Oost|(53.18860000,5.82825000)"
+Netherlands,NL,Gelderland,'s-Heerenberg,Amsterdam,,,51.87670000,6.25877000,'s-Heerenberg;Aalst;Aalten,"'s-Heerenberg|(51.87670000,6.25877000);Aalst|(51.78250000,5.12778000);Aalten|(51.92500000,6.58056000)"
+Netherlands,NL,Groningen,Groningen,Amsterdam,,,53.21917000,6.56667000,Aduard;Appingedam;Baflo,"Aduard|(53.25667000,6.45972000);Appingedam|(53.32167000,6.85833000);Baflo|(53.36250000,6.51389000)"
+Netherlands,NL,Limburg,Abdissenbosch,Amsterdam,,,50.91667000,6.03333000,Abdissenbosch;Amby;America,"Abdissenbosch|(50.91667000,6.03333000);Amby|(50.86215000,5.73226000);America|(51.43667000,5.97917000)"
+Netherlands,NL,North Brabant,'s Gravenmoer,Amsterdam,,,51.65594000,4.94076000,'s Gravenmoer;'s-Hertogenbosch;'t Hofke,"'s Gravenmoer|(51.65594000,4.94076000);'s-Hertogenbosch|(51.69917000,5.30417000);'t Hofke|(51.44943000,5.51926000)"
+Netherlands,NL,North Holland,'s-Graveland,Amsterdam,,,52.24420000,5.12110000,'s-Graveland;'t Horntje;'t Kabel,"'s-Graveland|(52.24420000,5.12110000);'t Horntje|(53.00560000,4.78610000);'t Kabel|(52.25610000,4.64970000)"
+Netherlands,NL,Overijssel,Almelo,Amsterdam,,,52.35667000,6.66250000,Almelo;Baalder;Berkum,"Almelo|(52.35667000,6.66250000);Baalder|(52.58579000,6.65299000);Berkum|(52.52395000,6.13655000)"
+Netherlands,NL,South Holland,'s-Gravenland,Amsterdam,,,51.92336000,4.55315000,'s-Gravenland;'s-Gravenzande;Adegeest,"'s-Gravenland|(51.92336000,4.55315000);'s-Gravenzande|(52.00167000,4.16528000);Adegeest|(52.13621000,4.45249000)"
+Netherlands,NL,Utrecht,Utrecht,Amsterdam,,,52.09083000,5.12222000,Abcoude;Amerongen;Amersfoort,"Abcoude|(52.27250000,4.96944000);Amerongen|(52.00250000,5.45972000);Amersfoort|(52.15500000,5.38750000)"
+Netherlands,NL,Zeeland,Aagtekerke,Amsterdam,,,51.54667000,3.50972000,Aagtekerke;Aardenburg;Arnemuiden,"Aagtekerke|(51.54667000,3.50972000);Aardenburg|(51.27333000,3.44722000);Arnemuiden|(51.50167000,3.67500000)"
+New Caledonia,NC,Loyalty Islands Province,Lifou,Noumea,,,-20.96670000,167.23330000,Lifou;Maré,"Lifou|(-20.96670000,167.23330000);Maré|(-21.51670000,167.98330000)"
+New Caledonia,NC,North Province,Houaïlou,Noumea,,,-21.29090000,165.62170000,Houaïlou;Koné;Poindimié,"Houaïlou|(-21.29090000,165.62170000);Koné|(-21.05900000,164.85180000);Poindimié|(-20.94960000,165.32930000)"
+New Caledonia,NC,South Province,Bourail,Noumea,,,-21.57010000,165.48040000,Bourail;Dumbéa;Le Mont-Dore,"Bourail|(-21.57010000,165.48040000);Dumbéa|(-22.15000000,166.45000000);Le Mont-Dore|(-22.21570000,166.46650000)"
+New Zealand,NZ,Auckland,Auckland,Wellington,,,-36.84853000,174.76349000,Auckland;Mangere;Manukau City,"Auckland|(-36.84853000,174.76349000);Mangere|(-36.96807000,174.79875000);Manukau City|(-36.99282000,174.87986000)"
+New Zealand,NZ,Bay of Plenty,Edgecumbe,Wellington,,,-37.98333000,176.83333000,Edgecumbe;Katikati;Kawerau,"Edgecumbe|(-37.98333000,176.83333000);Katikati|(-37.55000000,175.91667000);Kawerau|(-38.10000000,176.70000000)"
+New Zealand,NZ,Canterbury,Amberley,Wellington,,,-43.15589000,172.72975000,Amberley;Ashburton;Ashburton District,"Amberley|(-43.15589000,172.72975000);Ashburton|(-43.89834000,171.73011000);Ashburton District|(-43.90000000,171.75000000)"
+New Zealand,NZ,Chatham Islands,Waitangi,Wellington,,,-43.95353000,-176.55973000,Waitangi,"Waitangi|(-43.95353000,-176.55973000)"
+New Zealand,NZ,Gisborne,Gisborne,Wellington,,,-38.65333000,178.00417000,Gisborne,"Gisborne|(-38.65333000,178.00417000)"
+New Zealand,NZ,Hawke's Bay,Hastings,Wellington,,,-39.63810000,176.84918000,Hastings;Napier;Taradale,"Hastings|(-39.63810000,176.84918000);Napier|(-39.49260000,176.91233000);Taradale|(-39.53333000,176.85000000)"
+New Zealand,NZ,Manawatu-Wanganui,Bulls,Wellington,,,-40.17487000,175.38463000,Bulls;Foxton;Horowhenua District,"Bulls|(-40.17487000,175.38463000);Foxton|(-40.46667000,175.30000000);Horowhenua District|(-40.57733000,175.38071000)"
+New Zealand,NZ,Marlborough,Blenheim,Wellington,,,-41.51603000,173.95280000,Blenheim;Picton,"Blenheim|(-41.51603000,173.95280000);Picton|(-41.29067000,174.00801000)"
+New Zealand,NZ,Nelson,Nelson,Wellington,,,-41.27078000,173.28404000,Nelson,"Nelson|(-41.27078000,173.28404000)"
+New Zealand,NZ,Northland,Ahipara,Wellington,,,-35.16667000,173.16667000,Ahipara;Dargaville;Far North District,"Ahipara|(-35.16667000,173.16667000);Dargaville|(-35.93333000,173.88333000);Far North District|(-35.03359000,173.48841000)"
+New Zealand,NZ,Otago,Arrowtown,Wellington,,,-44.93837000,168.81007000,Arrowtown;Balclutha;Clutha District,"Arrowtown|(-44.93837000,168.81007000);Balclutha|(-46.23389000,169.75000000);Clutha District|(-46.03883000,169.60617000)"
+New Zealand,NZ,Southland,Bluff,Wellington,,,-46.60000000,168.33333000,Bluff;Gore;Invercargill,"Bluff|(-46.60000000,168.33333000);Gore|(-46.10282000,168.94357000);Invercargill|(-46.40000000,168.35000000)"
+New Zealand,NZ,Taranaki,Eltham,Wellington,,,-39.42917000,174.30000000,Eltham;Hawera;New Plymouth,"Eltham|(-39.42917000,174.30000000);Hawera|(-39.59167000,174.28333000);New Plymouth|(-39.06667000,174.08333000)"
+New Zealand,NZ,Tasman,Brightwater,Wellington,,,-41.38333000,173.11667000,Brightwater;Mapua;Motueka,"Brightwater|(-41.38333000,173.11667000);Mapua|(-41.25000000,173.10000000);Motueka|(-41.13333000,173.01667000)"
+New Zealand,NZ,Waikato,Cambridge,Wellington,,,-37.87822000,175.44020000,Cambridge;Coromandel;Hamilton,"Cambridge|(-37.87822000,175.44020000);Coromandel|(-36.76110000,175.49634000);Hamilton|(-37.78333000,175.28333000)"
+New Zealand,NZ,Wellington,Wellington,Wellington,,,-41.28664000,174.77557000,Brooklyn;Castlepoint;Kapiti Coast District,"Brooklyn|(-41.30586000,174.76257000);Castlepoint|(-40.90000000,176.21667000);Kapiti Coast District|(-40.85682000,175.14690000)"
+New Zealand,NZ,West Coast,Greymouth,Wellington,,,-42.46667000,171.20000000,Greymouth;Hokitika;Westport,"Greymouth|(-42.46667000,171.20000000);Hokitika|(-42.71667000,170.96667000);Westport|(-41.75262000,171.60370000)"
+Nicaragua,NI,Boaco,Boaco,Managua,EMEA,13,12.47224000,-85.65860000,Boaco;Camoapa;San José de los Remates,"Boaco|(12.47224000,-85.65860000);Camoapa|(12.38383000,-85.51277000);San José de los Remates|(12.59750000,-85.76174000)"
+Nicaragua,NI,Carazo,Diriamba,Managua,EMEA,13,11.85812000,-86.23922000,Diriamba;Dolores;El Rosario,"Diriamba|(11.85812000,-86.23922000);Dolores|(11.85672000,-86.21552000);El Rosario|(11.77756000,-86.37374000)"
+Nicaragua,NI,Chinandega,Chinandega,Managua,EMEA,13,12.62937000,-87.13105000,Chichigalpa;Chinandega;Cinco Pinos,"Chichigalpa|(12.57758000,-87.02705000);Chinandega|(12.62937000,-87.13105000);Cinco Pinos|(13.22956000,-86.86808000)"
+Nicaragua,NI,Chontales,Acoyapa,Managua,EMEA,13,11.97028000,-85.17113000,Acoyapa;Comalapa;Cuapa,"Acoyapa|(11.97028000,-85.17113000);Comalapa|(12.28345000,-85.51081000);Cuapa|(12.26875000,-85.38205000)"
+Nicaragua,NI,Estelí,Estelí,Managua,EMEA,13,13.09185000,-86.35384000,Condega;Estelí;La Trinidad,"Condega|(13.36502000,-86.39846000);Estelí|(13.09185000,-86.35384000);La Trinidad|(12.96881000,-86.23534000)"
+Nicaragua,NI,Granada,Granada,Managua,EMEA,13,11.92988000,-85.95602000,Diriá;Diriomo;Granada,"Diriá|(11.88420000,-86.05508000);Diriomo|(11.87631000,-86.05184000);Granada|(11.92988000,-85.95602000)"
+Nicaragua,NI,Jinotega,Jinotega,Managua,EMEA,13,13.09103000,-86.00234000,El Cuá;Jinotega;La Concordia,"El Cuá|(13.41667000,-85.75000000);Jinotega|(13.09103000,-86.00234000);La Concordia|(13.19528000,-86.16659000)"
+Nicaragua,NI,León,León,Managua,EMEA,13,12.43787000,-86.87804000,Achuapa;El Jicaral;El Sauce,"Achuapa|(13.05370000,-86.59004000);El Jicaral|(12.72676000,-86.38057000);El Sauce|(12.88687000,-86.53903000)"
+Nicaragua,NI,Madriz,Las Sabanas,Managua,EMEA,13,13.34302000,-86.62184000,Las Sabanas;Palacagüina;San José de Cusmapa,"Las Sabanas|(13.34302000,-86.62184000);Palacagüina|(13.45566000,-86.40622000);San José de Cusmapa|(13.28841000,-86.65539000)"
+Nicaragua,NI,Managua,Managua,Managua,EMEA,13,12.13282000,-86.25040000,Ciudad Sandino;El Crucero;Managua,"Ciudad Sandino|(12.15889000,-86.34417000);El Crucero|(11.99008000,-86.30954000);Managua|(12.13282000,-86.25040000)"
+Nicaragua,NI,Masaya,Masaya,Managua,EMEA,13,11.97444000,-86.09417000,Catarina;La Concepción;Masatepe,"Catarina|(11.91197000,-86.07383000);La Concepción|(11.93711000,-86.18976000);Masatepe|(11.91445000,-86.14458000)"
+Nicaragua,NI,Matagalpa,Matagalpa,Managua,EMEA,13,12.92559000,-85.91747000,Ciudad Darío;Matagalpa;Matiguás,"Ciudad Darío|(12.73143000,-86.12402000);Matagalpa|(12.92559000,-85.91747000);Matiguás|(12.83734000,-85.46218000)"
+Nicaragua,NI,North Caribbean Coast,Bonanza,Managua,EMEA,13,14.02885000,-84.59103000,Bonanza;Prinzapolka;Puerto Cabezas,"Bonanza|(14.02885000,-84.59103000);Prinzapolka|(13.40708000,-83.56452000);Puerto Cabezas|(14.03507000,-83.38882000)"
+Nicaragua,NI,Nueva Segovia,Ciudad Antigua,Managua,EMEA,13,13.63929030,-86.31189830,Ciudad Antigua;Dipilto;El Jícaro,"Ciudad Antigua|(13.63929030,-86.31189830);Dipilto|(13.72225520,-86.51366060);El Jícaro|(13.72222480,-86.14115420)"
+Nicaragua,NI,Río San Juan,El Almendro,Managua,EMEA,13,11.67859000,-84.70269000,El Almendro;Greytown;Morrito,"El Almendro|(11.67859000,-84.70269000);Greytown|(10.94684000,-83.73467000);Morrito|(11.62118000,-85.08052000)"
+Nicaragua,NI,Rivas,Rivas,Managua,EMEA,13,11.43716000,-85.82632000,Altagracia;Belén;Buenos Aires,"Altagracia|(11.56615000,-85.57840000);Belén|(11.50299000,-85.88935000);Buenos Aires|(11.46916000,-85.81661000)"
+Nicaragua,NI,South Caribbean Coast,Bluefields,Managua,EMEA,13,12.01366000,-83.76353000,Bluefields;Bocana de Paiwas;Corn Island,"Bluefields|(12.01366000,-83.76353000);Bocana de Paiwas|(12.78571000,-85.12269000);Corn Island|(12.17575000,-83.06145000)"
+Niger,NE,Agadez,Agadez,Niamey,EMEA,11,16.97333000,7.99111000,Agadez;Alaghsas;Arlit,"Agadez|(16.97333000,7.99111000);Alaghsas|(17.01870000,8.01680000);Arlit|(18.83409000,7.43327000)"
+Niger,NE,Diffa,Diffa,Niamey,EMEA,11,13.31536000,12.61135000,Département de Diffa;Département de Maïné-Soroa;Département de Nguigmi,"Département de Diffa|(13.66667000,12.50000000);Département de Maïné-Soroa|(13.31206000,12.08321000);Département de Nguigmi|(14.20753000,13.12177000)"
+Niger,NE,Dosso,Dosso,Niamey,EMEA,11,13.04900000,3.19370000,Boboye Department;Département de Dogondoutchi;Département de Dosso,"Boboye Department|(13.08167000,2.91083000);Département de Dogondoutchi|(13.50000000,4.00000000);Département de Dosso|(12.83333000,3.33333000)"
+Niger,NE,Maradi,Maradi,Niamey,EMEA,11,13.50000000,7.10174000,Aguié;Dakoro;Département d’Aguié,"Aguié|(13.50601000,7.77863000);Dakoro|(14.51056000,6.76500000);Département d’Aguié|(13.46976000,7.74219000)"
+Niger,NE,Tahoua,Tahoua,Niamey,EMEA,11,14.88880000,5.26920000,Abalak;Birni N Konni;Bouza,"Abalak|(15.41618000,6.16975000);Birni N Konni|(13.79599000,5.25026000);Bouza|(14.42293000,6.04278000)"
+Niger,NE,Tillabéri,Tillabéri,Niamey,EMEA,11,14.20711000,1.45418000,Ayorou;Balleyara;Département de Filingué,"Ayorou|(14.73075000,0.91739000);Balleyara|(13.72848000,2.87503000);Département de Filingué|(14.31645000,3.23611000)"
+Niger,NE,Zinder,Zinder,Niamey,EMEA,11,13.80716000,8.98810000,Département de Gouré;Département de Kantché;Département de Tânout,"Département de Gouré|(14.01618000,10.14722000);Département de Kantché|(13.40000000,8.60000000);Département de Tânout|(14.75000000,8.33333000)"
+Nigeria,NG,Abia,Aba,Abuja,,,5.10658000,7.36667000,Aba;Amaigbo;Arochukwu,"Aba|(5.10658000,7.36667000);Amaigbo|(5.78917000,7.83829000);Arochukwu|(5.38941000,7.91235000)"
+Nigeria,NG,Abuja Federal Capital Territory,Abuja,Abuja,,,9.05785000,7.49508000,Abuja;Asokoro;Bamburu,"Abuja|(9.05785000,7.49508000);Asokoro|(9.04790000,7.51550000);Bamburu|(9.11360000,7.10960000)"
+Nigeria,NG,Adamawa,Ganye,Abuja,,,8.43497000,12.05107000,Ganye;Gombi;Holma,"Ganye|(8.43497000,12.05107000);Gombi|(10.16756000,12.73684000);Holma|(9.89863000,13.05450000)"
+Nigeria,NG,Akwa Ibom,Eket,Abuja,,,4.64231000,7.92438000,Eket;Esuk Oron;Ikot Ekpene,"Eket|(4.64231000,7.92438000);Esuk Oron|(4.80293000,8.25341000);Ikot Ekpene|(5.18194000,7.71481000)"
+Nigeria,NG,Anambra,Agulu,Abuja,,,6.10045000,7.06100000,Agulu;Atani;Awka,"Agulu|(6.10045000,7.06100000);Atani|(6.01277000,6.74768000);Awka|(6.21269000,7.07199000)"
+Nigeria,NG,Bauchi,Bauchi,Abuja,,,10.31032000,9.84388000,Azare;Bauchi;Boi,"Azare|(11.67478000,10.19069000);Bauchi|(10.31032000,9.84388000);Boi|(9.56109000,9.50154000)"
+Nigeria,NG,Bayelsa,Amassoma,Abuja,,,4.97032000,6.10915000,Amassoma;Twon-Brass;Yenagoa,"Amassoma|(4.97032000,6.10915000);Twon-Brass|(4.31231000,6.24091000);Yenagoa|(4.92675000,6.26764000)"
+Nigeria,NG,Benue,Aliade,Abuja,,,7.29627000,8.48278000,Aliade;Boju;Gboko,"Aliade|(7.29627000,8.48278000);Boju|(7.35572000,7.89303000);Gboko|(7.33159530,8.97600680)"
+Nigeria,NG,Borno,Bama,Abuja,,,11.52134000,13.68952000,Bama;Benisheikh;Biu,"Bama|(11.52134000,13.68952000);Benisheikh|(11.80919000,12.49151000);Biu|(10.61285000,12.19458000)"
+Nigeria,NG,Cross River,Akankpa,Abuja,,,5.12640000,8.18980000,Akankpa;Calabar;Gakem,"Akankpa|(5.12640000,8.18980000);Calabar|(4.95893000,8.32695000);Gakem|(6.76963000,8.99120000)"
+Nigeria,NG,Delta,Abraka,Abuja,,,5.79023000,6.10473000,Abraka;Agbor;Asaba,"Abraka|(5.79023000,6.10473000);Agbor|(6.25375000,6.19420000);Asaba|(6.19824000,6.73187000)"
+Nigeria,NG,Ebonyi,Abakaliki,Abuja,,,6.32485000,8.11368000,Abakaliki;Afikpo;Effium,"Abakaliki|(6.32485000,8.11368000);Afikpo|(5.89258000,7.93534000);Effium|(6.63105000,8.05814000)"
+Nigeria,NG,Edo,Agenebode,Abuja,,,7.10512000,6.69381000,Agenebode;Auchi;Benin City,"Agenebode|(7.10512000,6.69381000);Auchi|(7.06756000,6.26360000);Benin City|(6.33815000,5.62575000)"
+Nigeria,NG,Ekiti,Ado-Ekiti,Abuja,,,7.62329000,5.22087000,Ado-Ekiti;Aramoko-Ekiti;Efon-Alaaye,"Ado-Ekiti|(7.62329000,5.22087000);Aramoko-Ekiti|(7.70483000,5.04054000);Efon-Alaaye|(7.65649000,4.92235000)"
+Nigeria,NG,Enugu,Enugu,Abuja,,,6.44132000,7.49883000,Adani;Ake-Eze;Aku,"Adani|(6.73971000,7.01117000);Ake-Eze|(5.91677000,7.67615000);Aku|(6.70902000,7.31826000)"
+Nigeria,NG,Gombe,Gombe,Abuja,,,10.28969000,11.16729000,Akko;Bara;Billiri,"Akko|(10.28899000,10.97320000);Bara|(10.37444000,10.72884000);Billiri|(9.86545000,11.22624000)"
+Nigeria,NG,Imo,Iho,Abuja,,,5.58225000,7.09896000,Iho;Oguta;Okigwe,"Iho|(5.58225000,7.09896000);Oguta|(5.71044000,6.80936000);Okigwe|(5.82917000,7.35056000)"
+Nigeria,NG,Jigawa,Babura,Abuja,,,12.77256000,9.01525000,Babura;Birnin Kudu;Birniwa,"Babura|(12.77256000,9.01525000);Birnin Kudu|(11.45207000,9.47856000);Birniwa|(12.79070000,10.23614000)"
+Nigeria,NG,Kaduna,Kaduna,Abuja,,,10.52641000,7.43879000,Anchau;Burumburum;Dutsen Wai,"Anchau|(10.96245000,8.39233000);Burumburum|(11.39106000,8.72341000);Dutsen Wai|(10.85009000,8.19900000)"
+Nigeria,NG,Kano,Kano,Abuja,,,12.00012000,8.51672000,Dan Gora;Gaya;Kano,"Dan Gora|(11.53485000,8.15224000);Gaya|(11.86064000,9.00270000);Kano|(12.00012000,8.51672000)"
+Nigeria,NG,Katsina,Katsina,Abuja,,,12.99082000,7.60177000,Danja;Dankama;Daura,"Danja|(11.37710000,7.56097000);Dankama|(13.29782000,7.79492000);Daura|(13.03299000,8.32351000)"
+Nigeria,NG,Kebbi,Argungu,Abuja,,,12.74482000,4.52514000,Argungu;Bagudo;Bena,"Argungu|(12.74482000,4.52514000);Bagudo|(11.40351000,4.22571000);Bena|(11.28444000,5.93472000)"
+Nigeria,NG,Kogi,Abocho,Abuja,,,7.56770000,6.98630000,Abocho;Adoru;Ankpa,"Abocho|(7.56770000,6.98630000);Adoru|(6.97694000,7.16262000);Ankpa|(7.40249000,7.63196000)"
+Nigeria,NG,Kwara,Ajasse Ipo,Abuja,,,8.23333000,4.81667000,Ajasse Ipo;Bode Saadu;Gwasero,"Ajasse Ipo|(8.23333000,4.81667000);Bode Saadu|(8.93900000,4.78227000);Gwasero|(9.48333000,3.50000000)"
+Nigeria,NG,Lagos,Lagos,Abuja,,,6.45407000,3.39467000,Abule Egba;Agege;Alimosho,"Abule Egba|(6.65074410,3.26554510);Agege|(6.61522360,3.30029700);Alimosho|(6.58890000,3.24850000)"
+Nigeria,NG,Nasarawa,Nasarawa,Abuja,,,8.53895000,7.70821000,Buga;Doma;Keffi,"Buga|(8.49056000,7.34139000);Doma|(8.39307000,8.35544000);Keffi|(8.84651000,7.87354000)"
+Nigeria,NG,Niger,Auna,Abuja,,,10.18805000,4.72318000,Auna;Babana;Badeggi,"Auna|(10.18805000,4.72318000);Babana|(10.42949000,3.81495000);Badeggi|(9.05630000,6.14300000)"
+Nigeria,NG,Ogun,Abeokuta,Abuja,,,7.15571000,3.34509000,Abeokuta;Ado Odo;Idi Iroko,"Abeokuta|(7.15571000,3.34509000);Ado Odo|(6.60000000,2.93333000);Idi Iroko|(6.63333000,2.73333000)"
+Nigeria,NG,Ondo,Ondo,Abuja,,,7.09316000,4.83528000,Agbabu;Akure;Idanre,"Agbabu|(6.58862000,4.83430000);Akure|(7.25256000,5.19312000);Idanre|(7.11270000,5.11590000)"
+Nigeria,NG,Osun,Apomu,Abuja,,,7.35156000,4.18335000,Apomu;Ejigbo;Gbongan,"Apomu|(7.35156000,4.18335000);Ejigbo|(7.90292000,4.31419000);Gbongan|(7.47734000,4.35351000)"
+Nigeria,NG,Oyo,Oyo,Abuja,,,7.85257000,3.93125000,Ago Are;Alapa;Fiditi,"Ago Are|(8.50000000,3.41667000);Alapa|(8.61667000,4.38333000);Fiditi|(7.71361000,3.91722000)"
+Nigeria,NG,Plateau,Amper,Abuja,,,9.35509000,9.70121000,Amper;Bukuru;Dengi,"Amper|(9.35509000,9.70121000);Bukuru|(9.79399000,8.86397000);Dengi|(9.36872000,9.96223000)"
+Nigeria,NG,Rivers,Abalama,Abuja,,,4.76305556,6.84027778,Abalama;Abonnema;Ahoada,"Abalama|(4.76305556,6.84027778);Abonnema|(4.72311690,6.77884610);Ahoada|(5.08333333,6.65000000)"
+Nigeria,NG,Sokoto,Sokoto,Abuja,,,13.06269000,5.24322000,Binji;Dange;Gandi,"Binji|(13.22294000,4.90888000);Dange|(12.85313000,5.34572000);Gandi|(12.96358000,5.74337000)"
+Nigeria,NG,Taraba,Baissa,Abuja,,,7.23087000,10.62444000,Baissa;Beli;Gassol,"Baissa|(7.23087000,10.62444000);Beli|(7.85868000,10.97187000);Gassol|(8.53535000,10.44615000)"
+Nigeria,NG,Yobe,Damaturu,Abuja,,,11.74697000,11.96083000,Damaturu;Dankalwa;Dapchi,"Damaturu|(11.74697000,11.96083000);Dankalwa|(11.74449000,12.18545000);Dapchi|(12.49536000,11.49977000)"
+Nigeria,NG,Zamfara,Anka,Abuja,,,12.11347000,5.92681000,Anka;Dan Sadau;Gummi,"Anka|(12.11347000,5.92681000);Dan Sadau|(11.29621000,6.49520000);Gummi|(12.14484000,5.11776000)"
+Niue,NU,Alofi North,,Alofi,,,,,,
+Niue,NU,Alofi South,,Alofi,,,,,,
+Niue,NU,Avatele,,Alofi,,,,,,
+Niue,NU,Hakupu,,Alofi,,,,,,
+Niue,NU,Hikutavake,,Alofi,,,,,,
+Niue,NU,Lakepa,,Alofi,,,,,,
+Niue,NU,Liku,,Alofi,,,,,,
+Niue,NU,Makefu,,Alofi,,,,,,
+Niue,NU,Mutalau,,Alofi,,,,,,
+Niue,NU,Namukulu,,Alofi,,,,,,
+Niue,NU,Tamakautoga,,Alofi,,,,,,
+Niue,NU,Toi,,Alofi,,,,,,
+Niue,NU,Tuapa,,Alofi,,,,,,
+Niue,NU,Vaiea,,Alofi,,,,,,
+North Korea,KP,Chagang,Changgang-gun,Pyongyang,,,41.06333000,126.72556000,Changgang-gun;Chasŏng;Kanggye,"Changgang-gun|(41.06333000,126.72556000);Chasŏng|(41.46083000,126.64139000);Kanggye|(40.96946000,126.58523000)"
+North Korea,KP,Kangwon,Anbyŏn-ŭp,Pyongyang,,,39.04250000,127.52389000,Anbyŏn-ŭp;Hoeyang;Kosan,"Anbyŏn-ŭp|(39.04250000,127.52389000);Hoeyang|(38.71028000,127.59833000);Kosan|(38.85583000,127.41806000)"
+North Korea,KP,North Hamgyong,Aoji,Pyongyang,,,42.52448000,130.39718000,Aoji;Chongjin;Hau-ri,"Aoji|(42.52448000,130.39718000);Chongjin|(41.79556000,129.77583000);Hau-ri|(41.20056000,129.47028000)"
+North Korea,KP,North Hwanghae,Anak,Pyongyang,,,38.51083000,125.49417000,Anak;Hŭkkyo-ri;Hwangju-ŭp,"Anak|(38.51083000,125.49417000);Hŭkkyo-ri|(38.79861000,125.79194000);Hwangju-ŭp|(38.67028000,125.77611000)"
+North Korea,KP,North Pyongan,Chŏngju,Pyongyang,,,39.69333000,125.21028000,Chŏngju;Chŏngju-gun;Kujang-ŭp,"Chŏngju|(39.69333000,125.21028000);Chŏngju-gun|(39.70944000,125.25278000);Kujang-ŭp|(39.86722000,126.03028000)"
+North Korea,KP,Pyongyang,Pyongyang,Pyongyang,,,39.03385000,125.75432000,Chunghwa;Kangdong-ŭp;Pyongyang,"Chunghwa|(38.86389000,125.80000000);Kangdong-ŭp|(39.14250000,126.09611000);Pyongyang|(39.03385000,125.75432000)"
+North Korea,KP,Rason,Sŏnbong,Pyongyang,,,42.35118000,130.38307000,Sŏnbong;Ungsang-nodongjagu,"Sŏnbong|(42.35118000,130.38307000);Ungsang-nodongjagu|(42.35778000,130.46222000)"
+North Korea,KP,Ryanggang,Hyesan,Pyongyang,,,41.40167000,128.17778000,Hyesan;Hyesan-dong;Kapsan-ŭp,"Hyesan|(41.40167000,128.17778000);Hyesan-dong|(41.39756000,128.17873000);Kapsan-ŭp|(41.09028000,128.29333000)"
+North Korea,KP,South Hamgyong,Hamhŭng,Pyongyang,,,39.91833000,127.53639000,Hamhŭng;Hongwŏn;Hŭngnam,"Hamhŭng|(39.91833000,127.53639000);Hongwŏn|(40.02528000,127.95583000);Hŭngnam|(39.83167000,127.61861000)"
+North Korea,KP,South Hwanghae,Ayang-ni,Pyongyang,,,38.24306000,125.78000000,Ayang-ni;Chaeryŏng-ŭp;Changyŏn,"Ayang-ni|(38.24306000,125.78000000);Chaeryŏng-ŭp|(38.39917000,125.61556000);Changyŏn|(38.25083000,125.09611000)"
+North Korea,KP,South Pyongan,Anju,Pyongyang,,,39.61778000,125.66472000,Anju;Namp’o;P’yŏngsŏng,"Anju|(39.61778000,125.66472000);Namp’o|(38.73750000,125.40778000);P’yŏngsŏng|(39.24639000,125.87194000)"
+North Macedonia,MK,Aerodrom,,Skopje,,,,,,
+North Macedonia,MK,Aračinovo,Арачиново,Skopje,,,42.02639000,21.56194000,Арачиново,"Арачиново|(42.02639000,21.56194000)"
+North Macedonia,MK,Berovo,Berovo,Skopje,,,41.70306000,22.85778000,Berovo;Rusinovo;Vladimirovo,"Berovo|(41.70306000,22.85778000);Rusinovo|(41.68728000,22.80849000);Vladimirovo|(41.71000000,22.79278000)"
+North Macedonia,MK,Bitola,Bitola,Skopje,,,41.03143000,21.33474000,Bistrica;Bitola;Capari,"Bistrica|(40.97892000,21.36580000);Bitola|(41.03143000,21.33474000);Capari|(41.05656000,21.17884000)"
+North Macedonia,MK,Bogdanci,Bogdanci,Skopje,,,41.20306000,22.57556000,Bogdanci;Stojakovo,"Bogdanci|(41.20306000,22.57556000);Stojakovo|(41.15556000,22.57750000)"
+North Macedonia,MK,Bogovinje,Bogovinje,Skopje,,,41.92361000,20.91361000,Bogovinje;Dolno Palčište;Gradec,"Bogovinje|(41.92361000,20.91361000);Dolno Palčište|(41.96859000,20.92899000);Gradec|(41.89611000,20.90417000)"
+North Macedonia,MK,Bosilovo,Bosilovo,Skopje,,,41.44056000,22.72778000,Bosilovo;Ilovica;Sekirnik,"Bosilovo|(41.44056000,22.72778000);Ilovica|(41.47224000,22.80480000);Sekirnik|(41.43999000,22.79536000)"
+North Macedonia,MK,Brvenica,Brvenica,Skopje,,,41.96722000,20.98083000,Brvenica;Čelopek;Gurgurnica,"Brvenica|(41.96722000,20.98083000);Čelopek|(41.93167000,21.01333000);Gurgurnica|(41.84508000,21.10538000)"
+North Macedonia,MK,Butel,Butel,Skopje,,,42.03083000,21.44667000,Butel;Radishani,"Butel|(42.03083000,21.44667000);Radishani|(42.06111000,21.44778000)"
+North Macedonia,MK,Čair,Čair,Skopje,,,42.01528000,21.44111000,Čair,"Čair|(42.01528000,21.44111000)"
+North Macedonia,MK,Čaška,Čaška,Skopje,,,41.65056000,21.66222000,Bogomila;Čaška,"Bogomila|(41.59306000,21.47167000);Čaška|(41.65056000,21.66222000)"
+North Macedonia,MK,Centar,,Skopje,,,,,,
+North Macedonia,MK,Centar Župa,Centar Župa,Skopje,,,41.47849000,20.55945000,Centar Župa,"Centar Župa|(41.47849000,20.55945000)"
+North Macedonia,MK,Češinovo-Obleševo,Češinovo,Skopje,,,41.87148000,22.28961000,Češinovo;Oblesevo,"Češinovo|(41.87148000,22.28961000);Oblesevo|(41.88333000,22.33389000)"
+North Macedonia,MK,Čučer-Sandevo,Чучер - Сандево,Skopje,,,42.10361000,21.38222000,Чучер - Сандево,"Чучер - Сандево|(42.10361000,21.38222000)"
+North Macedonia,MK,Debarca,Belčišta,Skopje,,,41.30278000,20.83028000,Belčišta;Mešeišta,"Belčišta|(41.30278000,20.83028000);Mešeišta|(41.23814000,20.77414000)"
+North Macedonia,MK,Delčevo,Delcevo,Skopje,,,41.96722000,22.76944000,Delcevo,"Delcevo|(41.96722000,22.76944000)"
+North Macedonia,MK,Demir Hisar,Demir Hisar,Skopje,,,41.22097000,21.20302000,Demir Hisar;Slepče;Sopotnica,"Demir Hisar|(41.22097000,21.20302000);Slepče|(41.23333000,21.17500000);Sopotnica|(41.29594000,21.15357000)"
+North Macedonia,MK,Demir Kapija,Demir Kapija,Skopje,,,41.40613000,22.24631000,Demir Kapija,"Demir Kapija|(41.40613000,22.24631000)"
+North Macedonia,MK,Dojran,Star Dojran,Skopje,,,41.18647000,22.72030000,Star Dojran,"Star Dojran|(41.18647000,22.72030000)"
+North Macedonia,MK,Dolneni,Dolneni,Skopje,,,41.42579000,21.45402000,Crnilište;Desovo;Dolneni,"Crnilište|(41.53025000,21.41416000);Desovo|(41.46278000,21.49111000);Dolneni|(41.42579000,21.45402000)"
+North Macedonia,MK,Drugovo,,Skopje,,,,,,
+North Macedonia,MK,Gazi Baba,Cresevo,Skopje,,,42.05083000,21.50972000,Cresevo,"Cresevo|(42.05083000,21.50972000)"
+North Macedonia,MK,Gevgelija,Gevgelija,Skopje,,,41.14166000,22.50141000,Gevgelija;Miravci,"Gevgelija|(41.14166000,22.50141000);Miravci|(41.30925000,22.43641000)"
+North Macedonia,MK,Gjorče Petrov,Gjorče Petro,Skopje,,,42.00778000,21.35306000,Gjorče Petro,"Gjorče Petro|(42.00778000,21.35306000)"
+North Macedonia,MK,Gostivar,Gostivar,Skopje,,,41.79601000,20.90819000,Cegrane;Dolna Banjica;Forino,"Cegrane|(41.83889000,20.97583000);Dolna Banjica|(41.78611000,20.90611000);Forino|(41.82334000,20.96174000)"
+North Macedonia,MK,Gradsko,Gradsko,Skopje,,,41.57750000,21.94278000,Gradsko,"Gradsko|(41.57750000,21.94278000)"
+North Macedonia,MK,Greater Skopje,Bojane,Skopje,,,42.00009000,21.19265000,Bojane;Dračevo;Ljubin,"Bojane|(42.00009000,21.19265000);Dračevo|(41.93667000,21.52167000);Ljubin|(42.00139000,21.30917000)"
+North Macedonia,MK,Ilinden,Ilinden,Skopje,,,41.99451000,21.58002000,Ilinden;Kadino;Marino,"Ilinden|(41.99451000,21.58002000);Kadino|(41.96889000,21.60139000);Marino|(41.98776000,21.59148000)"
+North Macedonia,MK,Jegunovce,Jegunovce,Skopje,,,42.07238000,21.12367000,Jegunovce;Vratnica,"Jegunovce|(42.07238000,21.12367000);Vratnica|(42.14333000,21.11694000)"
+North Macedonia,MK,Karbinci,Karbinci,Skopje,,,41.81758000,22.23529000,Karbinci,"Karbinci|(41.81758000,22.23529000)"
+North Macedonia,MK,Karpoš,Skopje,Skopje,,,41.99646000,21.43141000,Skopje,"Skopje|(41.99646000,21.43141000)"
+North Macedonia,MK,Kavadarci,Kavadarci,Skopje,,,41.43306000,22.01194000,Kavadarci;Vataša,"Kavadarci|(41.43306000,22.01194000);Vataša|(41.41694000,22.01889000)"
+North Macedonia,MK,Kičevo,Kičevo,Skopje,,,41.51267000,20.95886000,Drugovo;Kičevo;Srbica,"Drugovo|(41.48490000,20.92636000);Kičevo|(41.51267000,20.95886000);Srbica|(41.58672000,21.03027000)"
+North Macedonia,MK,Kisela Voda,Kisela Voda,Skopje,,,41.94889000,21.50278000,Kisela Voda,"Kisela Voda|(41.94889000,21.50278000)"
+North Macedonia,MK,Kočani,Kochani,Skopje,,,41.91639000,22.41278000,Kochani;Orizari,"Kochani|(41.91639000,22.41278000);Orizari|(41.92262000,22.44628000)"
+North Macedonia,MK,Konče,Konče,Skopje,,,41.49511000,22.38359000,Konče,"Konče|(41.49511000,22.38359000)"
+North Macedonia,MK,Kratovo,Kratovo,Skopje,,,42.07838000,22.18070000,Kratovo,"Kratovo|(42.07838000,22.18070000)"
+North Macedonia,MK,Kriva Palanka,Kriva Palanka,Skopje,,,42.20088000,22.33244000,Kriva Palanka,"Kriva Palanka|(42.20088000,22.33244000)"
+North Macedonia,MK,Krivogaštani,Krivogashtani,Skopje,,,41.33611000,21.33306000,Krivogashtani;Obršani;Клечовце,"Krivogashtani|(41.33611000,21.33306000);Obršani|(41.28168000,21.36150000);Клечовце|(42.11611000,21.85722000)"
+North Macedonia,MK,Kruševo,Bučin,Skopje,,,41.27377000,21.31692000,Bučin;Krusevo,"Bučin|(41.27377000,21.31692000);Krusevo|(41.36889000,21.24889000)"
+North Macedonia,MK,Kumanovo,Kumanovo,Skopje,,,42.13222000,21.71444000,Bedinje;Kumanovo;Romanovci,"Bedinje|(42.14167000,21.69639000);Kumanovo|(42.13222000,21.71444000);Romanovci|(42.09472000,21.69306000)"
+North Macedonia,MK,Lipkovo,Lipkovo,Skopje,,,42.15639000,21.58528000,Izvor;Lipkovo;Lojane,"Izvor|(42.20322000,21.57812000);Lipkovo|(42.15639000,21.58528000);Lojane|(42.23276000,21.66550000)"
+North Macedonia,MK,Lozovo,Lozovo,Skopje,,,41.78389000,21.90556000,Lozovo,"Lozovo|(41.78389000,21.90556000)"
+North Macedonia,MK,Makedonska Kamenica,Makedonska Kamenica,Skopje,,,42.02079000,22.58760000,Makedonska Kamenica,"Makedonska Kamenica|(42.02079000,22.58760000)"
+North Macedonia,MK,Makedonski Brod,Makedonski Brod,Skopje,,,41.51361000,21.21528000,Makedonski Brod;Samokov,"Makedonski Brod|(41.51361000,21.21528000);Samokov|(41.68331000,21.14625000)"
+North Macedonia,MK,Mavrovo and Rostuša,Rostusa,Skopje,,,41.61000000,20.60000000,Rostusa,"Rostusa|(41.61000000,20.60000000)"
+North Macedonia,MK,Mogila,Mogila,Skopje,,,41.10833000,21.37861000,Beranci;Dobruševo;Dolno Srpci,"Beranci|(41.15969000,21.35963000);Dobruševo|(41.16861000,21.48250000);Dolno Srpci|(41.17480000,21.36464000)"
+North Macedonia,MK,Negotino,Negotino,Skopje,,,41.48456000,22.09056000,Negotino,"Negotino|(41.48456000,22.09056000)"
+North Macedonia,MK,Novaci,Novaci,Skopje,,,41.04197000,21.45866000,Novaci,"Novaci|(41.04197000,21.45866000)"
+North Macedonia,MK,Novo Selo,Novo Selo,Skopje,,,41.41486000,22.88164000,Novo Selo;Sušica,"Novo Selo|(41.41486000,22.88164000);Sušica|(41.43982000,22.83676000)"
+North Macedonia,MK,Ohrid,Ohrid,Skopje,,,41.11722000,20.80194000,Kosel;Ohrid;Ohrid Opština,"Kosel|(41.17444000,20.83556000);Ohrid|(41.11722000,20.80194000);Ohrid Opština|(41.16667000,20.83333000)"
+North Macedonia,MK,Oslomej ,,Skopje,,,,,,
+North Macedonia,MK,Pehčevo,Pehčevo,Skopje,,,41.76226000,22.88921000,Pehčevo,"Pehčevo|(41.76226000,22.88921000)"
+North Macedonia,MK,Petrovec,Sredno Konjare,Skopje,,,41.95743000,21.71494000,Sredno Konjare;Петровец,"Sredno Konjare|(41.95743000,21.71494000);Петровец|(41.93889000,21.61500000)"
+North Macedonia,MK,Plasnica,Plasnica,Skopje,,,41.46722000,21.12306000,Lisičani;Plasnica,"Lisičani|(41.46139000,21.05444000);Plasnica|(41.46722000,21.12306000)"
+North Macedonia,MK,Prilep,Prilep,Skopje,,,41.34514000,21.55504000,Kanatlarci;Markov Grad;Prilep,"Kanatlarci|(41.21028000,21.50333000);Markov Grad|(41.35722000,21.53250000);Prilep|(41.34514000,21.55504000)"
+North Macedonia,MK,Probištip,Probishtip,Skopje,,,42.00306000,22.17861000,Probishtip;Zletovo,"Probishtip|(42.00306000,22.17861000);Zletovo|(41.98861000,22.23611000)"
+North Macedonia,MK,Radoviš,Oraovica,Skopje,,,41.62583000,22.51333000,Oraovica;Podareš;Radovis,"Oraovica|(41.62583000,22.51333000);Podareš|(41.61389000,22.54222000);Radovis|(41.63833000,22.46472000)"
+North Macedonia,MK,Rankovce,Ранковце,Skopje,,,42.16964000,22.11617000,Ранковце,"Ранковце|(42.16964000,22.11617000)"
+North Macedonia,MK,Resen,Resen,Skopje,,,41.08934000,21.01092000,Grnčari;Jankovec;Krani,"Grnčari|(41.01722000,21.05333000);Jankovec|(41.11028000,21.01139000);Krani|(40.93934000,21.10911000)"
+North Macedonia,MK,Rosoman,Rosoman,Skopje,,,41.51671000,21.94585000,Rosoman,"Rosoman|(41.51671000,21.94585000)"
+North Macedonia,MK,Saraj,Bukovik,Skopje,,,41.96833000,21.23694000,Bukovik;Grčec;Kondovo,"Bukovik|(41.96833000,21.23694000);Grčec|(41.98806000,21.33028000);Kondovo|(42.01167000,21.31361000)"
+North Macedonia,MK,Sopište,Сопиште,Skopje,,,41.95472000,21.42750000,Сопиште,"Сопиште|(41.95472000,21.42750000)"
+North Macedonia,MK,Staro Nagoričane,Старо Нагоричане,Skopje,,,42.19806000,21.82861000,Старо Нагоричане,"Старо Нагоричане|(42.19806000,21.82861000)"
+North Macedonia,MK,Štip,Shtip,Skopje,,,41.74583000,22.19583000,Shtip,"Shtip|(41.74583000,22.19583000)"
+North Macedonia,MK,Struga,Struga,Skopje,,,41.17799000,20.67784000,Delogožda;Labunista;Lukovo,"Delogožda|(41.25728000,20.72180000);Labunista|(41.26861000,20.59611000);Lukovo|(41.35339000,20.60637000)"
+North Macedonia,MK,Strumica,Strumica,Skopje,,,41.43750000,22.64333000,Kuklis;Murtino;Strumica,"Kuklis|(41.40528000,22.66528000);Murtino|(41.41537000,22.72589000);Strumica|(41.43750000,22.64333000)"
+North Macedonia,MK,Studeničani,Batinci,Skopje,,,41.91909000,21.47978000,Batinci;Dolno Količani;Morani,"Batinci|(41.91909000,21.47978000);Dolno Količani|(41.88639000,21.48556000);Morani|(41.90978000,21.54997000)"
+North Macedonia,MK,Šuto Orizari,Šuto Orizare,Skopje,,,42.04000000,21.42500000,Šuto Orizare,"Šuto Orizare|(42.04000000,21.42500000)"
+North Macedonia,MK,Sveti Nikole,Sveti Nikole,Skopje,,,41.86956000,21.95274000,Gorobinci;Sveti Nikole,"Gorobinci|(41.87507000,21.87599000);Sveti Nikole|(41.86956000,21.95274000)"
+North Macedonia,MK,Tearce,Tearce,Skopje,,,42.07666000,21.05310000,Nerašte;Orashac;Pršovce,"Nerašte|(42.10711000,21.10810000);Orashac|(42.06250000,21.79972000);Pršovce|(42.08336000,21.05994000)"
+North Macedonia,MK,Tetovo,Tetovo,Skopje,,,42.00973000,20.97155000,Dobrošte;Džepčište;Golema Rečica,"Dobrošte|(42.10333000,21.07778000);Džepčište|(42.03287000,20.99817000);Golema Rečica|(41.98803000,20.94517000)"
+North Macedonia,MK,Valandovo,Valandovo,Skopje,,,41.31744000,22.56002000,Pirava;Valandovo,"Pirava|(41.32042000,22.53047000);Valandovo|(41.31744000,22.56002000)"
+North Macedonia,MK,Vasilevo,Vasilevo,Skopje,,,41.47408000,22.64301000,Vasilevo,"Vasilevo|(41.47408000,22.64301000)"
+North Macedonia,MK,Veles,Veles,Skopje,,,41.71556000,21.77556000,Gorno Orizari;Ivankovci;Veles,"Gorno Orizari|(41.68583000,21.73475000);Ivankovci|(41.84889000,21.82028000);Veles|(41.71556000,21.77556000)"
+North Macedonia,MK,Vevčani,Vevčani,Skopje,,,41.24056000,20.59333000,Vevčani,"Vevčani|(41.24056000,20.59333000)"
+North Macedonia,MK,Vinica,Vinica,Skopje,,,41.88278000,22.50917000,Blatec;Gradec;Vinica,"Blatec|(41.83668000,22.57909000);Gradec|(41.85068000,22.51132000);Vinica|(41.88278000,22.50917000)"
+North Macedonia,MK,Vraneštica,,Skopje,,,,,,
+North Macedonia,MK,Vrapčište,Vrapčište,Skopje,,,41.83439000,20.88563000,Dobri Dol;Negotino;Vrapčište,"Dobri Dol|(41.86520000,20.89009000);Negotino|(41.87792000,20.88389000);Vrapčište|(41.83439000,20.88563000)"
+North Macedonia,MK,Zajas,,Skopje,,,,,,
+North Macedonia,MK,Zelenikovo,Zelenikovo,Skopje,,,41.88413000,21.58848000,Zelenikovo,"Zelenikovo|(41.88413000,21.58848000)"
+North Macedonia,MK,Želino,Dobarce,Skopje,,,41.95530000,21.08875000,Dobarce;Larce;Sedlarevo,"Dobarce|(41.95530000,21.08875000);Larce|(41.93319000,21.12628000);Sedlarevo|(41.88306000,21.12750000)"
+North Macedonia,MK,Zrnovci,Zrnovci,Skopje,,,41.85417000,22.44444000,Zrnovci,"Zrnovci|(41.85417000,22.44444000)"
+Norway,NO,Agder,Åseral,Oslo,,,58.61730000,7.41118000,Åseral;Audnedal;Farsund,"Åseral|(58.61730000,7.41118000);Audnedal|(58.28378000,7.35487000);Farsund|(58.09538000,6.80403000)"
+Norway,NO,Akershus,Åneby,Oslo,,,60.08926000,10.86998000,Åneby;Årnes;Ås,"Åneby|(60.08926000,10.86998000);Årnes|(60.12237000,11.47005000);Ås|(59.66366000,10.79101000)"
+Norway,NO,Buskerud,Ål,Oslo,,,60.63028000,8.56115000,Ål;Åros;Drammen,"Ål|(60.63028000,8.56115000);Åros|(59.70610000,10.51092000);Drammen|(59.74389000,10.20449000)"
+Norway,NO,Finnmark,Alta,Oslo,,,69.97675000,23.29634000,Alta;Ávanuorri;Båtsfjord,"Alta|(69.97675000,23.29634000);Ávanuorri|(70.99634000,24.66217000);Båtsfjord|(70.63428000,29.71750000)"
+Norway,NO,Innlandet,Alvdal,Oslo,,,62.10854000,10.63483000,Alvdal;Åmot;Åsnes,"Alvdal|(62.10854000,10.63483000);Åmot|(61.13199000,11.37328000);Åsnes|(60.61363000,12.01200000)"
+Norway,NO,Jan Mayen,,Oslo,,,,,,
+Norway,NO,Møre og Romsdal,Ålesund,Oslo,,,62.47225000,6.15492000,Ålesund;Åndalsnes;Aukra,"Ålesund|(62.47225000,6.15492000);Åndalsnes|(62.56749000,7.68709000);Aukra|(62.80500000,6.88722000)"
+Norway,NO,Nordland,Alstahaug,Oslo,,,65.97556000,12.56836000,Alstahaug;Andenes;Andøy,"Alstahaug|(65.97556000,12.56836000);Andenes|(69.31428000,16.11939000);Andøy|(69.08033000,15.77637000)"
+Norway,NO,Oslo,Oslo,Oslo,,,59.91273000,10.74609000,Oslo;Sjølyststranda,"Oslo|(59.91273000,10.74609000);Sjølyststranda|(59.92105000,10.68017000)"
+Norway,NO,Østfold,Aremark,Oslo,,,59.22198000,11.69582000,Aremark;Askim;Eidsberg,"Aremark|(59.22198000,11.69582000);Askim|(59.58464000,11.16084000);Eidsberg|(59.55148000,11.33587000)"
+Norway,NO,Rogaland,Åkrehamn,Oslo,,,59.26053000,5.18689000,Åkrehamn;Bjerkreim;Bokn,"Åkrehamn|(59.26053000,5.18689000);Bjerkreim|(58.63050000,6.08130000);Bokn|(59.23062000,5.43524000)"
+Norway,NO,Svalbard,,Oslo,,,,,,
+Norway,NO,Telemark,Bamble,Oslo,,,59.00146000,9.74573000,Bamble;Bø;Dalen,"Bamble|(59.00146000,9.74573000);Bø|(59.41281000,9.06618000);Dalen|(59.44499000,8.00492000)"
+Norway,NO,Troms,Balsfjord,Oslo,,,69.24024000,19.22653000,Balsfjord;Bardu;Dyrøy,"Balsfjord|(69.24024000,19.22653000);Bardu|(68.86058000,18.35052000);Dyrøy|(69.09154000,17.69094000)"
+Norway,NO,Trøndelag,Å i Åfjord,Oslo,,,63.96068000,10.22468000,Å i Åfjord;Åfjord;Agdenes,"Å i Åfjord|(63.96068000,10.22468000);Åfjord|(63.96196000,10.22587000);Agdenes|(63.50575000,9.82623000)"
+Norway,NO,Vestfold,Årøysund,Oslo,,,59.18321000,10.45743000,Årøysund;Åsgårdstrand;Barkåker,"Årøysund|(59.18321000,10.45743000);Åsgårdstrand|(59.34938000,10.46948000);Barkåker|(59.31859000,10.38963000)"
+Norway,NO,Vestland,Ågotnes,Oslo,,,60.40306000,5.01927000,Ågotnes;Årdal;Årdalstangen,"Ågotnes|(60.40306000,5.01927000);Årdal|(61.23639000,7.70204000);Årdalstangen|(61.23581000,7.70370000)"
+Oman,OM,Ad Dakhiliyah,Adam,Muscat,,,22.37934000,57.52718000,Adam;Bahlā’;Bidbid,"Adam|(22.37934000,57.52718000);Bahlā’|(22.97886000,57.30470000);Bidbid|(23.40787000,58.12830000)"
+Oman,OM,Ad Dhahirah,‘Ibrī,Muscat,,,23.22573000,56.51572000,‘Ibrī;Yanqul,"‘Ibrī|(23.22573000,56.51572000);Yanqul|(23.58645000,56.53969000)"
+Oman,OM,Al Batinah North,Al Khābūrah,Muscat,,,23.97144000,57.09313000,Al Khābūrah;As Suwayq;Liwá,"Al Khābūrah|(23.97144000,57.09313000);As Suwayq|(23.84944000,57.43861000);Liwá|(24.53077000,56.56300000)"
+Oman,OM,Al Batinah Region,Barkā’,Muscat,,,23.67872000,57.88605000,Barkā’;Bayt al ‘Awābī;Oman Smart Future City,"Barkā’|(23.67872000,57.88605000);Bayt al ‘Awābī|(23.30324000,57.52459000);Oman Smart Future City|(23.65270000,57.59926000)"
+Oman,OM,Al Batinah South,,Muscat,,,,,,
+Oman,OM,Al Buraimi,Al Buraymī,Muscat,,,24.25088000,55.79312000,Al Buraymī,"Al Buraymī|(24.25088000,55.79312000)"
+Oman,OM,Al Wusta,Haymā’,Muscat,,,19.95931000,56.27575000,Haymā’,"Haymā’|(19.95931000,56.27575000)"
+Oman,OM,Ash Sharqiyah North,,Muscat,,,,,,
+Oman,OM,Ash Sharqiyah Region,Sur,Muscat,,,22.56667000,59.52889000,Sur,"Sur|(22.56667000,59.52889000)"
+Oman,OM,Ash Sharqiyah South,,Muscat,,,,,,
+Oman,OM,Dhofar,Şalālah,Muscat,,,17.01505000,54.09237000,Şalālah,"Şalālah|(17.01505000,54.09237000)"
+Oman,OM,Musandam,Dib Dibba,Muscat,,,26.19778000,56.25778000,Dib Dibba;Khasab;Madḩā’ al Jadīdah,"Dib Dibba|(26.19778000,56.25778000);Khasab|(26.17993000,56.24774000);Madḩā’ al Jadīdah|(25.28345000,56.33280000)"
+Oman,OM,Muscat,Muscat,Muscat,,,23.58413000,58.40778000,Bawshar;Muscat;Seeb,"Bawshar|(23.57769000,58.39982000);Muscat|(23.58413000,58.40778000);Seeb|(23.67027000,58.18911000)"
+Pakistan,PK,Azad Kashmir,Bhimbar,Islamabad,,,32.97465000,74.07846000,Bhimbar;Kotli;Kotli District,"Bhimbar|(32.97465000,74.07846000);Kotli|(33.51836000,73.90220000);Kotli District|(33.44559000,73.91557000)"
+Pakistan,PK,Balochistan,Alik Ghund,Islamabad,,,30.48976000,67.52177000,Alik Ghund;Awārān District;Barkhan,"Alik Ghund|(30.48976000,67.52177000);Awārān District|(26.21157000,65.42944000);Barkhan|(29.89773000,69.52558000)"
+Pakistan,PK,Federally Administered Tribal Areas,Alizai,Islamabad,,,33.53613000,70.34607000,Alizai;Gulishah Kach;Landi Kotal,"Alizai|(33.53613000,70.34607000);Gulishah Kach|(32.67087000,70.33917000);Landi Kotal|(34.09880000,71.14108000)"
+Pakistan,PK,Gilgit-Baltistan,Barishal,Islamabad,,,36.32162000,74.69502000,Barishal;Gilgit;Skardu,"Barishal|(36.32162000,74.69502000);Gilgit|(35.91869000,74.31245000);Skardu|(35.29787000,75.63372000)"
+Pakistan,PK,Islamabad,Islamabad,Islamabad,,,33.72148000,73.04329000,Islamabad,"Islamabad|(33.72148000,73.04329000)"
+Pakistan,PK,Khyber Pakhtunkhwa,Abbottabad,Islamabad,,,34.14630000,73.21168000,Abbottabad;Akora;Aman Garh,"Abbottabad|(34.14630000,73.21168000);Akora|(34.00337000,72.12561000);Aman Garh|(34.00584000,71.92971000)"
+Pakistan,PK,Punjab,Ahmadpur Sial,Islamabad,,,30.67791000,71.74344000,Ahmadpur Sial;Ahmedpur East;Alipur Chatha,"Ahmadpur Sial|(30.67791000,71.74344000);Ahmedpur East|(29.14269000,71.25771000);Alipur Chatha|(29.38242000,70.91106000)"
+Pakistan,PK,Sindh,Adilpur,Islamabad,,,27.93677000,69.31941000,Adilpur;Badin;Bagarji,"Adilpur|(27.93677000,69.31941000);Badin|(24.65600000,68.83700000);Bagarji|(27.75431000,68.75866000)"
+Palau,PW,Aimeliik,Ngchemiangel,Melekeok,,,7.44613000,134.47678000,Ngchemiangel,"Ngchemiangel|(7.44613000,134.47678000)"
+Palau,PW,Airai,Ngetkib,Melekeok,,,7.36451000,134.51484000,Ngetkib,"Ngetkib|(7.36451000,134.51484000)"
+Palau,PW,Angaur,Angaur State,Melekeok,,,6.90601000,134.12997000,Angaur State,"Angaur State|(6.90601000,134.12997000)"
+Palau,PW,Hatohobei,Tobi Village,Melekeok,,,3.00488000,131.12168000,Tobi Village,"Tobi Village|(3.00488000,131.12168000)"
+Palau,PW,Kayangel,Kayangel,Melekeok,,,8.08228000,134.71725000,Kayangel,"Kayangel|(8.08228000,134.71725000)"
+Palau,PW,Koror,Koror,Melekeok,,,7.33978000,134.47326000,Koror,"Koror|(7.33978000,134.47326000)"
+Palau,PW,Melekeok,Melekeok Village,Melekeok,,,7.49567000,134.63671000,Melekeok Village,"Melekeok Village|(7.49567000,134.63671000)"
+Palau,PW,Ngaraard,Ulimang,Melekeok,,,7.62416000,134.64208000,Ulimang,"Ulimang|(7.62416000,134.64208000)"
+Palau,PW,Ngarchelong,Mengellang,Melekeok,,,7.69570000,134.63054000,Mengellang,"Mengellang|(7.69570000,134.63054000)"
+Palau,PW,Ngardmau,Ngardmau,Melekeok,,,7.60986000,134.57440000,Ngardmau,"Ngardmau|(7.60986000,134.57440000)"
+Palau,PW,Ngatpang,,Melekeok,,,,,,
+Palau,PW,Ngchesar,Ngchesar Hamlet,Melekeok,,,7.46932000,134.60991000,Ngchesar Hamlet,"Ngchesar Hamlet|(7.46932000,134.60991000)"
+Palau,PW,Ngeremlengui,Imeong Hamlet,Melekeok,,,7.53134000,134.52713000,Imeong Hamlet,"Imeong Hamlet|(7.53134000,134.52713000)"
+Palau,PW,Ngiwal,Ngerkeai,Melekeok,,,7.55456000,134.63612000,Ngerkeai,"Ngerkeai|(7.55456000,134.63612000)"
+Palau,PW,Peleliu,Kloulklubed,Melekeok,,,7.04192000,134.25561000,Kloulklubed,"Kloulklubed|(7.04192000,134.25561000)"
+Palau,PW,Sonsorol,Sonsorol Village,Melekeok,,,5.32608000,132.21943000,Sonsorol Village,"Sonsorol Village|(5.32608000,132.21943000)"
+Palestinian Territory Occupied,PS,Bethlehem,Bethlehem,East Jerusalem,,,31.70541650,35.18184280,Al-Dawha;al-Khader;al-Ubeidiya,"Al-Dawha|(31.69773990,35.14595450);al-Khader|(31.69484540,35.15014530);al-Ubeidiya|(31.72386430,35.27122130)"
+Palestinian Territory Occupied,PS,Deir El Balah,az-Zawayda,East Jerusalem,,,31.42979750,34.35014230,az-Zawayda;Deir al-Balah,"az-Zawayda|(31.42979750,34.35014230);Deir al-Balah|(31.41717350,34.33033130)"
+Palestinian Territory Occupied,PS,Gaza,Al-Zahra,East Jerusalem,,,31.47246750,34.37782930,Al-Zahra;Gaza City,"Al-Zahra|(31.47246750,34.37782930);Gaza City|(31.50172950,34.44624480)"
+Palestinian Territory Occupied,PS,Hebron,Hebron,East Jerusalem,,,31.53260350,35.07922630,ad-Dhahiriya;as-Samu;Bani Na'im,"ad-Dhahiriya|(31.40967250,34.95490830);as-Samu|(31.39864450,35.04468830);Bani Na'im|(31.51490050,35.14474030)"
+Palestinian Territory Occupied,PS,Jenin,Jenin,East Jerusalem,,,32.45728400,35.28161440,Ajjah;al-Yamun;Arrabah,"Ajjah|(32.36001710,35.17739430);al-Yamun|(32.48671110,35.21299230);Arrabah|(32.40331010,35.18531430)"
+Palestinian Territory Occupied,PS,Jericho ,Jericho,East Jerusalem,,,31.85950700,35.44390820,al-Auja;al-Jiftlik;Jericho,"al-Auja|(31.94809930,35.45056430);al-Jiftlik|(32.14143230,35.44660250);Jericho|(31.85950700,35.44390820)"
+Palestinian Territory Occupied,PS,Jerusalem (Quds),Abu Dis,East Jerusalem,,,31.76361630,35.23712230,Abu Dis;Ar-Ram;Beit 'Anan,"Abu Dis|(31.76361630,35.23712230);Ar-Ram|(31.84928630,35.21288930);Beit 'Anan|(31.85109930,35.09111930)"
+Palestinian Territory Occupied,PS,Khan Yunis,Khan Yunis,East Jerusalem,,,31.34623510,34.28339890,Abasan al-Kabira;Abasan al-Saghira;Al-Qarara,"Abasan al-Kabira|(31.32316050,34.32342530);Abasan al-Saghira|(31.33974350,34.32603330);Al-Qarara|(31.37134650,34.31466030)"
+Palestinian Territory Occupied,PS,Nablus,Nablus,East Jerusalem,,,32.22437550,35.20647930,Aqraba;Asira ash-Shamaliya;Beit Furik,"Aqraba|(32.12762020,35.32213530);Asira ash-Shamaliya|(32.25186910,35.24757130);Beit Furik|(32.17549020,35.31588430)"
+Palestinian Territory Occupied,PS,North Gaza,Beit Hanoun,East Jerusalem,,,31.53851740,34.51617030,Beit Hanoun;Beit Lahia;Izbat Beit Hanoun,"Beit Hanoun|(31.53851740,34.51617030);Beit Lahia|(31.55132340,34.48862230);Izbat Beit Hanoun|(31.54728950,34.50197220)"
+Palestinian Territory Occupied,PS,Qalqilya,Qalqilya,East Jerusalem,,,32.19604910,34.96091330,Azzun;Hableh;Kafr Thulth,"Azzun|(32.17713520,35.03535730);Hableh|(32.16387820,34.95768030);Kafr Thulth|(32.15283320,35.02469030)"
+Palestinian Territory Occupied,PS,Rafah,Rafah ,East Jerusalem,,,31.29681450,34.22288230,Al Qarya as Suwaydiya;Al-Bayuk;Al-Mawasi,"Al Qarya as Suwaydiya|(31.32316550,34.20157530);Al-Bayuk|(31.26347860,34.26098130);Al-Mawasi|(31.34844960,34.23553630)"
+Palestinian Territory Occupied,PS,Ramallah,Ramallah,East Jerusalem,,,31.90741710,35.16468200,Al-Bireh;al-Mazra'a ash-Sharqiya;Bani Zeid al-Sharqiya,"Al-Bireh|(31.91259730,35.20111730);al-Mazra'a ash-Sharqiya|(32.00327220,35.25553230);Bani Zeid al-Sharqiya|(32.04074320,35.15327830)"
+Palestinian Territory Occupied,PS,Salfit,az-Zawiya,East Jerusalem,,,32.09470520,35.01867630,az-Zawiya;Biddya;Bruqin,"az-Zawiya|(32.09470520,35.01867630);Biddya|(32.11340020,35.05686530);Bruqin|(32.07264720,35.07780630)"
+Palestinian Territory Occupied,PS,Tubas,Tubas,East Jerusalem,,,32.32112010,35.34935330,'Aqqaba;Tammun;Tubas,"'Aqqaba|(32.35257060,35.32674760);Tammun|(32.28315510,35.36518930);Tubas|(32.32112010,35.34935330)"
+Palestinian Territory Occupied,PS,Tulkarm,Tulkarm,East Jerusalem,,,32.30796480,35.00802890,Anabta;Attil;Bal'a,"Anabta|(32.30728710,35.09887830);Attil|(32.37010310,35.05193830);Bal'a|(32.33255610,35.08935330)"
+Panama,PA,Bocas del Toro,Bocas del Toro,Panama City,EMEA,13,9.34031000,-82.24204000,Almirante;Barranco;Barranco Adentro,"Almirante|(9.30091000,-82.40180000);Barranco|(9.51984000,-82.70424000);Barranco Adentro|(9.52757000,-82.73344000)"
+Panama,PA,Chiriquí Province,Alanje,Panama City,EMEA,13,8.39791000,-82.55947000,Alanje;Algarrobos Arriba;Alto Boquete,"Alanje|(8.39791000,-82.55947000);Algarrobos Arriba|(8.51550000,-82.42263000);Alto Boquete|(8.73458000,-82.43213000)"
+Panama,PA,Coclé,Coclé,Panama City,EMEA,13,8.45601000,-80.42899000,Aguadulce;Aguas Blancas;Alto de La Estancia,"Aguadulce|(8.24183000,-80.54609000);Aguas Blancas|(8.50351000,-80.31169000);Alto de La Estancia|(8.58792000,-80.18443000)"
+Panama,PA,Colón,Colón,Panama City,EMEA,13,9.35451000,-79.90011000,Buena Vista;Cativá;Coclé del Norte,"Buena Vista|(9.27356000,-79.69551000);Cativá|(9.36218000,-79.83232000);Coclé del Norte|(9.07540000,-80.57177000)"
+Panama,PA,Darién,Boca de Cupé,Panama City,EMEA,13,8.03003000,-77.58978000,Boca de Cupé;Camogantí;Cucunatí,"Boca de Cupé|(8.03003000,-77.58978000);Camogantí|(8.04171000,-77.88682000);Cucunatí|(8.57508000,-78.25671000)"
+Panama,PA,Emberá-Wounaan Comarca,Bayamón,Panama City,EMEA,13,7.96817000,-78.21648000,Bayamón;Cémaco;Corozal,"Bayamón|(7.96817000,-78.21648000);Cémaco|(8.08285000,-77.54210000);Corozal|(8.20108000,-77.59637000)"
+Panama,PA,Guna,Achutupo,Panama City,EMEA,13,9.19827000,-77.98729000,Achutupo;Ailigandí;Cartí Sugdup,"Achutupo|(9.19827000,-77.98729000);Ailigandí|(9.22810000,-78.02778000);Cartí Sugdup|(9.46460000,-78.95931000)"
+Panama,PA,Herrera,Boca de Parita,Panama City,EMEA,13,8.00796000,-80.45320000,Boca de Parita;Cabuya;Cerro Largo,"Boca de Parita|(8.00796000,-80.45320000);Cabuya|(8.03138000,-80.63227000);Cerro Largo|(7.83377000,-80.83168000)"
+Panama,PA,Los Santos,Los Santos,Panama City,EMEA,13,7.93333000,-80.41667000,Agua Buena;Ave María;Bahía Honda,"Agua Buena|(7.83465000,-80.39405000);Ave María|(7.32481000,-80.45361000);Bahía Honda|(7.70517000,-80.45342000)"
+Panama,PA,Ngöbe-Buglé Comarca,Bahía Azul,Panama City,EMEA,13,9.14176000,-81.89425000,Bahía Azul;Besiko;Bisira,"Bahía Azul|(9.14176000,-81.89425000);Besiko|(8.54863000,-82.08980000);Bisira|(8.89553000,-81.85352000)"
+Panama,PA,Panamá,Panamá,Panama City,EMEA,13,8.99360000,-79.51973000,Alcalde Díaz;Ancón;Brujas,"Alcalde Díaz|(9.12016000,-79.55641000);Ancón|(8.96015000,-79.55140000);Brujas|(8.58536000,-78.53008000)"
+Panama,PA,Panamá Oeste,Alto del Espino,Panama City,EMEA,13,8.84213000,-79.84551000,Alto del Espino;Altos de San Francisco;Arenosa,"Alto del Espino|(8.84213000,-79.84551000);Altos de San Francisco|(8.86167000,-79.79000000);Arenosa|(9.03978000,-79.95128000)"
+Panama,PA,Veraguas,Alto de Jesús,Panama City,EMEA,13,8.26152000,-81.48412000,Alto de Jesús;Arenas;Atalaya,"Alto de Jesús|(8.26152000,-81.48412000);Arenas|(7.36865000,-80.86268000);Atalaya|(8.04213000,-80.92528000)"
+Papua New Guinea,PG,Bougainville,Arawa,Port Moresby,,,-6.22977000,155.56598000,Arawa;Central Bougainville;Kieta,"Arawa|(-6.22977000,155.56598000);Central Bougainville|(-6.22806000,155.56583000);Kieta|(-6.21462000,155.63251000)"
+Papua New Guinea,PG,Central,Abau,Port Moresby,,,-10.08333000,148.91667000,Abau;Goilala;Kairuku-Hiri,"Abau|(-10.08333000,148.91667000);Goilala|(-8.33333000,147.00000000);Kairuku-Hiri|(-9.13648000,147.27905000)"
+Papua New Guinea,PG,Chimbu,Chuave,Port Moresby,,,-6.16667000,145.08333000,Chuave;Gumine;Karimui Nomane,"Chuave|(-6.16667000,145.08333000);Gumine|(-6.25000000,144.88333000);Karimui Nomane|(-6.58333000,144.83333000)"
+Papua New Guinea,PG,East New Britain,Gazelle,Port Moresby,,,-4.48333000,151.86667000,Gazelle;Kokopo;Pomio,"Gazelle|(-4.48333000,151.86667000);Kokopo|(-4.40000000,152.28333000);Pomio|(-5.50000000,151.33333000)"
+Papua New Guinea,PG,East Sepik,,Port Moresby,,,,,,
+Papua New Guinea,PG,Eastern Highlands,Daulo,Port Moresby,,,-5.98333000,145.23333000,Daulo;Goroka;Henganofi,"Daulo|(-5.98333000,145.23333000);Goroka|(-6.05000000,145.38333000);Henganofi|(-6.21667000,145.66667000)"
+Papua New Guinea,PG,Enga,Kandep,Port Moresby,,,-5.83333000,143.55000000,Kandep;Kompiam Ambum;Lagaip Porgera,"Kandep|(-5.83333000,143.55000000);Kompiam Ambum|(-5.25000000,144.00000000);Lagaip Porgera|(-5.38333000,143.16667000)"
+Papua New Guinea,PG,Gulf,Kerema,Port Moresby,,,-7.79600000,146.09300000,Kerema;Kikori,"Kerema|(-7.79600000,146.09300000);Kikori|(-7.25000000,144.33333000)"
+Papua New Guinea,PG,Hela,Komo Margarima,Port Moresby,,,-6.11667000,143.00000000,Komo Margarima;Koroba-Lake Kopiago;Tari,"Komo Margarima|(-6.11667000,143.00000000);Koroba-Lake Kopiago|(-5.41667000,142.50000000);Tari|(-5.84500000,142.94667000)"
+Papua New Guinea,PG,Jiwaka,Angalimp South Wahgi,Port Moresby,,,-6.05000000,144.56667000,Angalimp South Wahgi;Jimi;North Wahgi,"Angalimp South Wahgi|(-6.05000000,144.56667000);Jimi|(-5.53333000,144.56667000);North Wahgi|(-5.80000000,144.68333000)"
+Papua New Guinea,PG,Madang,Madang,Port Moresby,,,-5.22152000,145.78695000,Bogia;Madang;Middle Ramu,"Bogia|(-4.50000000,145.00000000);Madang|(-5.22152000,145.78695000);Middle Ramu|(-4.91667000,144.75000000)"
+Papua New Guinea,PG,Manus,Manus,Port Moresby,,,-2.09626000,146.96612000,Lorengau;Manus,"Lorengau|(-2.03410000,147.27173000);Manus|(-2.09626000,146.96612000)"
+Papua New Guinea,PG,Milne Bay,Alotau,Port Moresby,,,-10.25000000,150.08333000,Alotau;Esa’ala;Kiriwina Goodenough,"Alotau|(-10.25000000,150.08333000);Esa’ala|(-9.58333000,150.75000000);Kiriwina Goodenough|(-8.48333000,151.06667000)"
+Papua New Guinea,PG,Morobe,Bulolo,Port Moresby,,,-7.41667000,146.75000000,Bulolo;Finschhafen;Huon Gulf,"Bulolo|(-7.41667000,146.75000000);Finschhafen|(-6.41667000,147.50000000);Huon Gulf|(-7.18333000,146.95000000)"
+Papua New Guinea,PG,New Ireland,Kavieng,Port Moresby,,,-3.00000000,151.41667000,Kavieng;Namatanai,"Kavieng|(-3.00000000,151.41667000);Namatanai|(-4.33333000,152.83333000)"
+Papua New Guinea,PG,Oro,Ijivitari,Port Moresby,,,-9.33333000,148.58333000,Ijivitari;Kokoda;Popondetta,"Ijivitari|(-9.33333000,148.58333000);Kokoda|(-8.87778000,147.73642000);Popondetta|(-8.76536000,148.23252000)"
+Papua New Guinea,PG,Port Moresby,Port Moresby,Port Moresby,,,-9.47723000,147.15089000,National Capital District;Port Moresby,"National Capital District|(-9.42257000,147.16641000);Port Moresby|(-9.47723000,147.15089000)"
+Papua New Guinea,PG,Sandaun,Aitape,Port Moresby,,,-3.13697000,142.34913000,Aitape;Aitape Lumi;Nuku,"Aitape|(-3.13697000,142.34913000);Aitape Lumi|(-3.25000000,142.08333000);Nuku|(-3.66667000,142.41667000)"
+Papua New Guinea,PG,Southern Highlands,Ialibu,Port Moresby,,,-6.28208000,143.99354000,Ialibu;Ialibu Pangia;Kagua Erave,"Ialibu|(-6.28208000,143.99354000);Ialibu Pangia|(-6.38401880,144.08381900);Kagua Erave|(-6.66667000,144.00000000)"
+Papua New Guinea,PG,West New Britain,Kandrian,Port Moresby,,,-6.20655000,149.54744000,Kandrian;Kandrian Gloucester;Kimbe,"Kandrian|(-6.20655000,149.54744000);Kandrian Gloucester|(-6.08333000,149.91667000);Kimbe|(-5.55085000,150.13766000)"
+Papua New Guinea,PG,Western,Daru,Port Moresby,,,-9.07786000,143.20893000,Daru;Kiunga;Middle Fly,"Daru|(-9.07786000,143.20893000);Kiunga|(-6.12193000,141.29061000);Middle Fly|(-7.16667000,142.03333000)"
+Papua New Guinea,PG,Western Highlands,Baiyer Mul,Port Moresby,,,-5.53333000,144.15000000,Baiyer Mul;Dei;Hagen,"Baiyer Mul|(-5.53333000,144.15000000);Dei|(-5.68333000,144.36667000);Hagen|(-5.83333000,144.28333000)"
+Paraguay,PY,Alto Paraguay,Capitán Pablo Lagerenza,Asuncion,EMEA,5,-19.91667000,-60.78333000,Capitán Pablo Lagerenza;Fuerte Olimpo,"Capitán Pablo Lagerenza|(-19.91667000,-60.78333000);Fuerte Olimpo|(-21.04153000,-57.87377000)"
+Paraguay,PY,Alto Paraná,Cedrales,Asuncion,EMEA,5,-25.65668000,-54.72272000,Cedrales;Ciudad del Este;Colonia Minga Porá,"Cedrales|(-25.65668000,-54.72272000);Ciudad del Este|(-25.50972000,-54.61111000);Colonia Minga Porá|(-24.86667000,-54.90000000)"
+Paraguay,PY,Amambay,Bella Vista,Asuncion,EMEA,5,-22.13333000,-56.51667000,Bella Vista;Capitán Bado;Pedro Juan Caballero,"Bella Vista|(-22.13333000,-56.51667000);Capitán Bado|(-23.26667000,-55.53333000);Pedro Juan Caballero|(-22.54722000,-55.73333000)"
+Paraguay,PY,Asuncion,,Asuncion,EMEA,5,,,,
+Paraguay,PY,Boquerón,Colonia Menno,Asuncion,EMEA,5,-22.36667000,-59.81667000,Colonia Menno;Colonia Neuland;Filadelfia,"Colonia Menno|(-22.36667000,-59.81667000);Colonia Neuland|(-22.66667000,-60.11667000);Filadelfia|(-22.33936000,-60.03157000)"
+Paraguay,PY,Caaguazú,Caaguazú,Asuncion,EMEA,5,-25.47104000,-56.01603000,Caaguazú;Carayaó;Cecilio Baez,"Caaguazú|(-25.47104000,-56.01603000);Carayaó|(-25.19750000,-56.39878000);Cecilio Baez|(-25.07158000,-56.24386000)"
+Paraguay,PY,Caazapá,Caazapá,Asuncion,EMEA,5,-26.19583000,-56.36806000,Abaí;Buena Vista;Caazapá,"Abaí|(-26.03333000,-55.93333000);Buena Vista|(-26.18387000,-56.08171000);Caazapá|(-26.19583000,-56.36806000)"
+Paraguay,PY,Canindeyú,Colonia Catuete,Asuncion,EMEA,5,-24.13333000,-54.61667000,Colonia Catuete;Corpus Christi;La Paloma,"Colonia Catuete|(-24.13333000,-54.61667000);Corpus Christi|(-24.08040000,-54.93933000);La Paloma|(-24.12957000,-54.61376000)"
+Paraguay,PY,Central,Areguá,Asuncion,EMEA,5,-25.31250000,-57.38472000,Areguá;Capiatá;Fernando de la Mora,"Areguá|(-25.31250000,-57.38472000);Capiatá|(-25.35520000,-57.44545000);Fernando de la Mora|(-25.33860000,-57.52167000)"
+Paraguay,PY,Concepción,Concepción,Asuncion,EMEA,5,-23.39985000,-57.43236000,Belén;Concepción;Horqueta,"Belén|(-23.46611000,-57.26194000);Concepción|(-23.39985000,-57.43236000);Horqueta|(-23.34278000,-57.05972000)"
+Paraguay,PY,Cordillera,Altos,Asuncion,EMEA,5,-25.26263000,-57.25443000,Altos;Arroyos y Esteros;Atyrá,"Altos|(-25.26263000,-57.25443000);Arroyos y Esteros|(-25.05478000,-57.09873000);Atyrá|(-25.27876000,-57.17192000)"
+Paraguay,PY,Guairá,Colonia Mauricio José Troche,Asuncion,EMEA,5,-25.56667000,-56.28333000,Colonia Mauricio José Troche;Coronel Martínez;Independencia,"Colonia Mauricio José Troche|(-25.56667000,-56.28333000);Coronel Martínez|(-25.75862000,-56.61677000);Independencia|(-25.69100000,-56.26781000)"
+Paraguay,PY,Itapúa,Arquitecto Tomás Romero Pereira,Asuncion,EMEA,5,-26.48333000,-55.25000000,Arquitecto Tomás Romero Pereira;Bella Vista;Capitán Miranda,"Arquitecto Tomás Romero Pereira|(-26.48333000,-55.25000000);Bella Vista|(-27.05000000,-55.55000000);Capitán Miranda|(-27.20000000,-55.80000000)"
+Paraguay,PY,Misiones,Juan de Ayolas,Asuncion,EMEA,5,-27.38662000,-56.84724000,Juan de Ayolas;San Juan Bautista;San Miguel,"Juan de Ayolas|(-27.38662000,-56.84724000);San Juan Bautista|(-26.66944000,-57.14583000);San Miguel|(-26.50000000,-57.05000000)"
+Paraguay,PY,Ñeembucú,Cerrito,Asuncion,EMEA,5,-27.34215000,-57.64119000,Cerrito;General José Eduvigis Díaz;Pilar,"Cerrito|(-27.34215000,-57.64119000);General José Eduvigis Díaz|(-27.20136000,-58.36740000);Pilar|(-26.85874000,-58.30639000)"
+Paraguay,PY,Paraguarí,Paraguarí,Asuncion,EMEA,5,-25.62083000,-57.14722000,Acahay;Caapucú;Carapeguá,"Acahay|(-25.91667000,-57.15000000);Caapucú|(-26.23523000,-57.18212000);Carapeguá|(-25.80000000,-57.23333000)"
+Paraguay,PY,Presidente Hayes,Benjamín Aceval,Asuncion,EMEA,5,-24.96667000,-57.56667000,Benjamín Aceval;Nanawua;Villa Hayes,"Benjamín Aceval|(-24.96667000,-57.56667000);Nanawua|(-25.27930000,-57.70307000);Villa Hayes|(-25.09306000,-57.52361000)"
+Paraguay,PY,San Pedro,Antequera,Asuncion,EMEA,5,-24.08526000,-57.20221000,Antequera;Capiíbary;Colonia Nueva Germania,"Antequera|(-24.08526000,-57.20221000);Capiíbary|(-24.80000000,-56.03333000);Colonia Nueva Germania|(-23.91137000,-56.70091000)"
+Peru,PE,Amazonas,Bagua Grande,Lima,,,-5.75611000,-78.44111000,Bagua Grande;Cajaruro;Chachapoyas,"Bagua Grande|(-5.75611000,-78.44111000);Cajaruro|(-5.73639000,-78.42556000);Chachapoyas|(-6.23169000,-77.86903000)"
+Peru,PE,Áncash,Asuncion,Lima,,,-9.18987000,-77.39878000,Asuncion;Carás;Carhuaz,"Asuncion|(-9.18987000,-77.39878000);Carás|(-9.04692000,-77.80901000);Carhuaz|(-9.28194000,-77.64472000)"
+Peru,PE,Apurímac,Abancay,Lima,,,-13.63389000,-72.88139000,Abancay;Andahuaylas;Provincia de Abancay,"Abancay|(-13.63389000,-72.88139000);Andahuaylas|(-13.65556000,-73.38722000);Provincia de Abancay|(-13.66667000,-72.91667000)"
+Peru,PE,Arequipa,Arequipa,Lima,,,-16.39889000,-71.53500000,Acarí;Arequipa;Camaná,"Acarí|(-15.42393000,-74.61361000);Arequipa|(-16.39889000,-71.53500000);Camaná|(-16.62375000,-72.71055000)"
+Peru,PE,Ayacucho,Ayacucho,Lima,,,-13.15878000,-74.22321000,Ayacucho;Ayna;Coracora,"Ayacucho|(-13.15878000,-74.22321000);Ayna|(-12.65000000,-73.91667000);Coracora|(-15.03333000,-73.78333000)"
+Peru,PE,Cajamarca,Cajamarca,Lima,,,-7.16378000,-78.50027000,Bambamarca;Bellavista;Cajabamba,"Bambamarca|(-6.68333000,-78.53333000);Bellavista|(-5.66417000,-78.67722000);Cajabamba|(-7.61667000,-78.05000000)"
+Peru,PE,Callao,Callao,Lima,,,-12.05659000,-77.11814000,Callao,"Callao|(-12.05659000,-77.11814000)"
+Peru,PE,Cusco,Cusco,Lima,,,-13.52264000,-71.96734000,Anta;Cahuanuyo;Calca,"Anta|(-13.47056000,-72.14833000);Cahuanuyo|(-14.34147000,-71.46311000);Calca|(-13.33333000,-71.95000000)"
+Peru,PE,Huancavelica,Huancavelica,Lima,,,-12.78261000,-74.97266000,Huancavelica;Huaytara;Pampas,"Huancavelica|(-12.78261000,-74.97266000);Huaytara|(-13.65616000,-75.09234000);Pampas|(-12.39490000,-74.86687000)"
+Peru,PE,Huanuco,Ambo,Lima,,,-10.13083000,-76.20472000,Ambo;Huacaybamba;Huánuco,"Ambo|(-10.13083000,-76.20472000);Huacaybamba|(-8.99480000,-76.81027000);Huánuco|(-9.93062000,-76.24223000)"
+Peru,PE,Ica,Ica,Lima,,,-14.06777000,-75.72861000,Chincha Alta;Ica;Los Aquijes,"Chincha Alta|(-13.40985000,-76.13235000);Ica|(-14.06777000,-75.72861000);Los Aquijes|(-14.09667000,-75.69083000)"
+Peru,PE,Junín,Junín,Lima,,,-11.15895000,-75.99304000,Acolla;Carhuamayo;Chanchamayo,"Acolla|(-11.73193000,-75.54634000);Carhuamayo|(-10.91667000,-76.03333000);Chanchamayo|(-11.05000000,-75.31667000)"
+Peru,PE,La Libertad,Ascope,Lima,,,-7.71444000,-79.10778000,Ascope;Cascas;Chepen,"Ascope|(-7.71444000,-79.10778000);Cascas|(-7.48333000,-78.81667000);Chepen|(-7.14367000,-79.45674000)"
+Peru,PE,Lambayeque,Lambayeque,Lima,,,-6.70111000,-79.90611000,Chiclayo;Chongoyape;Eten,"Chiclayo|(-6.77137000,-79.84088000);Chongoyape|(-6.64056000,-79.38917000);Eten|(-6.90806000,-79.86417000)"
+Peru,PE,Lima,Lima,Lima,,,-12.04318000,-77.02824000,Asentamiento Humano Nicolas de Pierola;Barranca;Caleta de Carquín,"Asentamiento Humano Nicolas de Pierola|(-11.93573000,-76.70611000);Barranca|(-10.75000000,-77.76667000);Caleta de Carquín|(-11.09250000,-77.62667000)"
+Peru,PE,Loreto,Andoas,Lima,,,-2.90250000,-76.40250000,Andoas;Borja;Caballococha,"Andoas|(-2.90250000,-76.40250000);Borja|(-4.43333333,-77.55000000);Caballococha|(-3.90583333,-70.51638889)"
+Peru,PE,Madre de Dios,Iberia,Lima,,,-11.35000000,-69.58333000,Iberia;Provincia de Manú;Provincia de Tahuamanú,"Iberia|(-11.35000000,-69.58333000);Provincia de Manú|(-12.25000000,-71.00000000);Provincia de Tahuamanú|(-11.25000000,-70.50000000)"
+Peru,PE,Moquegua,Moquegua,Lima,,,-17.19832000,-70.93567000,Ilo;Moquegua;Pacocha,"Ilo|(-17.63185000,-71.34108000);Moquegua|(-17.19832000,-70.93567000);Pacocha|(-17.64604000,-71.34481000)"
+Peru,PE,Pasco,Cerro de Pasco,Lima,,,-10.66748000,-76.25668000,Cerro de Pasco;Chaupimarca;Oxapampa,"Cerro de Pasco|(-10.66748000,-76.25668000);Chaupimarca|(-10.40696000,-76.46168000);Oxapampa|(-10.57750000,-75.40167000)"
+Peru,PE,Piura,Piura,Lima,,,-5.19449000,-80.63282000,Ayabaca;Bernal;Buenos Aires,"Ayabaca|(-4.63983000,-79.71491000);Bernal|(-5.45000000,-80.75000000);Buenos Aires|(-5.26083000,-79.96417000)"
+Peru,PE,Puno,Puno,Lima,,,-15.84220000,-70.01990000,Atuncolla;Ayaviri;Azángaro,"Atuncolla|(-15.68333000,-70.15000000);Ayaviri|(-14.88639000,-70.58889000);Azángaro|(-14.90843000,-70.19616000)"
+Peru,PE,San Martín,Bellavista,Lima,,,-7.05614000,-76.59110000,Bellavista;Chazuta;El Dorado,"Bellavista|(-7.05614000,-76.59110000);Chazuta|(-6.57087000,-76.13753000);El Dorado|(-6.56298000,-76.74130000)"
+Peru,PE,Tacna,Tacna,Lima,,,-18.01465000,-70.25362000,Calana;Candarave;Chipispaya,"Calana|(-17.94167000,-70.18694000);Candarave|(-17.26778000,-70.24944000);Chipispaya|(-17.49790000,-70.21714000)"
+Peru,PE,Tumbes,Tumbes,Lima,,,-3.56694000,-80.45153000,Aguas Verdes;Papayal;Provincia de Contralmirante Villar,"Aguas Verdes|(-3.48139000,-80.24500000);Papayal|(-4.07771000,-80.73690000);Provincia de Contralmirante Villar|(-4.00000000,-80.75000000)"
+Peru,PE,Ucayali,Atalaya,Lima,,,-10.38980000,-73.21977000,Atalaya;Campoverde;Padre Abad,"Atalaya|(-10.38980000,-73.21977000);Campoverde|(-8.47533000,-74.80709000);Padre Abad|(-8.79680000,-75.42850000)"
+Philippines,PH,Abra,Alac,Manila,,,15.98777778,120.80638889,Alac;Allangigan Primero;Aloleng,"Alac|(15.98777778,120.80638889);Allangigan Primero|(17.17388889,120.49194444);Aloleng|(16.13083333,119.78250000)"
+Philippines,PH,Agusan del Norte,Abut,Manila,,,17.35416667,121.60138889,Abut;Accusilian;Afusing Centro,"Abut|(17.35416667,121.60138889);Accusilian|(17.74777778,121.46250000);Afusing Centro|(17.85250000,121.62694444)"
+Philippines,PH,Agusan del Sur,Acli,Manila,,,15.12277778,120.64472222,Acli;Agbannawag;Akle,"Acli|(15.12277778,120.64472222);Agbannawag|(15.67916667,121.08333333);Akle|(15.04833333,121.07333333)"
+Philippines,PH,Aklan,Altavas,Manila,,,11.51937220,122.38395760,Altavas;Balete;Banga,"Altavas|(11.51937220,122.38395760);Balete|(11.52259720,122.29336200);Banga|(11.59926330,122.29023350)"
+Philippines,PH,Albay,Aanislag,Manila,,,13.07480000,123.70300000,Aanislag;Abucay;Agos,"Aanislag|(13.07480000,123.70300000);Abucay|(12.98200000,123.64920000);Agos|(13.34340000,123.39830000)"
+Philippines,PH,Antique,Abaca,Manila,,,11.13420000,122.71560000,Abaca;Abangay;Abiera,"Abaca|(11.13420000,122.71560000);Abangay|(10.96667000,122.65000000);Abiera|(11.57490000,122.09000000)"
+Philippines,PH,Apayao,Calanasan,Manila,,,18.25797860,120.71187320,Calanasan;Conner;Flora,"Calanasan|(18.25797860,120.71187320);Conner|(17.77495440,121.09925090);Flora|(18.11880180,121.24518720)"
+Philippines,PH,Aurora,Baler,Manila,,,15.75232690,121.48904400,Baler;Casiguran;Dilasag,"Baler|(15.75232690,121.48904400);Casiguran|(16.20941190,121.89393840);Dilasag|(16.43307200,121.96135840)"
+Philippines,PH,Autonomous Region in Muslim Mindanao,Andalan,Manila,,,5.95944000,121.39028000,Andalan;Anuling;Awang,"Andalan|(5.95944000,121.39028000);Anuling|(6.03556000,121.00667000);Awang|(7.15306000,124.22111000)"
+Philippines,PH,Basilan,Akbar,Manila,,,6.63622070,122.13063910,Akbar;Al-Barka;Hadji Mohammad Ajul,"Akbar|(6.63622070,122.13063910);Al-Barka|(6.48418650,122.11105890);Hadji Mohammad Ajul|(6.62700220,122.19440060)"
+Philippines,PH,Bataan,Abaca,Manila,,,9.92040000,124.50510000,Abaca;Abis;Abucayan,"Abaca|(9.92040000,124.50510000);Abis|(9.71730000,122.94380000);Abucayan|(9.92900000,123.91460000)"
+Philippines,PH,Batanes,Alugan,Manila,,,12.21880000,125.48080000,Alugan;Anito;Balagtas,"Alugan|(12.21880000,125.48080000);Anito|(12.44972000,125.28861000);Balagtas|(11.13330000,124.51920000)"
+Philippines,PH,Batangas,Batangas,Manila,,,13.68745230,120.93977710,Agoncillo;Alitagtag;Balayan,"Agoncillo|(13.96521120,120.88951970);Alitagtag|(13.87053610,120.97725720);Balayan|(13.95074580,120.64737750)"
+Philippines,PH,Benguet,Adtugan,Manila,,,7.81194000,124.85444000,Adtugan;Aglayan;Agusan,"Adtugan|(7.81194000,124.85444000);Aglayan|(8.05500000,125.13417000);Agusan|(8.49056000,124.73722000)"
+Philippines,PH,Bicol,,Manila,,,,,,
+Philippines,PH,Biliran,Biliran,Manila,,,11.50995020,124.40218050,Almeria;Biliran;Cabucgayan,"Almeria|(11.63242470,124.31995460);Biliran|(11.50995020,124.40218050);Cabucgayan|(11.49883130,124.48716360)"
+Philippines,PH,Bohol,Anibongan,Manila,,,9.72711900,124.38813110,Anibongan;Babag;Balutakay,"Anibongan|(9.72711900,124.38813110);Babag|(9.91848690,124.33950980);Balutakay|(6.90868740,125.27003170)"
+Philippines,PH,Bukidnon,Amas,Manila,,,7.05694444,124.98388889,Amas;Bagontapay;Baguer,"Amas|(7.05694444,124.98388889);Bagontapay|(6.85888889,124.90888889);Baguer|(7.25611111,124.50416667)"
+Philippines,PH,Bulacan,Agay,Manila,,,9.05361111,125.58666667,Agay;Amaga;Anticala,"Agay|(9.05361111,125.58666667);Amaga|(8.53083333,126.07027778);Anticala|(9.00444444,125.64527778)"
+Philippines,PH,Cagayan,Andalan,Manila,,,5.95944444,121.39027778,Andalan;Anuling;Awang,"Andalan|(5.95944444,121.39027778);Anuling|(6.03555556,121.00666667);Awang|(7.15305556,124.22111111)"
+Philippines,PH,Cagayan Valley,Abulug,Manila,,,18.44528000,121.45333000,Abulug;Abut;Accusilian,"Abulug|(18.44528000,121.45333000);Abut|(17.35423000,121.60138000);Accusilian|(17.74791000,121.46254000)"
+Philippines,PH,Calabarzon,,Manila,,,,,,
+Philippines,PH,Camarines Norte,Ambuclao,Manila,,,16.48333333,120.75000000,Ambuclao;Amlimay;Ampusungan,"Ambuclao|(16.48333333,120.75000000);Amlimay|(16.69388889,120.83694444);Ampusungan|(16.78027778,120.72472222)"
+Philippines,PH,Camarines Sur,Baao,Manila,,,13.48844070,123.28093120,Baao;Balatan;Bato,"Baao|(13.48844070,123.28093120);Balatan|(13.33921120,123.20690530);Bato|(13.31786510,123.24565490)"
+Philippines,PH,Camiguin,Catarman,Manila,,,9.17776630,124.62218990,Catarman;Guinsiliban;Mahinog,"Catarman|(9.17776630,124.62218990);Guinsiliban|(9.10904250,124.73748100);Mahinog|(9.16437120,124.69769550)"
+Philippines,PH,Capiz,Cuartero,Manila,,,11.31111010,122.60093620,Cuartero;Dao;Dumalag,"Cuartero|(11.31111010,122.60093620);Dao|(11.38463020,122.62605390);Dumalag|(11.31440130,122.58094210)"
+Philippines,PH,Caraga,Adlay,Manila,,,9.40972000,125.89750000,Adlay;Agay;Amaga,"Adlay|(9.40972000,125.89750000);Agay|(9.05361000,125.58667000);Amaga|(8.53083000,126.07028000)"
+Philippines,PH,Catanduanes,Bagamanoc,Manila,,,13.96034610,124.18442810,Bagamanoc;Baras;Bato,"Bagamanoc|(13.96034610,124.18442810);Baras|(13.68655350,124.36716560);Bato|(13.58767010,124.26910310)"
+Philippines,PH,Cavite,Alfonso,Manila,,,14.11151590,120.85312840,Alfonso;Amadeo;Bacoor,"Alfonso|(14.11151590,120.85312840);Amadeo|(14.18352860,120.88189830);Bacoor|(14.41609380,120.92757490)"
+Philippines,PH,Cebu,Alcantara,Manila,,,9.96235140,123.36356470,Alcantara;Alcoy;Alegria,"Alcantara|(9.96235140,123.36356470);Alcoy|(9.72267010,123.42821970);Alegria|(9.75304140,123.38268490)"
+Philippines,PH,Central Luzon,Abucay,Manila,,,14.73347000,120.53358000,Abucay;Acli;Agbannawag,"Abucay|(14.73347000,120.53358000);Acli|(15.12279000,120.64470000);Agbannawag|(15.67920000,121.08330000)"
+Philippines,PH,Central Visayas,,Manila,,,,,,
+Philippines,PH,Cordillera Administrative,Agbannawag,Manila,,,17.37641000,121.54780000,Agbannawag;Ambuclao;Amlimay,"Agbannawag|(17.37641000,121.54780000);Ambuclao|(16.48333000,120.75000000);Amlimay|(16.69377000,120.83704000)"
+Philippines,PH,Cotabato,Alamada,Manila,,,7.50842730,124.40036580,Alamada;Aleosan;Antipas,"Alamada|(7.50842730,124.40036580);Aleosan|(7.18182870,124.54811680);Antipas|(7.25961410,124.98825380)"
+Philippines,PH,Davao,Davao,Manila,,,7.07306000,125.61278000,Alejal;Andili;Andop,"Alejal|(7.38417000,125.66000000);Andili|(7.46200000,125.97010000);Andop|(7.86111000,125.75389000)"
+Philippines,PH,Davao de Oro,Compostela,Manila,,,7.71401500,125.99196720,Compostela;Laak;Mabini,"Compostela|(7.71401500,125.99196720);Laak|(7.81706790,125.65576840);Mabini|(7.28909420,125.77121070)"
+Philippines,PH,Davao del Norte,Asuncion,Manila,,,7.64215700,125.64255040,Asuncion;Braulio E. Dujali;Carmen,"Asuncion|(7.64215700,125.64255040);Braulio E. Dujali|(7.45139940,125.62497660);Carmen|(7.36724970,125.58138830)"
+Philippines,PH,Davao del Sur,Bansalan,Manila,,,6.78693390,125.21080710,Bansalan;Davao City;Digos,"Bansalan|(6.78693390,125.21080710);Davao City|(7.25419890,125.12141680);Digos|(6.84352490,125.23817960)"
+Philippines,PH,Davao Occidental,Balangonan,Manila,,,5.57054290,125.35436450,Balangonan;Basiawan;Biao,"Balangonan|(5.57054290,125.35436450);Basiawan|(6.51135870,125.51108700);Biao|(6.38623950,125.46996650)"
+Philippines,PH,Davao Oriental,Baganga,Manila,,,7.60140380,126.24409090,Baganga;Banaybanay;Boston,"Baganga|(7.60140380,126.24409090);Banaybanay|(7.09273580,125.79562300);Boston|(7.90499890,126.11753750)"
+Philippines,PH,Dinagat Islands,Basilisa,Manila,,,10.04008510,125.46317660,Basilisa;Cagdianao;Dinagat,"Basilisa|(10.04008510,125.46317660);Cagdianao|(10.01931460,125.49702460);Dinagat|(9.96098390,125.54737950)"
+Philippines,PH,Eastern Samar,Arteche,Manila,,,12.25845870,125.18071710,Arteche;Balangiga;Balangkayan,"Arteche|(12.25845870,125.18071710);Balangiga|(11.18308620,125.27078700);Balangkayan|(11.39104930,125.23202240)"
+Philippines,PH,Eastern Visayas,Alugan,Manila,,,12.21888889,125.48083333,Alugan;Anito;Balagtas,"Alugan|(12.21888889,125.48083333);Anito|(12.44972222,125.28861111);Balagtas|(11.13333333,124.51916667)"
+Philippines,PH,Guimaras,Buenavista,Manila,,,10.69045770,122.58102410,Buenavista;Jordan;Nueva Valencia,"Buenavista|(10.69045770,122.58102410);Jordan|(10.60930520,122.48744660);Nueva Valencia|(10.43014400,122.46056150)"
+Philippines,PH,Ifugao,Aguinaldo,Manila,,,16.92878200,121.17167600,Aguinaldo;Alfonso Lista;Asipulo,"Aguinaldo|(16.92878200,121.17167600);Alfonso Lista|(16.94064700,121.32020320);Asipulo|(16.69006550,120.98551840)"
+Philippines,PH,Ilocos,Acao,Manila,,,16.52556000,120.37639000,Acao;Alac;Allangigan Primero,"Acao|(16.52556000,120.37639000);Alac|(15.98770000,120.80650000);Allangigan Primero|(17.17393000,120.49195000)"
+Philippines,PH,Ilocos Norte,Adams,Manila,,,18.43902960,120.83394140,Adams;Bacarra;Badoc,"Adams|(18.43902960,120.83394140);Bacarra|(18.25832460,120.52870080);Badoc|(17.91022520,120.41798330)"
+Philippines,PH,Ilocos Sur,Alilem,Manila,,,16.89298940,120.50868600,Alilem;Banayoyo;Bantay,"Alilem|(16.89298940,120.50868600);Banayoyo|(17.23901590,120.45737430);Bantay|(17.59949900,120.36224660)"
+Philippines,PH,Iloilo,Iloilo,Manila,,,10.73007800,122.46596890,Ajuy;Alimodian;Anilao,"Ajuy|(11.12023540,122.88060490);Alimodian|(10.87096780,122.20288580);Anilao|(11.00849930,122.65865880)"
+Philippines,PH,Isabela,Alicia,Manila,,,16.80918220,121.50199620,Alicia;Angadanan;Aurora,"Alicia|(16.80918220,121.50199620);Angadanan|(16.77954890,121.62228440);Aurora|(16.97668040,121.55777900)"
+Philippines,PH,Kalinga,Balbalan,Manila,,,17.55137830,120.97473740,Balbalan;Lubuagan;Pasil,"Balbalan|(17.55137830,120.97473740);Lubuagan|(17.31437780,120.91319690);Pasil|(17.38726110,120.93778470)"
+Philippines,PH,La Union,Agoo,Manila,,,16.33614330,120.32866980,Agoo;Aringay;Bacnotan,"Agoo|(16.33614330,120.32866980);Aringay|(16.41146870,120.31937570);Bacnotan|(16.74118340,120.30198850)"
+Philippines,PH,Laguna,Alaminos,Manila,,,14.04447540,121.20826000,Alaminos;Bay;Biñan,"Alaminos|(14.04447540,121.20826000);Bay|(14.14166320,121.21217880);Biñan|(14.30323770,121.02888720)"
+Philippines,PH,Lanao del Norte,Bacolod,Manila,,,8.13884430,123.98303210,Bacolod;Baloi;Baroy,"Bacolod|(8.13884430,123.98303210);Baloi|(8.09752910,124.13224300);Baroy|(7.97983380,123.73422460)"
+Philippines,PH,Lanao del Sur,Amai Manabilang,Manila,,,7.72220020,124.55045300,Amai Manabilang;Bacolod-Kalawi;Balabagan,"Amai Manabilang|(7.72220020,124.55045300);Bacolod-Kalawi|(7.87428350,124.08564780);Balabagan|(7.54228570,124.07091690)"
+Philippines,PH,Leyte,Leyte,Manila,,,11.32959150,124.39561440,Abuyog;Alangalang;Albuera,"Abuyog|(10.65058610,124.87917240);Alangalang|(11.21542780,124.78185250);Albuera|(10.91766310,124.66030250)"
+Philippines,PH,Maguindanao del Norte,Barira,Manila,,,7.47420330,124.23953130,Barira;Buldon;Cotabato City,"Barira|(7.47420330,124.23953130);Buldon|(7.49428290,124.24226560);Cotabato City|(7.19867700,124.16271400)"
+Philippines,PH,Maguindanao del Sur,Ampatuan,Manila,,,6.79822870,124.22200960,Ampatuan;Buluan;Datu Abdullah Sangki,"Ampatuan|(6.79822870,124.22200960);Buluan|(6.72915810,124.71966940);Datu Abdullah Sangki|(6.82019260,124.44011760)"
+Philippines,PH,Marinduque,Boac,Manila,,,13.38925470,121.81348400,Boac;Buenavista;Gasan,"Boac|(13.38925470,121.81348400);Buenavista|(13.25567130,121.89021660);Gasan|(13.29685110,121.79910740)"
+Philippines,PH,Masbate,Masbate,Manila,,,12.35298800,123.48220930,Aroroy;Baleno;Balud,"Aroroy|(12.46930250,123.16273030);Baleno|(12.41969550,123.40728940);Balud|(11.91071010,122.81699820)"
+Philippines,PH,Mimaropa,,Manila,,,,,,
+Philippines,PH,Misamis Occidental,Aloran,Manila,,,8.39998540,123.66952300,Aloran;Baliangao;Bonifacio,"Aloran|(8.39998540,123.66952300);Baliangao|(8.61394410,123.57207190);Bonifacio|(8.08888390,123.56099720)"
+Philippines,PH,Misamis Oriental,Alubijid,Manila,,,8.50805920,124.35592760,Alubijid;Balingasag;Balingoan,"Alubijid|(8.50805920,124.35592760);Balingasag|(8.73832420,124.72486090);Balingoan|(8.94233430,124.78112830)"
+Philippines,PH,Mountain Province,Barlig,Manila,,,17.09793430,121.05903230,Barlig;Bauko;Besao,"Barlig|(17.09793430,121.05903230);Bauko|(16.94195780,120.80543750);Besao|(17.12193260,120.74608560)"
+Philippines,PH,National Capital Region (Metro Manila),,Manila,,,,,,
+Philippines,PH,Negros Occidental,Bacolod,Manila,,,10.64655290,122.83691700,Bacolod;Bago;Binalbagan,"Bacolod|(10.64655290,122.83691700);Bago|(10.50839140,122.78958130);Binalbagan|(10.20781480,122.82414050)"
+Philippines,PH,Negros Oriental,Amlan,Manila,,,9.42889660,123.09429250,Amlan;Ayungon;Bacong,"Amlan|(9.42889660,123.09429250);Ayungon|(9.86362920,122.86901760);Bacong|(9.23897310,123.21582970)"
+Philippines,PH,Northern Mindanao,,Manila,,,,,,
+Philippines,PH,Northern Samar,Allen,Manila,,,12.52978630,124.24781400,Allen;Biri;Bobon,"Allen|(12.52978630,124.24781400);Biri|(12.65401400,124.32008350);Bobon|(12.41771900,124.44076140)"
+Philippines,PH,Nueva Ecija,Aliaga,Manila,,,15.50701190,120.77497560,Aliaga;Bongabon;Cabanatuan,"Aliaga|(15.50701190,120.77497560);Bongabon|(15.65749370,121.06088720);Cabanatuan|(15.50017230,120.81621410)"
+Philippines,PH,Nueva Vizcaya,Alfonso Castañeda,Manila,,,15.89895800,121.17600760,Alfonso Castañeda;Ambaguio;Aritao,"Alfonso Castañeda|(15.89895800,121.17600760);Ambaguio|(16.53995740,120.97062670);Aritao|(16.23158790,120.83860710)"
+Philippines,PH,Occidental Mindoro,Abuyon,Manila,,,13.62260000,122.51910000,Abuyon;Aga;Aliang,"Abuyon|(13.62260000,122.51910000);Aga|(14.09650000,120.80217000);Aliang|(14.28333000,120.88333000)"
+Philippines,PH,Oriental Mindoro,Abra de Ilog,Manila,,,13.44370000,120.72910000,Abra de Ilog;Adela;Agcogon,"Abra de Ilog|(13.44370000,120.72910000);Adela|(12.44164000,120.97291000);Agcogon|(12.06146000,121.95911000)"
+Philippines,PH,Palawan,Aborlan,Manila,,,9.50252080,118.28831960,Aborlan;Agutaya;Araceli,"Aborlan|(9.50252080,118.28831960);Agutaya|(11.29341430,120.60209410);Araceli|(10.60574930,119.70705160)"
+Philippines,PH,Pampanga,Angeles City,Manila,,,15.14649350,120.47721760,Angeles City;Apalit;Arayat,"Angeles City|(15.14649350,120.47721760);Apalit|(14.95510310,120.72276330);Arayat|(15.18828100,120.66932350)"
+Philippines,PH,Pangasinan,Agno,Manila,,,16.10929910,119.73903000,Agno;Aguilar;Alaminos,"Agno|(16.10929910,119.73903000);Aguilar|(15.83519450,120.12969410);Alaminos|(16.14423360,119.90742360)"
+Philippines,PH,Quezon,Quezon,Manila,,,14.06464960,122.03838180,Agdangan;Alabat;Atimonan,"Agdangan|(13.88253030,121.88210860);Alabat|(14.11212590,121.98424710);Atimonan|(13.99405220,121.71914430)"
+Philippines,PH,Quirino,Aglipay,Manila,,,16.44113450,121.53324410,Aglipay;Cabarroguis;Diffun,"Aglipay|(16.44113450,121.53324410);Cabarroguis|(16.44622780,121.41724670);Diffun|(16.53436880,121.31342010)"
+Philippines,PH,Rizal,Angono,Manila,,,14.53908180,121.12685790,Angono;Antipolo;Baras,"Angono|(14.53908180,121.12685790);Antipolo|(14.66547100,121.08089880);Baras|(14.53760640,121.23194580)"
+Philippines,PH,Romblon,Romblon,Manila,,,12.57434520,122.19706140,Alcantara;Banton;Cajidiocan,"Alcantara|(12.28437610,121.97911810);Banton|(12.95464490,121.82514510);Cajidiocan|(12.40582770,122.63342860)"
+Philippines,PH,Sarangani,Alabel,Manila,,,6.15485020,125.21985580,Alabel;Glan;Kiamba,"Alabel|(6.15485020,125.21985580);Glan|(5.75459120,125.16704840);Kiamba|(5.98155570,124.52667650)"
+Philippines,PH,Siquijor,Siquijor,Manila,,,9.19173800,123.44340890,Enrique Villanueva;Larena;Lazi,"Enrique Villanueva|(9.25850550,123.59464550);Larena|(9.24753350,123.55786710);Lazi|(9.14598110,123.53644920)"
+Philippines,PH,Soccsksargen,Amas,Manila,,,7.05694000,124.98389000,Amas;Bagontapay;Baguer,"Amas|(7.05694000,124.98389000);Bagontapay|(6.85889000,124.90889000);Baguer|(7.25611000,124.50417000)"
+Philippines,PH,Sorsogon,Sorsogon,Manila,,,12.97087900,123.80311330,Barcelona;Bulan;Bulusan,"Barcelona|(12.83727870,124.07658470);Bulan|(12.65366420,123.83028410);Bulusan|(12.74866770,124.02345260)"
+Philippines,PH,South Cotabato,Banga,Manila,,,6.38235180,124.64562710,Banga;General Santos;Koronadal,"Banga|(6.38235180,124.64562710);General Santos|(6.13742790,124.99270490);Koronadal|(6.46431840,124.74763690)"
+Philippines,PH,Southern Leyte,Anahawan,Manila,,,10.29867120,125.12734260,Anahawan;Bontoc;Hinunangan,"Anahawan|(10.29867120,125.12734260);Bontoc|(10.39098860,124.84611830);Hinunangan|(10.40165330,125.07599430)"
+Philippines,PH,Sultan Kudarat,Bagumbayan,Manila,,,6.47305080,124.33843910,Bagumbayan;Esperanza;Isulan,"Bagumbayan|(6.47305080,124.33843910);Esperanza|(6.72072040,124.26975300);Isulan|(6.60762030,124.29080290)"
+Philippines,PH,Sulu,Banguingui,Manila,,,6.08188500,121.40761480,Banguingui;Hadji Panglima Tahil;Indanan,"Banguingui|(6.08188500,121.40761480);Hadji Panglima Tahil|(6.22260290,120.78041360);Indanan|(5.99239660,120.88041850)"
+Philippines,PH,Surigao del Norte,Alegria,Manila,,,9.48507120,125.53845010,Alegria;Bacuag;Burgos,"Alegria|(9.48507120,125.53845010);Bacuag|(9.53346440,125.55329880);Burgos|(10.01910090,126.05189300)"
+Philippines,PH,Surigao del Sur,Barobo,Manila,,,8.48629260,126.02381030,Barobo;Bayabas;Bislig,"Barobo|(8.48629260,126.02381030);Bayabas|(8.97600390,126.22479810);Bislig|(8.20949370,126.17006570)"
+Philippines,PH,Tarlac,Anao,Manila,,,15.74348520,120.57733200,Anao;Bamban;Camiling,"Anao|(15.74348520,120.57733200);Bamban|(15.24958250,120.31388110);Camiling|(15.69344400,120.31758390)"
+Philippines,PH,Tawi-Tawi,Bongao,Manila,,,5.09318240,119.67366970,Bongao;Languyan;Mapun,"Bongao|(5.09318240,119.67366970);Languyan|(5.31145130,119.78489910);Mapun|(7.00709880,118.39656420)"
+Philippines,PH,Western Samar,Almagro,Manila,,,11.92402790,124.24232080,Almagro;Basey;Calbayog City,"Almagro|(11.92402790,124.24232080);Basey|(11.41137320,124.98083880);Calbayog City|(12.19353630,124.27388810)"
+Philippines,PH,Western Visayas,,Manila,,,,,,
+Philippines,PH,Zambales,Botolan,Manila,,,15.22543770,119.85695690,Botolan;Cabangan;Candelaria,"Botolan|(15.22543770,119.85695690);Cabangan|(15.17284720,120.03065190);Candelaria|(15.63411950,119.91914590)"
+Philippines,PH,Zamboanga del Norte,Baliguian,Manila,,,7.82305300,122.26409910,Baliguian;Dapitan;Dipolog,"Baliguian|(7.82305300,122.26409910);Dapitan|(8.57700720,123.26873100);Dipolog|(8.50856760,123.27535230)"
+Philippines,PH,Zamboanga del Sur,Aurora,Manila,,,7.93139380,123.48785830,Aurora;Bayog;Dimataling,"Aurora|(7.93139380,123.48785830);Bayog|(7.91051020,122.88438120);Dimataling|(7.52214930,123.24710860)"
+Philippines,PH,Zamboanga Peninsula,,Manila,,,,,,
+Philippines,PH,Zamboanga Sibugay,Alicia,Manila,,,7.51389000,122.93000000,Alicia;Aurora;Balagon,"Alicia|(7.51389000,122.93000000);Aurora|(7.95060000,123.58260000);Balagon|(8.00630000,123.23960000)"
+Poland,PL,Greater Poland,Babiak,Warsaw,,,52.34530000,18.66663000,Babiak;Baranów;Baranowo,"Babiak|(52.34530000,18.66663000);Baranów|(51.26342000,18.00470000);Baranowo|(52.43525000,16.78631000)"
+Poland,PL,Holy Cross,Baćkowice,Warsaw,,,50.79194000,21.23211000,Baćkowice;Bałtów;Bejsce,"Baćkowice|(50.79194000,21.23211000);Bałtów|(51.01845000,21.54385000);Bejsce|(50.23903000,20.59834000)"
+Poland,PL,Kuyavia-Pomerania,Aleksandrów Kujawski,Warsaw,,,52.87659000,18.69345000,Aleksandrów Kujawski;Barcin;Bartniczka,"Aleksandrów Kujawski|(52.87659000,18.69345000);Barcin|(52.86607000,17.94625000);Bartniczka|(53.24776000,19.60433000)"
+Poland,PL,Lesser Poland,Alwernia,Warsaw,,,50.06056000,19.53953000,Alwernia;Andrychów;Babice,"Alwernia|(50.06056000,19.53953000);Andrychów|(49.85497000,19.33834000);Babice|(50.05565000,19.19955000)"
+Poland,PL,Lower Silesia,Bardo,Warsaw,,,50.50589000,16.73986000,Bardo;Bielany Wrocławskie;Bielawa,"Bardo|(50.50589000,16.73986000);Bielany Wrocławskie|(51.03610000,16.96770000);Bielawa|(50.69075000,16.62300000)"
+Poland,PL,Lublin,Lublin,Warsaw,,,51.25000000,22.56667000,Abramów;Adamów;Aleksandrów,"Abramów|(51.45647000,22.31521000);Adamów|(51.74335000,22.26414000);Aleksandrów|(50.46630000,22.89225000)"
+Poland,PL,Lubusz,Babimost,Warsaw,,,52.16488000,15.82769000,Babimost;Bledzew;Bobrowice,"Babimost|(52.16488000,15.82769000);Bledzew|(52.51711000,15.41382000);Bobrowice|(51.94850000,15.09058000)"
+Poland,PL,Łódź,Łódź,Warsaw,,,51.77058000,19.47395000,Aleksandrów;Aleksandrów Łódzki;Andrespol,"Aleksandrów|(51.27126000,19.99005000);Aleksandrów Łódzki|(51.81965000,19.30384000);Andrespol|(51.72783000,19.64175000)"
+Poland,PL,Mazovia,Baboszewo,Warsaw,,,52.68070000,20.25527000,Baboszewo;Baniocha;Baranowo,"Baboszewo|(52.68070000,20.25527000);Baniocha|(52.01653000,21.13984000);Baranowo|(53.17554000,21.29803000)"
+Poland,PL,Podlaskie,Augustów,Warsaw,,,53.84321000,22.97979000,Augustów;Białowieża;Białystok,"Augustów|(53.84321000,22.97979000);Białowieża|(52.70000000,23.86667000);Białystok|(53.13333000,23.16433000)"
+Poland,PL,Pomerania,Banino,Warsaw,,,54.39215000,18.40622000,Banino;Bobowo;Bojano,"Banino|(54.39215000,18.40622000);Bobowo|(53.88378000,18.55681000);Bojano|(54.47123000,18.38408000)"
+Poland,PL,Silesia,Bąków,Warsaw,,,49.89342000,18.71495000,Bąków;Bażanowice;Będzin,"Bąków|(49.89342000,18.71495000);Bażanowice|(49.73791000,18.70345000);Będzin|(50.32607000,19.12565000)"
+Poland,PL,Subcarpathia,Adamówka,Warsaw,,,50.25857000,22.69595000,Adamówka;Albigowa;Babica,"Adamówka|(50.25857000,22.69595000);Albigowa|(50.01425000,22.22414000);Babica|(49.93476000,21.87035000)"
+Poland,PL,Upper Silesia,Baborów,Warsaw,,,50.15760000,17.98513000,Baborów;Biała;Bierawa,"Baborów|(50.15760000,17.98513000);Biała|(50.38587000,17.66035000);Bierawa|(50.28111000,18.24177000)"
+Poland,PL,Warmia-Masuria,Banie Mazurskie,Warsaw,,,54.24662000,22.03617000,Banie Mazurskie;Barciany;Barczewo,"Banie Mazurskie|(54.24662000,22.03617000);Barciany|(54.21993000,21.35347000);Barczewo|(53.83055000,20.69112000)"
+Poland,PL,West Pomerania,Banie,Warsaw,,,53.10031000,14.66228000,Banie;Barlinek;Barwice,"Banie|(53.10031000,14.66228000);Barlinek|(52.99464000,15.21864000);Barwice|(53.74490000,16.35530000)"
+Portugal,PT,Açores,Água de Pau,Lisbon,,,37.72142000,-25.51170000,Água de Pau;Angra do Heroísmo;Angústias,"Água de Pau|(37.72142000,-25.51170000);Angra do Heroísmo|(38.65483000,-27.21734000);Angústias|(38.52547000,-28.63132000)"
+Portugal,PT,Aveiro,Aveiro,Lisbon,,,40.64427000,-8.64554000,Aguada de Cima;Águeda;Albergaria-a-Velha,"Aguada de Cima|(40.52291000,-8.42700000);Águeda|(40.57720000,-8.44442000);Albergaria-a-Velha|(40.68706000,-8.50399000)"
+Portugal,PT,Beja,Beja,Lisbon,,,38.01506000,-7.86323000,Aldeia Nova de São Bento;Aljustrel;Almodôvar,"Aldeia Nova de São Bento|(37.92603000,-7.40804000);Aljustrel|(37.87759000,-8.16516000);Almodôvar|(37.49590000,-8.09372000)"
+Portugal,PT,Braga,Braga,Lisbon,,,41.55032000,-8.42005000,Adaúfe;Amares;Apúlia,"Adaúfe|(41.58732000,-8.39817000);Amares|(41.64718000,-8.35558000);Apúlia|(41.48512000,-8.76413000)"
+Portugal,PT,Bragança,Alfândega da Fé,Lisbon,,,41.34315000,-6.96112000,Alfândega da Fé;Belver;Bragança Municipality,"Alfândega da Fé|(41.34315000,-6.96112000);Belver|(41.24696000,-7.27594000);Bragança Municipality|(41.75608000,-6.75535000)"
+Portugal,PT,Castelo Branco,Castelo Branco,Lisbon,,,39.82219000,-7.49087000,Aldeia de Joanes;Belmonte;Castelo Branco,"Aldeia de Joanes|(40.13905000,-7.51694000);Belmonte|(40.36181000,-7.35157000);Castelo Branco|(39.82219000,-7.49087000)"
+Portugal,PT,Coimbra,Coimbra,Lisbon,,,40.20564000,-8.41955000,Alfarelos;Alhadas;Ançã,"Alfarelos|(40.15057000,-8.65326000);Alhadas|(40.18607000,-8.79057000);Ançã|(40.27161000,-8.52090000)"
+Portugal,PT,Évora,Évora,Lisbon,,,38.56667000,-7.90000000,Alandroal;Arraiolos;Borba,"Alandroal|(38.62924000,-7.36599000);Arraiolos|(38.76774000,-7.95831000);Borba|(38.80553000,-7.45465000)"
+Portugal,PT,Faro,Faro,Lisbon,,,37.01869000,-7.92716000,Albufeira;Alcantarilha;Alcoutim,"Albufeira|(37.08819000,-8.25030000);Alcantarilha|(37.13044000,-8.34623000);Alcoutim|(37.42400000,-7.65456000)"
+Portugal,PT,Guarda,Guarda,Lisbon,,,40.53638889,-7.26833333,Açores;Adão;Agualva,"Açores|(40.64500000,-7.30527778);Adão|(40.45916667,-7.16500000);Agualva|(38.77004444,-9.29881111)"
+Portugal,PT,Leiria,Leiria,Lisbon,,,39.74362000,-8.80705000,A dos Francos;Alcobaça;Alfeizerão,"A dos Francos|(39.32272000,-9.04743000);Alcobaça|(39.55223000,-8.97749000);Alfeizerão|(39.49971000,-9.10341000)"
+Portugal,PT,Lisbon,Lisbon,Lisbon,,,38.72635000,-9.14843000,A dos Cunhados;Abrigada;Alcabideche,"A dos Cunhados|(39.15237000,-9.29720000);Abrigada|(39.14416000,-9.01853000);Alcabideche|(38.73366000,-9.40928000)"
+Portugal,PT,Madeira,Água de Pena,Lisbon,,,32.70143000,-16.77874000,Água de Pena;Arco da Calheta;Boaventura,"Água de Pena|(32.70143000,-16.77874000);Arco da Calheta|(32.71502000,-17.14974000);Boaventura|(32.81846000,-16.97268000)"
+Portugal,PT,Portalegre,Portalegre,Lisbon,,,39.29740000,-7.41538000,Alter do Chão;Arronches;Atalaia,"Alter do Chão|(39.23098000,-7.74430000);Arronches|(39.12242000,-7.28619000);Atalaia|(39.45551000,-7.87295000)"
+Portugal,PT,Porto,Porto,Lisbon,,,41.14961000,-8.61099000,Água Longa;Águas Santas;Aguçadoura,"Água Longa|(41.24972000,-8.49285000);Águas Santas|(41.21017000,-8.57599000);Aguçadoura|(41.43116000,-8.77844000)"
+Portugal,PT,Santarém,Santarém,Lisbon,,,39.23333000,-8.68333000,Abrantes;Alcanede;Alcanena,"Abrantes|(39.46667000,-8.20000000);Alcanede|(39.41501000,-8.82189000);Alcanena|(39.45900000,-8.66892000)"
+Portugal,PT,Setúbal,Setúbal,Lisbon,,,38.52440000,-8.88820000,Alcácer do Sal;Alcochete;Aldeia de Paio Pires,"Alcácer do Sal|(38.37326000,-8.51444000);Alcochete|(38.73827000,-8.97936000);Aldeia de Paio Pires|(38.61667000,-9.08333000)"
+Portugal,PT,Viana do Castelo,Viana do Castelo,Lisbon,,,41.69371000,-8.83456000,Arcos de Valdevez;Caminha;Melgaço,"Arcos de Valdevez|(41.84668000,-8.41905000);Caminha|(41.84647000,-8.80133000);Melgaço|(42.08067000,-8.24844000)"
+Portugal,PT,Vila Real,Vila Real,Lisbon,,,41.30021000,-7.73985000,Alijó;Boticas;Chaves,"Alijó|(41.28447000,-7.48545000);Boticas|(41.68939000,-7.66914000);Chaves|(41.73961000,-7.45030000)"
+Portugal,PT,Viseu,Viseu,Lisbon,,,40.67450000,-7.91721000,Abraveses;Armamar;Cabanas de Viriato,"Abraveses|(40.68137000,-7.92102000);Armamar|(41.09718000,-7.68553000);Cabanas de Viriato|(40.47662000,-7.97445000)"
+Puerto Rico,PR,Adjuntas,Adjuntas,San Juan,,,18.16348480,-66.72315800,Adjuntas,"Adjuntas|(18.16348480,-66.72315800)"
+Puerto Rico,PR,Aguada,Aguada,San Juan,,,18.38015790,-67.18870400,Aguada,"Aguada|(18.38015790,-67.18870400)"
+Puerto Rico,PR,Aguadilla,Aguadilla,San Juan,,,18.42744540,-67.15406980,Aguadilla,"Aguadilla|(18.42744540,-67.15406980)"
+Puerto Rico,PR,Aguas Buenas,Aguas Buenas,San Juan,,,18.25689890,-66.10294420,Aguas Buenas,"Aguas Buenas|(18.25689890,-66.10294420)"
+Puerto Rico,PR,Aibonito,Aibonito,San Juan,,,18.13995940,-66.26600160,Aibonito,"Aibonito|(18.13995940,-66.26600160)"
+Puerto Rico,PR,Añasco,Añasco,San Juan,,,18.28544760,-67.14029350,Añasco,"Añasco|(18.28544760,-67.14029350)"
+Puerto Rico,PR,Arecibo,Arecibo,San Juan,,,18.47051370,-66.72184720,Arecibo,"Arecibo|(18.47051370,-66.72184720)"
+Puerto Rico,PR,Arecibo,,San Juan,,,,,,
+Puerto Rico,PR,Arroyo,Arroyo,San Juan,,,17.99642200,-66.09248790,Arroyo,"Arroyo|(17.99642200,-66.09248790)"
+Puerto Rico,PR,Barceloneta,Barceloneta,San Juan,,,41.38010610,2.18969570,Barceloneta,"Barceloneta|(41.38010610,2.18969570)"
+Puerto Rico,PR,Barranquitas,Barranquitas,San Juan,,,18.18662420,-66.30628020,Barranquitas,"Barranquitas|(18.18662420,-66.30628020)"
+Puerto Rico,PR,Bayamon,,San Juan,,,,,,
+Puerto Rico,PR,Bayamón,Bayamón,San Juan,,,18.38939600,-66.16532240,Bayamón,"Bayamón|(18.38939600,-66.16532240)"
+Puerto Rico,PR,Cabo Rojo,Cabo Rojo,San Juan,,,18.08662650,-67.14573470,Cabo Rojo,"Cabo Rojo|(18.08662650,-67.14573470)"
+Puerto Rico,PR,Caguas,,San Juan,,,,,,
+Puerto Rico,PR,Caguas,Caguas,San Juan,,,18.23879950,-66.03524900,Caguas,"Caguas|(18.23879950,-66.03524900)"
+Puerto Rico,PR,Camuy,Camuy,San Juan,,,18.48383300,-66.84489940,Camuy,"Camuy|(18.48383300,-66.84489940)"
+Puerto Rico,PR,Canóvanas,Canóvanas,San Juan,,,18.37487480,-65.89975330,Canóvanas,"Canóvanas|(18.37487480,-65.89975330)"
+Puerto Rico,PR,Carolina,,San Juan,,,,,,
+Puerto Rico,PR,Carolina,Carolina,San Juan,,,18.36808770,-66.04247340,Carolina,"Carolina|(18.36808770,-66.04247340)"
+Puerto Rico,PR,Cataño,Cataño,San Juan,,,18.44653550,-66.13557750,Cataño,"Cataño|(18.44653550,-66.13557750)"
+Puerto Rico,PR,Cayey,Cayey,San Juan,,,18.11190510,-66.16600000,Cayey,"Cayey|(18.11190510,-66.16600000)"
+Puerto Rico,PR,Ceiba,Ceiba,San Juan,,,18.24751770,-65.90849530,Ceiba,"Ceiba|(18.24751770,-65.90849530)"
+Puerto Rico,PR,Ciales,Ciales,San Juan,,,18.33606220,-66.46878230,Ciales,"Ciales|(18.33606220,-66.46878230)"
+Puerto Rico,PR,Cidra,Cidra,San Juan,,,18.17579140,-66.16127790,Cidra,"Cidra|(18.17579140,-66.16127790)"
+Puerto Rico,PR,Coamo,Coamo,San Juan,,,18.07996160,-66.35794730,Coamo,"Coamo|(18.07996160,-66.35794730)"
+Puerto Rico,PR,Comerío,Comerío,San Juan,,,18.21920010,-66.22560220,Comerío,"Comerío|(18.21920010,-66.22560220)"
+Puerto Rico,PR,Corozal,Corozal,San Juan,,,18.40308020,-88.39675360,Corozal,"Corozal|(18.40308020,-88.39675360)"
+Puerto Rico,PR,Culebra,Culebra,San Juan,,,18.31039400,-65.30307050,Culebra,"Culebra|(18.31039400,-65.30307050)"
+Puerto Rico,PR,Dorado,Dorado,San Juan,,,43.14805560,-77.57722220,Dorado,"Dorado|(43.14805560,-77.57722220)"
+Puerto Rico,PR,Fajardo,Fajardo,San Juan,,,18.32521480,-65.65393560,Fajardo,"Fajardo|(18.32521480,-65.65393560)"
+Puerto Rico,PR,Florida,Florida,San Juan,,,27.66482740,-81.51575350,Florida,"Florida|(27.66482740,-81.51575350)"
+Puerto Rico,PR,Guánica,Guánica,San Juan,,,17.97251450,-66.90862640,Guánica,"Guánica|(17.97251450,-66.90862640)"
+Puerto Rico,PR,Guayama,Guayama,San Juan,,,17.98413280,-66.11377670,Guayama,"Guayama|(17.98413280,-66.11377670)"
+Puerto Rico,PR,Guayanilla,Guayanilla,San Juan,,,18.01913140,-66.79184200,Guayanilla,"Guayanilla|(18.01913140,-66.79184200)"
+Puerto Rico,PR,Guaynabo,,San Juan,,,,,,
+Puerto Rico,PR,Guaynabo,Guaynabo,San Juan,,,18.36129540,-66.11029570,Guaynabo,"Guaynabo|(18.36129540,-66.11029570)"
+Puerto Rico,PR,Gurabo,Gurabo,San Juan,,,18.25439870,-65.97294210,Gurabo,"Gurabo|(18.25439870,-65.97294210)"
+Puerto Rico,PR,Hatillo,Hatillo,San Juan,,,18.42846420,-66.78753210,Hatillo,"Hatillo|(18.42846420,-66.78753210)"
+Puerto Rico,PR,Hormigueros,Hormigueros,San Juan,,,18.13346380,-67.11281230,Hormigueros,"Hormigueros|(18.13346380,-67.11281230)"
+Puerto Rico,PR,Humacao,Humacao,San Juan,,,18.15157360,-65.82485290,Humacao,"Humacao|(18.15157360,-65.82485290)"
+Puerto Rico,PR,Isabela,Isabela,San Juan,,,16.97537580,121.81070790,Isabela,"Isabela|(16.97537580,121.81070790)"
+Puerto Rico,PR,Jayuya,Jayuya,San Juan,,,18.21856740,-66.59156170,Jayuya,"Jayuya|(18.21856740,-66.59156170)"
+Puerto Rico,PR,Juana Díaz,Juana Díaz,San Juan,,,18.05343720,-66.50750790,Juana Díaz,"Juana Díaz|(18.05343720,-66.50750790)"
+Puerto Rico,PR,Juncos,Juncos,San Juan,,,18.22745580,-65.92099700,Juncos,"Juncos|(18.22745580,-65.92099700)"
+Puerto Rico,PR,Lajas,Lajas,San Juan,,,18.04996200,-67.05934490,Lajas,"Lajas|(18.04996200,-67.05934490)"
+Puerto Rico,PR,Lares,Lares,San Juan,,,34.02508020,-118.45945930,Lares,"Lares|(34.02508020,-118.45945930)"
+Puerto Rico,PR,Las Marías,Las Marías,San Juan,,,35.83822380,-78.61035660,Las Marías,"Las Marías|(35.83822380,-78.61035660)"
+Puerto Rico,PR,Las Piedras,Las Piedras,San Juan,,,18.18557530,-65.87362450,Las Piedras,"Las Piedras|(18.18557530,-65.87362450)"
+Puerto Rico,PR,Loíza,Loíza,San Juan,,,18.43299040,-65.87836000,Loíza,"Loíza|(18.43299040,-65.87836000)"
+Puerto Rico,PR,Luquillo,Luquillo,San Juan,,,18.37245070,-65.71655110,Luquillo,"Luquillo|(18.37245070,-65.71655110)"
+Puerto Rico,PR,Manatí,Manatí,San Juan,,,18.41812150,-66.52627830,Manatí,"Manatí|(18.41812150,-66.52627830)"
+Puerto Rico,PR,Maricao,Maricao,San Juan,,,18.18079020,-66.97990010,Maricao,"Maricao|(18.18079020,-66.97990010)"
+Puerto Rico,PR,Maunabo,Maunabo,San Juan,,,18.00718850,-65.89932890,Maunabo,"Maunabo|(18.00718850,-65.89932890)"
+Puerto Rico,PR,Mayagüez,,San Juan,,,,,,
+Puerto Rico,PR,Mayagüez,Mayagüez,San Juan,,,18.20134520,-67.14515490,Mayagüez,"Mayagüez|(18.20134520,-67.14515490)"
+Puerto Rico,PR,Moca,Moca,San Juan,,,18.39679290,-67.14790350,Moca,"Moca|(18.39679290,-67.14790350)"
+Puerto Rico,PR,Morovis,Morovis,San Juan,,,18.32578500,-66.40655920,Morovis,"Morovis|(18.32578500,-66.40655920)"
+Puerto Rico,PR,Naguabo,Naguabo,San Juan,,,18.21162470,-65.73488410,Naguabo,"Naguabo|(18.21162470,-65.73488410)"
+Puerto Rico,PR,Naranjito,Naranjito,San Juan,,,18.30078610,-66.24489040,Naranjito,"Naranjito|(18.30078610,-66.24489040)"
+Puerto Rico,PR,Orocovis,Orocovis,San Juan,,,18.22692240,-66.39116860,Orocovis,"Orocovis|(18.22692240,-66.39116860)"
+Puerto Rico,PR,Patillas,Patillas,San Juan,,,18.00373810,-66.01340590,Patillas,"Patillas|(18.00373810,-66.01340590)"
+Puerto Rico,PR,Peñuelas,Peñuelas,San Juan,,,18.06335770,-66.72738960,Peñuelas,"Peñuelas|(18.06335770,-66.72738960)"
+Puerto Rico,PR,Ponce,,San Juan,,,,,,
+Puerto Rico,PR,Ponce,Ponce,San Juan,,,18.01107680,-66.61406160,Ponce,"Ponce|(18.01107680,-66.61406160)"
+Puerto Rico,PR,Quebradillas,Quebradillas,San Juan,,,18.47383300,-66.93851200,Quebradillas,"Quebradillas|(18.47383300,-66.93851200)"
+Puerto Rico,PR,Rincón,Rincón,San Juan,,,18.34015140,-67.24994590,Rincón,"Rincón|(18.34015140,-67.24994590)"
+Puerto Rico,PR,Río Grande,Río Grande,San Juan,,,28.81063826,-101.83538780,Río Grande,"Río Grande|(28.81063826,-101.83538780)"
+Puerto Rico,PR,Sabana Grande,Sabana Grande,San Juan,,,18.07773920,-66.96045490,Sabana Grande,"Sabana Grande|(18.07773920,-66.96045490)"
+Puerto Rico,PR,Salinas,Salinas,San Juan,,,36.67773720,-121.65550130,Salinas,"Salinas|(36.67773720,-121.65550130)"
+Puerto Rico,PR,San Germán,San Germán,San Juan,,,18.08070820,-67.04110960,San Germán,"San Germán|(18.08070820,-67.04110960)"
+Puerto Rico,PR,San Juan,San Juan,San Juan,,,18.46320300,-66.11475710,San Juan,"San Juan|(18.46320300,-66.11475710)"
+Puerto Rico,PR,San Juan,,San Juan,,,,,,
+Puerto Rico,PR,San Lorenzo,San Lorenzo,San Juan,,,18.18869120,-65.97658620,San Lorenzo,"San Lorenzo|(18.18869120,-65.97658620)"
+Puerto Rico,PR,San Sebastián,San Sebastián,San Juan,,,43.31833400,-1.98123130,San Sebastián,"San Sebastián|(43.31833400,-1.98123130)"
+Puerto Rico,PR,Santa Isabel,Santa Isabel,San Juan,,,17.96607750,-66.40489200,Santa Isabel,"Santa Isabel|(17.96607750,-66.40489200)"
+Puerto Rico,PR,Toa Alta,Toa Alta,San Juan,,,18.38828230,-66.24822370,Toa Alta,"Toa Alta|(18.38828230,-66.24822370)"
+Puerto Rico,PR,Toa Baja,,San Juan,,,,,,
+Puerto Rico,PR,Toa Baja,Toa Baja,San Juan,,,18.44447090,-66.25432930,Toa Baja,"Toa Baja|(18.44447090,-66.25432930)"
+Puerto Rico,PR,Trujillo Alto,,San Juan,,,,,,
+Puerto Rico,PR,Trujillo Alto,Trujillo Alto,San Juan,,,18.35467190,-66.00738760,Trujillo Alto,"Trujillo Alto|(18.35467190,-66.00738760)"
+Puerto Rico,PR,Utuado,Utuado,San Juan,,,18.26550950,-66.70045190,Utuado,"Utuado|(18.26550950,-66.70045190)"
+Puerto Rico,PR,Vega Alta,Vega Alta,San Juan,,,18.41217030,-66.33128050,Vega Alta,"Vega Alta|(18.41217030,-66.33128050)"
+Puerto Rico,PR,Vega Baja,Vega Baja,San Juan,,,18.44614590,-66.40419670,Vega Baja,"Vega Baja|(18.44614590,-66.40419670)"
+Puerto Rico,PR,Vieques,Vieques,San Juan,,,18.12628540,-65.44009850,Vieques,"Vieques|(18.12628540,-65.44009850)"
+Puerto Rico,PR,Villalba,Villalba,San Juan,,,18.12175540,-66.49857870,Villalba,"Villalba|(18.12175540,-66.49857870)"
+Puerto Rico,PR,Yabucoa,Yabucoa,San Juan,,,18.05052010,-65.87932880,Yabucoa,"Yabucoa|(18.05052010,-65.87932880)"
+Puerto Rico,PR,Yauco,Yauco,San Juan,,,18.03496400,-66.84989830,Yauco,"Yauco|(18.03496400,-66.84989830)"
+Qatar,QA,Al Daayen,,Doha,,,,,,
+Qatar,QA,Al Khor,Al Ghuwayrīyah,Doha,,,25.82882000,51.24567000,Al Ghuwayrīyah;Al Khawr,"Al Ghuwayrīyah|(25.82882000,51.24567000);Al Khawr|(25.68389000,51.50583000)"
+Qatar,QA,Al Rayyan,Ar Rayyān,Doha,,,25.29194000,51.42444000,Ar Rayyān;Umm Bāb,"Ar Rayyān|(25.29194000,51.42444000);Umm Bāb|(25.21417000,50.80722000)"
+Qatar,QA,Al Wakrah,Al Wakrah,Doha,,,25.17151000,51.60337000,Al Wakrah;Al Wukayr;Musay‘īd,"Al Wakrah|(25.17151000,51.60337000);Al Wukayr|(25.15107000,51.53718000);Musay‘īd|(24.99226000,51.55067000)"
+Qatar,QA,Al-Shahaniya,Al Jumaylīyah,Doha,,,25.61068000,51.09108000,Al Jumaylīyah;Ash Shīḩānīyah;Dukhān,"Al Jumaylīyah|(25.61068000,51.09108000);Ash Shīḩānīyah|(25.37088000,51.22264000);Dukhān|(25.42485000,50.78227000)"
+Qatar,QA,Doha,Doha,Doha,,,25.28545000,51.53096000,Doha,"Doha|(25.28545000,51.53096000)"
+Qatar,QA,Madinat ash Shamal,Ar Ruways,Doha,,,26.13978000,51.21493000,Ar Ruways;Fuwayriţ;Madīnat ash Shamāl,"Ar Ruways|(26.13978000,51.21493000);Fuwayriţ|(26.02565000,51.36971000);Madīnat ash Shamāl|(26.12933000,51.20090000)"
+Qatar,QA,Umm Salal,Umm Şalāl Muḩammad,Doha,,,25.41524000,51.40647000,Umm Şalāl Muḩammad,"Umm Şalāl Muḩammad|(25.41524000,51.40647000)"
+Reunion,RE,Saint-Benoît,Saint-Benoît,Saint-Denis,,,-21.08859460,55.46640760,Bras-Panon;La Plaine-des-Palmistes;Saint-André,"Bras-Panon|(-21.03158160,55.54416340);La Plaine-des-Palmistes|(-21.15295070,55.56180140);Saint-André|(-20.95677270,55.55486740)"
+Reunion,RE,Saint-Denis,Saint-Denis,Saint-Denis,,,-20.96456720,55.41835300,Saint-Denis;Sainte-Marie;Sainte-Suzanne,"Saint-Denis|(-20.96456720,55.41835300);Sainte-Marie|(-20.94628420,55.44095870);Sainte-Suzanne|(-20.95063790,55.51114750)"
+Reunion,RE,Saint-Paul,Saint-Paul,Saint-Denis,,,-21.03656340,55.17542230,La Possession;Le Port;Les Trois-Bassins,"La Possession|(-20.99667150,55.30941960);Le Port|(-20.94599810,55.26258390);Les Trois-Bassins|(-21.11380650,55.25534670)"
+Reunion,RE,Saint-Pierre,Saint-Pierre,Saint-Denis,,,-21.30893030,55.33953130,Cilaos;Entre-Deux;L'Étang-Salé,"Cilaos|(-21.14026750,55.37314150);Entre-Deux|(-21.21073870,55.41125940);L'Étang-Salé|(-21.23474080,55.31636860)"
+Romania,RO,Alba,Abrud,Bucharest,,,46.27406000,23.06339000,Abrud;Abrud-Sat;Aiud,"Abrud|(46.27406000,23.06339000);Abrud-Sat|(46.28166000,23.06098000);Aiud|(46.31006000,23.72128000)"
+Romania,RO,Arad,Arad,Bucharest,,,46.18333000,21.31667000,Adea;Agrișu Mare;Almaş,"Adea|(46.55511000,21.58433000);Agrișu Mare|(46.27243000,21.75558000);Almaş|(46.28333000,22.23333000)"
+Romania,RO,Arges,Albeşti,Bucharest,,,45.30955000,25.00780000,Albeşti;Albeştii Pământeni;Albeștii Ungureni,"Albeşti|(45.30955000,25.00780000);Albeştii Pământeni|(45.20642110,24.66780310);Albeștii Ungureni|(45.22529000,24.67254000)"
+Romania,RO,Bacău,Bacău,Bucharest,,,46.56718000,26.91384000,Agăş;Apa Asău;Ardeoani,"Agăş|(46.48333000,26.21667000);Apa Asău|(46.48747000,26.37888000);Ardeoani|(46.53333000,26.60000000)"
+Romania,RO,Bihor,Abram,Bucharest,,,47.31667000,22.38333000,Abram;Abrămuţ;Albiș,"Abram|(47.31667000,22.38333000);Abrămuţ|(47.31667000,22.25000000);Albiș|(47.39024000,22.24528000)"
+Romania,RO,Bistrița-Năsăud,Agrieș,Bucharest,,,47.40022000,24.13491000,Agrieș;Anieș;Beclean,"Agrieș|(47.40022000,24.13491000);Anieș|(47.41347000,24.76853000);Beclean|(47.18333000,24.18333000)"
+Romania,RO,Botoșani,Adășeni,Bucharest,,,48.06920000,26.93789000,Adășeni;Alba;Albeşti,"Adășeni|(48.06920000,26.93789000);Alba|(48.15859000,26.47736000);Albeşti|(47.70000000,27.06667000)"
+Romania,RO,Braila,Baldovinești,Bucharest,,,45.32182000,27.91107000,Baldovinești;Bărăganul;Berteştii de Jos,"Baldovinești|(45.32182000,27.91107000);Bărăganul|(44.80000000,27.51667000);Berteştii de Jos|(44.83333000,27.75000000)"
+Romania,RO,Brașov,Acriș,Bucharest,,,45.63673000,25.99247000,Acriș;Apaţa;Augustin,"Acriș|(45.63673000,25.99247000);Apaţa|(45.95000000,25.51667000);Augustin|(46.04612980,25.55333050)"
+Romania,RO,Bucharest,Bucharest,Bucharest,,,44.43225000,26.10626000,Bucharest;Sector 1;Sector 2,"Bucharest|(44.43225000,26.10626000);Sector 1|(44.49239000,26.04831000);Sector 2|(44.45280000,26.13321000)"
+Romania,RO,Buzău,Buzău,Bucharest,,,45.15000000,26.83333000,Amara;Amaru;Băbeni,"Amara|(45.24866000,27.29244000);Amaru|(44.93333000,26.58333000);Băbeni|(45.44635000,26.97875000)"
+Romania,RO,Călărași,Alexandru Odobescu,Bucharest,,,44.26667000,27.08333000,Alexandru Odobescu;Aprozi;Belciugatele,"Alexandru Odobescu|(44.26667000,27.08333000);Aprozi|(44.26616000,26.50213000);Belciugatele|(44.48333000,26.43333000)"
+Romania,RO,Caraș-Severin,Anina,Bucharest,,,45.07944000,21.85694000,Anina;Armeniş;Băile Herculane,"Anina|(45.07944000,21.85694000);Armeniş|(45.20000000,22.31667000);Băile Herculane|(44.87972000,22.41250000)"
+Romania,RO,Cluj,Aghireșu,Bucharest,,,46.87209000,23.23773000,Aghireșu;Aghireșu-Fabrici;Aiton,"Aghireșu|(46.87209000,23.23773000);Aghireșu-Fabrici|(46.86690000,23.27129000);Aiton|(46.68333000,23.73333000)"
+Romania,RO,Constanța,23 August,Bucharest,,,43.91667000,28.58333000,23 August;Adamclisi;Agigea,"23 August|(43.91667000,28.58333000);Adamclisi|(44.08333000,27.95000000);Agigea|(44.09258000,28.61079000)"
+Romania,RO,Covasna,Covasna,Bucharest,,,45.85000000,26.18333000,Aita Mare;Araci;Arcuș,"Aita Mare|(45.96667000,25.55000000);Araci|(45.81187000,25.65482000);Arcuș|(45.90121390,25.77459540)"
+Romania,RO,Dâmbovița,Adânca,Bucharest,,,44.92250000,25.61005000,Adânca;Aninoasa;Bădeni,"Adânca|(44.92250000,25.61005000);Aninoasa|(44.96667000,25.43333000);Bădeni|(45.15272000,25.40263000)"
+Romania,RO,Dolj,Afumaţi,Bucharest,,,44.00000000,23.46667000,Afumaţi;Almăj;Amărăştii de Jos,"Afumaţi|(44.00000000,23.46667000);Almăj|(44.45000000,23.71667000);Amărăştii de Jos|(43.95000000,24.16667000)"
+Romania,RO,Galați,Bălăbănești,Bucharest,,,46.09546000,27.72206000,Bălăbănești;Bălăşeşti;Băleni,"Bălăbănești|(46.09546000,27.72206000);Bălăşeşti|(46.10000000,27.66667000);Băleni|(45.81667000,27.83333000)"
+Romania,RO,Giurgiu,Giurgiu,Bucharest,,,43.88664000,25.96270000,Adunații-Copăceni;Bâcu;Băneasa,"Adunații-Copăceni|(44.25413000,26.04929000);Bâcu|(44.48259000,25.88904000);Băneasa|(44.04611000,26.06417000)"
+Romania,RO,Gorj,Albeni,Bucharest,,,45.03333000,23.60000000,Albeni;Alimpeşti;Andreești,"Albeni|(45.03333000,23.60000000);Alimpeşti|(45.08333000,23.80000000);Andreești|(44.78948000,23.55099000)"
+Romania,RO,Harghita,Atid,Bucharest,,,46.45000000,25.05000000,Atid;Avrămeşti;Băile Tuşnad,"Atid|(46.45000000,25.05000000);Avrămeşti|(46.33333000,25.01667000);Băile Tuşnad|(46.15000000,25.85000000)"
+Romania,RO,Hunedoara,Hunedoara,Bucharest,,,45.75000000,22.90000000,Aninoasa;Băcia;Baia de Criş,"Aninoasa|(45.40924000,23.31505000);Băcia|(45.80000000,23.01667000);Baia de Criş|(46.16667000,22.71667000)"
+Romania,RO,Ialomița,Adâncata,Bucharest,,,44.76667000,26.43333000,Adâncata;Albeşti;Alexeni,"Adâncata|(44.76667000,26.43333000);Albeşti|(44.53333000,27.13333000);Alexeni|(44.68333000,26.70000000)"
+Romania,RO,Iași,Alexandru I. Cuza,Bucharest,,,47.13333000,26.85000000,Alexandru I. Cuza;Andrieşeni;Aroneanu,"Alexandru I. Cuza|(47.13333000,26.85000000);Andrieşeni|(47.53333000,27.28333000);Aroneanu|(47.20000000,27.60000000)"
+Romania,RO,Ilfov,1 Decembrie,Bucharest,,,44.29083000,26.05806000,1 Decembrie;Afumaţi;Alunișu,"1 Decembrie|(44.29083000,26.05806000);Afumaţi|(44.51667000,26.26667000);Alunișu|(44.33883000,26.05837000)"
+Romania,RO,Maramureș,Ardusat,Bucharest,,,47.65000000,23.36667000,Ardusat;Arduzel;Arieșu de Câmp,"Ardusat|(47.65000000,23.36667000);Arduzel|(47.44804500,23.26686200);Arieșu de Câmp|(47.63977000,23.39872600)"
+Romania,RO,Mehedinți,Bâcleș,Bucharest,,,44.48333000,23.13333000,Bâcleș;Baia de Aramă;Bala,"Bâcleș|(44.48333000,23.13333000);Baia de Aramă|(44.99929000,22.80784000);Bala|(44.88389000,22.83333000)"
+Romania,RO,Mureș,Abuș,Bucharest,,,46.35000000,24.38333333,Abuș;Acățari;Adămuș,"Abuș|(46.35000000,24.38333333);Acățari|(46.48333333,24.63333333);Adămuș|(46.30000000,24.23000000)"
+Romania,RO,Neamț,Adjudeni,Bucharest,,,47.01408000,26.94903000,Adjudeni;Agapia;Bahna,"Adjudeni|(47.01408000,26.94903000);Agapia|(47.16667000,26.28333000);Bahna|(46.78333000,26.78333000)"
+Romania,RO,Olt,Alimănești,Bucharest,,,44.25693000,24.53895000,Alimănești;Alunișu;Băbiciu,"Alimănești|(44.25693000,24.53895000);Alunișu|(44.71667000,24.55000000);Băbiciu|(44.03333000,24.56667000)"
+Romania,RO,Prahova,Adunaţi,Bucharest,,,45.13333000,25.61667000,Adunaţi;Albești-Muru;Albeşti-Paleologu,"Adunaţi|(45.13333000,25.61667000);Albești-Muru|(44.94440000,26.20899000);Albeşti-Paleologu|(44.95000000,26.21667000)"
+Romania,RO,Sălaj,Aghireș,Bucharest,,,47.16164000,23.01764000,Aghireș;Agrij;Almaşu,"Aghireș|(47.16164000,23.01764000);Agrij|(47.06685000,23.09918000);Almaşu|(46.94546000,23.12965000)"
+Romania,RO,Satu Mare,Satu Mare,Bucharest,,,47.79926000,22.86255000,Acâş;Agriș;Andrid,"Acâş|(47.53333000,22.78333000);Agriș|(47.88075000,23.00340000);Andrid|(47.51667000,22.35000000)"
+Romania,RO,Sibiu,Sibiu,Bucharest,,,45.80000000,24.15000000,Agârbiciu;Agnita;Alămor,"Agârbiciu|(46.06764000,24.19386000);Agnita|(45.96667000,24.61667000);Alămor|(45.93003000,23.99370000)"
+Romania,RO,Suceava,Suceava,Bucharest,,,47.63333000,26.25000000,Adâncata;Arbore;Argel,"Adâncata|(47.73333000,26.30000000);Arbore|(47.73333000,25.93333000);Argel|(47.76136000,25.47049000)"
+Romania,RO,Teleorman,Alexandria,Bucharest,,,43.98333000,25.33333000,Alexandria;Băbăiţa;Băcălești,"Alexandria|(43.98333000,25.33333000);Băbăiţa|(44.16667000,25.38333000);Băcălești|(44.05997000,24.81636000)"
+Romania,RO,Timiș,Bacova,Bucharest,,,45.66410000,21.55238000,Bacova;Balinţ;Banloc,"Bacova|(45.66410000,21.55238000);Balinţ|(45.81250000,21.85361000);Banloc|(45.38742000,21.13581000)"
+Romania,RO,Tulcea,Tulcea,Bucharest,,,45.17870000,28.80501000,Agighiol;Babadag;Baia,"Agighiol|(45.03362000,28.87628000);Babadag|(44.90000000,28.71667000);Baia|(44.71667000,28.66667000)"
+Romania,RO,Vâlcea,Alunu,Bucharest,,,45.01667000,23.81667000,Alunu;Amărăşti;Băbeni,"Alunu|(45.01667000,23.81667000);Amărăşti|(44.76667000,24.15000000);Băbeni|(44.96667000,24.23333000)"
+Romania,RO,Vaslui,Vaslui,Bucharest,,,46.63333000,27.73333000,Albeşti;Alexandru Vlăhuţă;Arsura,"Albeşti|(46.50000000,27.86667000);Alexandru Vlăhuţă|(46.41667000,27.63333000);Arsura|(46.81333000,28.02222000)"
+Romania,RO,Vrancea,Adjud,Bucharest,,,46.10000000,27.16667000,Adjud;Adjudu Vechi;Andreiaşu de Jos,"Adjud|(46.10000000,27.16667000);Adjudu Vechi|(46.13485000,27.18891000);Andreiaşu de Jos|(45.75000000,26.83333000)"
+Russia,RU,Adygea,Abadzekhskaya,Moscow,,,44.39389000,40.22139000,Abadzekhskaya;Adygeysk;Adygeysk Republican Urban Okrug,"Abadzekhskaya|(44.39389000,40.22139000);Adygeysk|(44.88414000,39.19071000);Adygeysk Republican Urban Okrug|(44.87850000,39.19167000)"
+Russia,RU,Altai,Aleysk,Moscow,,,52.49260000,82.78220000,Aleysk;Aleyskiy Rayon;Altayskoye,"Aleysk|(52.49260000,82.78220000);Aleyskiy Rayon|(52.41667000,82.75000000);Altayskoye|(51.95333000,85.33250000)"
+Russia,RU,Altai,Aktash,Moscow,,,50.30000000,87.73333000,Aktash;Artybash;Belyashi,"Aktash|(50.30000000,87.73333000);Artybash|(51.79278000,87.27611000);Belyashi|(49.70900000,87.42300000)"
+Russia,RU,Amur,Arkhara,Moscow,,,49.42447000,130.08569000,Arkhara;Arkharinskiy Rayon;Belogorsk,"Arkhara|(49.42447000,130.08569000);Arkharinskiy Rayon|(49.50000000,130.66667000);Belogorsk|(50.91644000,128.47726000)"
+Russia,RU,Arkhangelsk,Arkhangel’sk,Moscow,,,64.54010000,40.54330000,Arkhangel’sk;Berëznik;Cheremushskiy,"Arkhangel’sk|(64.54010000,40.54330000);Berëznik|(62.85200000,42.70710000);Cheremushskiy|(61.27306000,47.26361000)"
+Russia,RU,Astrakhan,Astrakhan,Moscow,,,46.34968000,48.04076000,Akhtubinsk;Akhtubinskiy Rayon;Aksarayskiy,"Akhtubinsk|(48.27955000,46.17217000);Akhtubinskiy Rayon|(48.16667000,46.25000000);Aksarayskiy|(46.79244000,48.01188000)"
+Russia,RU,Bashkortostan,Abzakovo,Moscow,,,53.82861000,58.59333000,Abzakovo;Abzelilovskiy Rayon;Agidel’,"Abzakovo|(53.82861000,58.59333000);Abzelilovskiy Rayon|(53.41667000,58.50000000);Agidel’|(55.90770000,53.93550000)"
+Russia,RU,Belgorod,Belgorod,Moscow,,,50.61074000,36.58015000,Alekseyevka;Bekhteyevka;Belgorod,"Alekseyevka|(50.63090000,38.69030000);Bekhteyevka|(50.80758000,37.21789000);Belgorod|(50.61074000,36.58015000)"
+Russia,RU,Bryansk,Bryansk,Moscow,,,53.25209000,34.37167000,Altukhovo;Ardon’;Belyye Berega,"Altukhovo|(52.67559000,34.36703000);Ardon’|(52.73524000,32.30857000);Belyye Berega|(53.20851000,34.66405000)"
+Russia,RU,Buryatia,Babushkin,Moscow,,,51.71222000,105.86472000,Babushkin;Bagdarin;Barguzin,"Babushkin|(51.71222000,105.86472000);Bagdarin|(54.43333000,113.60000000);Barguzin|(53.61875000,109.63904000)"
+Russia,RU,Chechen,Achkhoy-Martan,Moscow,,,43.18997000,45.28373000,Achkhoy-Martan;Achkhoy-Martanovskiy Rayon;Alkhan-Kala,"Achkhoy-Martan|(43.18997000,45.28373000);Achkhoy-Martanovskiy Rayon|(43.08333000,45.25000000);Alkhan-Kala|(43.25861000,45.53917000)"
+Russia,RU,Chelyabinsk,Chelyabinsk,Moscow,,,55.15402000,61.42915000,Agapovka;Agapovskiy Rayon;Argayash,"Agapovka|(53.29730000,59.13480000);Agapovskiy Rayon|(53.33333000,59.33333000);Argayash|(55.48880000,60.87670000)"
+Russia,RU,Chukotka,Anadyr,Moscow,,,64.73424000,177.51030000,Anadyr;Anadyrskiy Rayon;Beringovskiy,"Anadyr|(64.73424000,177.51030000);Anadyrskiy Rayon|(65.00000000,173.00000000);Beringovskiy|(63.06101000,179.35046000)"
+Russia,RU,Chuvash,Alatyr’,Moscow,,,54.84210000,46.58130000,Alatyr’;Alatyrskiy Rayon;Alikovo,"Alatyr’|(54.84210000,46.58130000);Alatyrskiy Rayon|(54.91667000,46.75000000);Alikovo|(55.73827000,46.75493000)"
+Russia,RU,Dagestan,Achisu,Moscow,,,42.65197000,47.68282000,Achisu;Adil’-Yangiyurt;Agul’skiy Rayon,"Achisu|(42.65197000,47.68282000);Adil’-Yangiyurt|(43.56328000,46.58462000);Agul’skiy Rayon|(41.83333000,47.58333000)"
+Russia,RU,Ingushetia,Ali-Yurt,Moscow,,,43.14250000,44.85250000,Ali-Yurt;Alkhan-Churt;Dalakovo,"Ali-Yurt|(43.14250000,44.85250000);Alkhan-Churt|(43.35194000,44.78694000);Dalakovo|(43.23759000,44.58964000)"
+Russia,RU,Irkutsk,,Moscow,,,,,,
+Russia,RU,Ivanovo,Ivanovo,Moscow,,,56.99719000,40.97139000,Arkhipovka;Bogorodskoye;Dulyapino,"Arkhipovka|(56.66292000,41.25434000);Bogorodskoye|(57.04695000,41.01354000);Dulyapino|(57.25783000,40.81471000)"
+Russia,RU,Jewish,Amurzet,Moscow,,,47.69541000,131.09493000,Amurzet;Babstovo;Bira,"Amurzet|(47.69541000,131.09493000);Babstovo|(48.11853000,132.47913000);Bira|(49.00135000,132.46826000)"
+Russia,RU,Kabardino-Balkar,Aleksandrovskaya,Moscow,,,43.48333000,43.65000000,Aleksandrovskaya;Altud;Argudan,"Aleksandrovskaya|(43.48333000,43.65000000);Altud|(43.72194000,43.86583000);Argudan|(43.42139000,43.91583000)"
+Russia,RU,Kaliningrad,Kaliningrad,Moscow,,,54.70649000,20.51095000,Bagrationovsk;Baltiysk;Bol'shoe Isakovo,"Bagrationovsk|(54.38714000,20.64372000);Baltiysk|(54.65455000,19.90929000);Bol'shoe Isakovo|(54.71774000,20.60284000)"
+Russia,RU,Kalmykia,Arshan’,Moscow,,,46.27320000,44.22000000,Arshan’;Elista;Gorodoviki,"Arshan’|(46.27320000,44.22000000);Elista|(46.30778000,44.25583000);Gorodoviki|(46.13528000,41.96556000)"
+Russia,RU,Kaluga,Kaluga,Moscow,,,54.52930000,36.27542000,Babynino;Babyninskiy Rayon;Balabanovo,"Babynino|(54.39385000,35.77013000);Babyninskiy Rayon|(54.41667000,35.75000000);Balabanovo|(55.18161000,36.66060000)"
+Russia,RU,Kamchatka,Aleutskiy Rayon,Moscow,,,55.21667000,165.98333000,Aleutskiy Rayon;Atlasovo;Bystrinskiy Rayon,"Aleutskiy Rayon|(55.21667000,165.98333000);Atlasovo|(55.60650000,159.64266000);Bystrinskiy Rayon|(56.00000000,158.50000000)"
+Russia,RU,Karachay-Cherkess,Adyge-Khabl’,Moscow,,,44.33434000,41.93922000,Adyge-Khabl’;Ali-Berdukovskiy;Besleney,"Adyge-Khabl’|(44.33434000,41.93922000);Ali-Berdukovskiy|(43.98952000,41.74212000);Besleney|(44.24050000,41.73870000)"
+Russia,RU,Karelia,Belomorsk,Moscow,,,64.52322000,34.76680000,Belomorsk;Borovoy;Chupa,"Belomorsk|(64.52322000,34.76680000);Borovoy|(64.61210000,32.24968000);Chupa|(66.27001000,33.05486000)"
+Russia,RU,Kemerovo,Kemerovo,Moscow,,,55.33333000,86.08333000,Abagur;Anzhero-Sudzhensk;Artyshta,"Abagur|(53.73080000,87.25260000);Anzhero-Sudzhensk|(56.08100000,86.02850000);Artyshta|(54.12220000,86.29090000)"
+Russia,RU,Khabarovsk,Khabarovsk,Moscow,,,48.48271000,135.08379000,Amursk;Ayan;Berëzovyy,"Amursk|(50.23685000,136.88136000);Ayan|(56.46314000,138.17777000);Berëzovyy|(51.66897000,135.66584000)"
+Russia,RU,Khakassia,Abakan,Moscow,,,53.71556000,91.42917000,Abakan;Abakan Gorod;Abaza,"Abakan|(53.71556000,91.42917000);Abakan Gorod|(53.71667000,91.43333000);Abaza|(52.65500000,90.09278000)"
+Russia,RU,Khanty-Mansi,Agirish,Moscow,,,61.92472000,63.02306000,Agirish;Andra;Barsovo,"Agirish|(61.92472000,63.02306000);Andra|(62.51472000,65.88778000);Barsovo|(61.16667000,73.16667000)"
+Russia,RU,Kirov,Kirov,Moscow,,,58.59665000,49.66007000,Afanas’yevskiy Rayon;Arbazh;Arkul’,"Afanas’yevskiy Rayon|(58.83333000,53.25000000);Arbazh|(57.68041000,48.30647000);Arkul’|(57.28085000,50.04400000)"
+Russia,RU,Komi,Aykino,Moscow,,,62.22481000,49.99222000,Aykino;Blagoyevo;Borovoy,"Aykino|(62.22481000,49.99222000);Blagoyevo|(63.42310000,47.96460000);Borovoy|(63.23005000,52.89031000)"
+Russia,RU,Kostroma,Kostroma,Moscow,,,57.76647000,40.92686000,Antropovo;Antropovskiy Rayon;Bogovarovo,"Antropovo|(58.39876000,43.00659000);Antropovskiy Rayon|(58.16667000,43.00000000);Bogovarovo|(58.97849000,47.02462000)"
+Russia,RU,Krasnodar,Krasnodar,Moscow,,,45.04484000,38.97603000,Abinsk;Abinskiy Rayon;Abrau-Dyurso,"Abinsk|(44.86803000,38.15728000);Abinskiy Rayon|(44.83402000,38.27891000);Abrau-Dyurso|(44.69973000,37.60098000)"
+Russia,RU,Krasnoyarsk,Krasnoyarsk,Moscow,,,56.01839000,92.86717000,Aban;Abanskiy Rayon;Achinsk,"Aban|(56.67870000,96.06580000);Abanskiy Rayon|(56.83333000,96.00000000);Achinsk|(56.26940000,90.49930000)"
+Russia,RU,Kurgan,Kurgan,Moscow,,,55.45000000,65.33333000,Belozërskoye;Dalmatovo;Glyadyanskoye,"Belozërskoye|(55.82139000,65.58417000);Dalmatovo|(56.26000000,62.93620000);Glyadyanskoye|(54.90750000,65.08833000)"
+Russia,RU,Kursk,Kursk,Moscow,,,51.73733000,36.18735000,Belaya;Cheremisinovo;Cheremisinovskiy Rayon,"Belaya|(51.05444000,35.71611000);Cheremisinovo|(51.88550000,37.26460000);Cheremisinovskiy Rayon|(51.91667000,37.16667000)"
+Russia,RU,Leningrad,Agalatovo,Moscow,,,60.21950000,30.27388000,Agalatovo;Akademicheskoe;Annino,"Agalatovo|(60.21950000,30.27388000);Akademicheskoe|(60.01375000,30.39471000);Annino|(59.77056000,30.05611000)"
+Russia,RU,Lipetsk,Lipetsk,Moscow,,,52.60311000,39.57076000,Bol’shoy Khomutets;Borinskoye;Chaplygin,"Bol’shoy Khomutets|(52.78285000,39.87214000);Borinskoye|(52.45690000,39.37130000);Chaplygin|(53.24319000,39.96288000)"
+Russia,RU,Magadan,Magadan,Moscow,,,59.56380000,150.80347000,Arman’;Dukat;Evensk,"Arman’|(59.66994000,150.13164000);Dukat|(62.57231000,155.34988000);Evensk|(61.91722000,159.23348000)"
+Russia,RU,Mari El,Gornomariyskiy Rayon,Moscow,,,56.41667000,46.75000000,Gornomariyskiy Rayon;Kilemarskiy Rayon;Kilemary,"Gornomariyskiy Rayon|(56.41667000,46.75000000);Kilemarskiy Rayon|(56.75000000,46.91667000);Kilemary|(56.77825000,46.86594000)"
+Russia,RU,Mordovia,Ardatov,Moscow,,,54.84767000,46.23878000,Ardatov;Ardatovskiy Rayon;Atemar,"Ardatov|(54.84767000,46.23878000);Ardatovskiy Rayon|(54.83333000,46.25000000);Atemar|(54.18097000,45.40909000)"
+Russia,RU,Moscow,Alabushevo,Moscow,,,56.01667000,37.15000000,Alabushevo;Alekseyevka;Andreyevka,"Alabushevo|(56.01667000,37.15000000);Alekseyevka|(55.63000000,37.80000000);Andreyevka|(55.98028000,37.13500000)"
+Russia,RU,Moscow,Moscow,Moscow,,,55.75222000,37.61556000,Altuf’yevskiy;Amin’yevo;Annino,"Altuf’yevskiy|(55.88333000,37.58333000);Amin’yevo|(55.70000000,37.46667000);Annino|(55.58333000,37.60000000)"
+Russia,RU,Murmansk,Murmansk,Moscow,,,68.97917000,33.09251000,Abram Mys;Afrikanda;Alakurtti,"Abram Mys|(68.97839000,33.01926000);Afrikanda|(67.44289000,32.78279000);Alakurtti|(66.96720000,30.34905000)"
+Russia,RU,Nenets,Iskateley,Moscow,,,67.68026000,53.15117000,Iskateley;Nar'yan-Mar,"Iskateley|(67.68026000,53.15117000);Nar'yan-Mar|(67.63869000,53.00371000)"
+Russia,RU,Nizhny Novgorod,Afonino,Moscow,,,56.26201000,44.09503000,Afonino;Ar’ya;Ardatov,"Afonino|(56.26201000,44.09503000);Ar’ya|(57.49146000,45.96691000);Ardatov|(55.24205000,43.09699000)"
+Russia,RU,North Ossetia-Alania,Alagir,Moscow,,,43.04222000,44.22222000,Alagir;Alagirskiy Rayon;Ardon,"Alagir|(43.04222000,44.22222000);Alagirskiy Rayon|(42.83333000,44.08333000);Ardon|(43.17720000,44.29702000)"
+Russia,RU,Novgorod,Batetskiy,Moscow,,,58.64610000,30.30268000,Batetskiy;Batetskiy Rayon;Borovichi,"Batetskiy|(58.64610000,30.30268000);Batetskiy Rayon|(58.58333000,30.50000000);Borovichi|(58.38778000,33.91546000)"
+Russia,RU,Novosibirsk,Novosibirsk,Moscow,,,55.04150000,82.93460000,Akademgorodok;Bagan;Barabinsk,"Akademgorodok|(54.85230000,83.10600000);Bagan|(54.10014000,77.66462000);Barabinsk|(55.35709000,78.35697000)"
+Russia,RU,Omsk,Omsk,Moscow,,,54.99244000,73.36859000,Azovo;Beregovoy;Bol’sherech’ye,"Azovo|(54.69972000,73.02367000);Beregovoy|(55.17301000,73.21984000);Bol’sherech’ye|(56.09252000,74.62716000)"
+Russia,RU,Orenburg,Orenburg,Moscow,,,51.77270000,55.09880000,Abdulino;Adamovka;Alandskoye,"Abdulino|(53.70000000,53.66667000);Adamovka|(51.52230000,59.93960000);Alandskoye|(52.22611000,59.79389000)"
+Russia,RU,Oryol,Bolkhov,Moscow,,,53.44295000,36.00546000,Bolkhov;Bolkhovskiy Rayon;Dmitrovsk-Orlovskiy,"Bolkhov|(53.44295000,36.00546000);Bolkhovskiy Rayon|(53.41667000,36.00000000);Dmitrovsk-Orlovskiy|(52.50500000,35.14640000)"
+Russia,RU,Penza,Penza,Moscow,,,53.20066000,45.00464000,Bashmakovo;Bekovo;Belinskiy,"Bashmakovo|(53.21329000,43.03420000);Bekovo|(52.46632000,43.71199000);Belinskiy|(52.96474000,43.41647000)"
+Russia,RU,Perm,Perm,Moscow,,,58.01046000,56.25017000,Aleksandrovsk;Barda;Berezniki,"Aleksandrovsk|(59.15810000,57.56950000);Barda|(56.92870000,55.59620000);Berezniki|(59.40910000,56.82040000)"
+Russia,RU,Primorsky,Anuchino,Moscow,,,43.96571000,133.05846000,Anuchino;Anuchinskiy Rayon;Arsen’yev,"Anuchino|(43.96571000,133.05846000);Anuchinskiy Rayon|(44.00000000,133.00000000);Arsen’yev|(44.15254000,133.27791000)"
+Russia,RU,Pskov,Pskov,Moscow,,,57.81360000,28.34960000,Bezhanitsy;Dedovichi;Dno,"Bezhanitsy|(56.97669000,29.89065000);Dedovichi|(57.55166000,29.95018000);Dno|(57.82772000,29.96368000)"
+Russia,RU,Rostov,Aksay,Moscow,,,47.25838000,39.86675000,Aksay;Almaznyy;Anastasiyevka,"Aksay|(47.25838000,39.86675000);Almaznyy|(48.04476000,40.04501000);Anastasiyevka|(47.56072000,38.52837000)"
+Russia,RU,Ryazan,Aleksandro-Nevskiy,Moscow,,,53.47510000,40.20950000,Aleksandro-Nevskiy;Bagramovo;Chuchkovo,"Aleksandro-Nevskiy|(53.47510000,40.20950000);Bagramovo|(54.72337000,39.45186000);Chuchkovo|(54.26931000,41.44648000)"
+Russia,RU,Saint Petersburg,Saint Petersburg,Moscow,,,59.93863000,30.31413000,Admiralteisky;Aleksandrovskaya;Avtovo,"Admiralteisky|(59.90839000,30.28484000);Aleksandrovskaya|(59.73083000,30.33222000);Avtovo|(59.87167000,30.26583000)"
+Russia,RU,Sakha,Abyysky District,Moscow,,,68.33333000,146.00000000,Abyysky District;Aldan;Allaikhovskiy Rayon,"Abyysky District|(68.33333000,146.00000000);Aldan|(58.61021000,125.39613000);Allaikhovskiy Rayon|(71.00000000,148.00000000)"
+Russia,RU,Sakhalin,Aleksandrovsk-Sakhalinskiy,Moscow,,,50.89926000,142.16215000,Aleksandrovsk-Sakhalinskiy;Aniva;Boshnyakovo,"Aleksandrovsk-Sakhalinskiy|(50.89926000,142.16215000);Aniva|(46.71492000,142.52866000);Boshnyakovo|(49.64572000,142.17047000)"
+Russia,RU,Samara,Samara,Moscow,,,53.20007000,50.15000000,Bakhilovo;Balasheyka;Berëza,"Bakhilovo|(53.40110000,49.63600000);Balasheyka|(53.28410000,48.08510000);Berëza|(53.51833000,50.13967000)"
+Russia,RU,Saratov,Saratov,Moscow,,,51.54056000,46.00861000,Aleksandrov Gay;Alekseyevka;Arkadak,"Aleksandrov Gay|(50.14704000,48.57037000);Alekseyevka|(52.30583000,48.02611000);Arkadak|(51.93261000,43.49779000)"
+Russia,RU,Smolensk,Smolensk,Moscow,,,54.78180000,32.04010000,Demidov;Desnogorsk;Dorogobuzh,"Demidov|(55.27063000,31.51497000);Desnogorsk|(54.15077000,33.28151000);Dorogobuzh|(54.91500000,33.29722000)"
+Russia,RU,Stavropol,Achikulak,Moscow,,,44.55167000,44.83778000,Achikulak;Aleksandriya;Aleksandriyskaya,"Achikulak|(44.55167000,44.83778000);Aleksandriya|(45.09472000,43.24556000);Aleksandriyskaya|(44.22722000,43.34528000)"
+Russia,RU,Sverdlovsk,Achit,Moscow,,,56.79850000,57.89940000,Achit;Alapayevsk;Aramil,"Achit|(56.79850000,57.89940000);Alapayevsk|(57.85158000,61.69627000);Aramil|(56.69770000,60.83690000)"
+Russia,RU,Tambov,Tambov,Moscow,,,52.73169000,41.44326000,Bokino;Bondarskiy Rayon;Donskoye,"Bokino|(52.63744000,41.45968000);Bondarskiy Rayon|(53.00000000,42.00000000);Donskoye|(52.77495000,41.47759000)"
+Russia,RU,Tatarstan,Agryz,Moscow,,,56.52034000,52.99422000,Agryz;Agryzskiy Rayon;Aksubayevskiy Rayon,"Agryz|(56.52034000,52.99422000);Agryzskiy Rayon|(56.25000000,52.83333000);Aksubayevskiy Rayon|(54.83333000,50.83333000)"
+Russia,RU,Tomsk,Tomsk,Moscow,,,56.49771000,84.97437000,Aleksandrovskoye;Asino;Bakchar,"Aleksandrovskoye|(56.74083000,85.39056000);Asino|(56.99987000,86.14393000);Bakchar|(57.01861000,82.07111000)"
+Russia,RU,Tula,Tula,Moscow,,,54.19609000,37.61822000,Ageyevo;Aleksin;Aleksinskiy Rayon,"Ageyevo|(54.15883000,36.46927000);Aleksin|(54.50503000,37.06740000);Aleksinskiy Rayon|(54.50000000,37.08333000)"
+Russia,RU,Tuva,Ak-Dovurak,Moscow,,,51.18333000,90.60000000,Ak-Dovurak;Balgazyn;Bay-Khaak,"Ak-Dovurak|(51.18333000,90.60000000);Balgazyn|(51.00000000,95.20000000);Bay-Khaak|(51.16105000,94.46371000)"
+Russia,RU,Tver,Tver,Moscow,,,56.85836000,35.90057000,Andreapol’;Andreapol’skiy Rayon;Bel’skiy Rayon,"Andreapol’|(56.65134000,32.26640000);Andreapol’skiy Rayon|(56.66667000,32.25000000);Bel’skiy Rayon|(55.83333000,33.08333000)"
+Russia,RU,Tyumen,Tyumen,Moscow,,,57.15222000,65.52722000,Abalak;Abatskoye;Antipino,"Abalak|(58.12861000,68.59444000);Abatskoye|(56.28748000,70.45553000);Antipino|(57.10679000,65.75755000)"
+Russia,RU,Udmurt,Alnashi,Moscow,,,56.18738000,52.47919000,Alnashi;Balezino;Debesy,"Alnashi|(56.18738000,52.47919000);Balezino|(57.97870000,53.01380000);Debesy|(57.65150000,53.80890000)"
+Russia,RU,Ulyanovsk,Ulyanovsk,Moscow,,,54.32824000,48.38657000,Barysh;Bazarnyy Syzgan;Cherdaklinskiy Rayon,"Barysh|(53.65533000,47.11229000);Bazarnyy Syzgan|(53.75117000,46.75354000);Cherdaklinskiy Rayon|(54.25000000,48.83333000)"
+Russia,RU,Vladimir,Vladimir,Moscow,,,56.13655000,40.39658000,Aleksandrov;Aleksandrovskiy Rayon;Andreyevo,"Aleksandrov|(56.39516000,38.71216000);Aleksandrovskiy Rayon|(56.41667000,38.58333000);Andreyevo|(55.94650000,41.15050000)"
+Russia,RU,Volgograd Oblast,Alimov-Lyubimovsky,Moscow,,,50.26631944,42.75618611,Alimov-Lyubimovsky;Amochayevsky;Antipovka,"Alimov-Lyubimovsky|(50.26631944,42.75618611);Amochayevsky|(50.70363889,42.42831944);Antipovka|(49.83000000,45.31222222)"
+Russia,RU,Vologda,Vologda,Moscow,,,59.22390000,39.88398000,Babayevo;Babayevskiy Rayon;Belozërsk,"Babayevo|(59.39360000,35.93710000);Babayevskiy Rayon|(59.50000000,36.00000000);Belozërsk|(60.02880000,37.80840000)"
+Russia,RU,Voronezh,Voronezh,Moscow,,,51.67204000,39.18430000,Abramovka;Anna;Anninskiy Rayon,"Abramovka|(51.18860000,41.02020000);Anna|(51.48420000,40.42990000);Anninskiy Rayon|(51.41667000,40.25000000)"
+Russia,RU,Yamalo-Nenets,Aksarka,Moscow,,,66.56056000,67.79750000,Aksarka;Gubkinskiy;Kharp,"Aksarka|(66.56056000,67.79750000);Gubkinskiy|(64.43400000,76.50261000);Kharp|(66.80139000,65.80806000)"
+Russia,RU,Yaroslavl,Yaroslavl,Moscow,,,57.62987000,39.87368000,Berendeyevo;Bol’shesel’skiy Rayon;Bol’shoye Selo,"Berendeyevo|(56.60078000,39.02173000);Bol’shesel’skiy Rayon|(57.66667000,39.00000000);Bol’shoye Selo|(57.71774000,38.93341000)"
+Russia,RU,Zabaykalsky,Aginskoye,Moscow,,,51.10000000,114.53000000,Aginskoye;Aksha;Akshinskiy Rayon,"Aginskoye|(51.10000000,114.53000000);Aksha|(50.28139000,113.28667000);Akshinskiy Rayon|(50.25000000,113.25000000)"
+Rwanda,RW,Eastern,Kibungo,Kigali,EMEA,14,-2.15970000,30.54270000,Kibungo;Rwamagana,"Kibungo|(-2.15970000,30.54270000);Rwamagana|(-1.94870000,30.43470000)"
+Rwanda,RW,Kigali,Kigali,Kigali,EMEA,14,-1.94995000,30.05885000,Kigali,"Kigali|(-1.94995000,30.05885000)"
+Rwanda,RW,Northern,Byumba,Kigali,EMEA,14,-1.57630000,30.06750000,Byumba;Musanze,"Byumba|(-1.57630000,30.06750000);Musanze|(-1.49984000,29.63497000)"
+Rwanda,RW,Southern,Butare,Kigali,EMEA,14,-2.59667000,29.73944000,Butare;Eglise Catholique Centrale GIKO;Gitarama,"Butare|(-2.59667000,29.73944000);Eglise Catholique Centrale GIKO|(-1.93653000,29.80610000);Gitarama|(-2.07444000,29.75667000)"
+Rwanda,RW,Western,Cyangugu,Kigali,EMEA,14,-2.48460000,28.90750000,Cyangugu;Gisenyi;Kibuye,"Cyangugu|(-2.48460000,28.90750000);Gisenyi|(-1.70278000,29.25639000);Kibuye|(-2.06028000,29.34778000)"
+Saint Helena,SH,Alarm Forest,,Jamestown,,,,,,
+Saint Helena,SH,Blue Hill,,Jamestown,,,,,,
+Saint Helena,SH,Half Tree Hollow,,Jamestown,,,,,,
+Saint Helena,SH,Jamestown,,Jamestown,,,,,,
+Saint Helena,SH,Levelwood,,Jamestown,,,,,,
+Saint Helena,SH,Longwood,,Jamestown,,,,,,
+Saint Helena,SH,Saint Paul's,,Jamestown,,,,,,
+Saint Helena,SH,Sandy Bay,,Jamestown,,,,,,
+Saint Kitts and Nevis,KN,Christ Church Nichola Town,Nicola Town,Basseterre,,,17.37956000,-62.75318000,Nicola Town,"Nicola Town|(17.37956000,-62.75318000)"
+Saint Kitts and Nevis,KN,Nevis,,Basseterre,,,,,,
+Saint Kitts and Nevis,KN,Saint Anne Sandy Point,Sandy Point Town,Basseterre,,,17.35908000,-62.84858000,Sandy Point Town,"Sandy Point Town|(17.35908000,-62.84858000)"
+Saint Kitts and Nevis,KN,Saint George Basseterre,,Basseterre,,,,,,
+Saint Kitts and Nevis,KN,Saint George Gingerland,Market Shop,Basseterre,,,17.13218000,-62.57267000,Market Shop,"Market Shop|(17.13218000,-62.57267000)"
+Saint Kitts and Nevis,KN,Saint James Windward,Newcastle,Basseterre,,,17.20000000,-62.58333000,Newcastle,"Newcastle|(17.20000000,-62.58333000)"
+Saint Kitts and Nevis,KN,Saint John Capisterre,Dieppe Bay Town,Basseterre,,,17.41473000,-62.81390000,Dieppe Bay Town,"Dieppe Bay Town|(17.41473000,-62.81390000)"
+Saint Kitts and Nevis,KN,Saint John Figtree,Fig Tree,Basseterre,,,17.12623000,-62.60265000,Fig Tree,"Fig Tree|(17.12623000,-62.60265000)"
+Saint Kitts and Nevis,KN,Saint Kitts,,Basseterre,,,,,,
+Saint Kitts and Nevis,KN,Saint Mary Cayon,Cayon,Basseterre,,,17.35000000,-62.73333000,Cayon,"Cayon|(17.35000000,-62.73333000)"
+Saint Kitts and Nevis,KN,Saint Paul Capisterre,Saint Paul’s,Basseterre,,,17.40605000,-62.83562000,Saint Paul’s,"Saint Paul’s|(17.40605000,-62.83562000)"
+Saint Kitts and Nevis,KN,Saint Paul Charlestown,Charlestown,Basseterre,,,17.13333000,-62.61667000,Charlestown,"Charlestown|(17.13333000,-62.61667000)"
+Saint Kitts and Nevis,KN,Saint Peter Basseterre,Monkey Hill,Basseterre,,,17.32327000,-62.72914000,Monkey Hill,"Monkey Hill|(17.32327000,-62.72914000)"
+Saint Kitts and Nevis,KN,Saint Thomas Lowland,Cotton Ground,Basseterre,,,17.16667000,-62.61667000,Cotton Ground,"Cotton Ground|(17.16667000,-62.61667000)"
+Saint Kitts and Nevis,KN,Saint Thomas Middle Island,Middle Island,Basseterre,,,17.32590000,-62.81055000,Middle Island,"Middle Island|(17.32590000,-62.81055000)"
+Saint Kitts and Nevis,KN,Trinity Palmetto Point,Trinity,Basseterre,,,17.30037000,-62.77584000,Trinity,"Trinity|(17.30037000,-62.77584000)"
+Saint Lucia,LC,Anse la Raye,Anse La Raye,Castries,,,13.94619000,-61.03879000,Anse La Raye;Au Tabor;Au Tabor Hill,"Anse La Raye|(13.94619000,-61.03879000);Au Tabor|(13.94540000,-61.04112000);Au Tabor Hill|(13.94457000,-61.03559000)"
+Saint Lucia,LC,Canaries,Anse Cochon,Castries,,,13.92261000,-61.05250000,Anse Cochon;Anse Galet;Anse La Verdue,"Anse Cochon|(13.92261000,-61.05250000);Anse Galet|(13.93221000,-61.04290000);Anse La Verdue|(13.90964000,-61.04755000)"
+Saint Lucia,LC,Castries,Castries,Castries,,,13.99570000,-61.00614000,Active Hill;Agard Lands/Morne Dudon;Almondale,"Active Hill|(14.01940000,-60.97767000);Agard Lands/Morne Dudon|(14.00768000,-60.96462000);Almondale|(14.01848000,-60.96162000)"
+Saint Lucia,LC,Choiseul,Choiseul,Castries,,,13.77273000,-61.04931000,Belle Vue;Bois Dinde;Caffiere,"Belle Vue|(13.80510000,-61.03615000);Bois Dinde|(13.80463000,-61.04952000);Caffiere|(13.78409000,-61.03554000)"
+Saint Lucia,LC,Dauphin,,Castries,,,,,,
+Saint Lucia,LC,Dennery,Dennery,Castries,,,13.91409000,-60.89132000,Anse Canot;Athens;Au Leon,"Anse Canot|(13.90871000,-60.90440000);Athens|(13.90574000,-60.89184000);Au Leon|(13.95245000,-60.90456000)"
+Saint Lucia,LC,Gros Islet,Gros Islet,Castries,,,14.06667000,-60.95000000,Beausejour;Beausejour/Fostin'S Development;Beausejour/Ndc,"Beausejour|(14.07647000,-60.93780000);Beausejour/Fostin'S Development|(14.07445000,-60.92929000);Beausejour/Ndc|(14.07733000,-60.92683000)"
+Saint Lucia,LC,Laborie,Laborie,Castries,,,13.75000000,-60.98333000,Annus;Balca;Balca/En Leur Ba,"Annus|(13.77449000,-61.00511000);Balca|(13.77117000,-61.02389000);Balca/En Leur Ba|(13.77638000,-61.01931000)"
+Saint Lucia,LC,Micoud,Micoud,Castries,,,13.81667000,-60.90000000,Anse Ger;Beauchamp;Blanchard,"Anse Ger|(13.79567000,-60.91567000);Beauchamp|(13.81778000,-60.91528000);Blanchard|(13.80616000,-60.94630000)"
+Saint Lucia,LC,Praslin,,Castries,,,,,,
+Saint Lucia,LC,Soufrière,Soufrière,Castries,,,13.85616000,-61.05660000,Anse Chastanet;Barons Drive/Coin De L'Anse;Beasejour/Myers Bridge,"Anse Chastanet|(13.86426000,-61.07016000);Barons Drive/Coin De L'Anse|(13.85138000,-61.05939000);Beasejour/Myers Bridge|(13.82147000,-61.03396000)"
+Saint Lucia,LC,Vieux Fort,Vieux Fort,Castries,,,13.71667000,-60.95000000,Augier;Beane Field;Beausejour,"Augier|(13.76669000,-60.98063000);Beane Field|(13.73976000,-60.94741000);Beausejour|(13.75229000,-60.95519000)"
+Saint Vincent and the Grenadines,VC,Charlotte,Biabou,Kingstown,,,13.19430000,-61.13904000,Biabou;Byera Village;Georgetown,"Biabou|(13.19430000,-61.13904000);Byera Village|(13.25636000,-61.11954000);Georgetown|(13.28054000,-61.11850000)"
+Saint Vincent and the Grenadines,VC,Grenadines,Port Elizabeth,Kingstown,,,13.01102000,-61.23548000,Port Elizabeth,"Port Elizabeth|(13.01102000,-61.23548000)"
+Saint Vincent and the Grenadines,VC,Saint Andrew,Layou,Kingstown,,,13.20175000,-61.27014000,Layou,"Layou|(13.20175000,-61.27014000)"
+Saint Vincent and the Grenadines,VC,Saint David,Chateaubelair,Kingstown,,,13.29069000,-61.24043000,Chateaubelair,"Chateaubelair|(13.29069000,-61.24043000)"
+Saint Vincent and the Grenadines,VC,Saint George,Kingstown,Kingstown,,,13.15527000,-61.22742000,Kingstown;Kingstown Park,"Kingstown|(13.15527000,-61.22742000);Kingstown Park|(13.15924000,-61.23161000)"
+Saint Vincent and the Grenadines,VC,Saint Patrick,Barrouallie,Kingstown,,,13.23676000,-61.27275000,Barrouallie,"Barrouallie|(13.23676000,-61.27275000)"
+Samoa,WS,A'ana,Fasito‘outa,Apia,,,-13.81163000,-171.94063000,Fasito‘outa;Leulumoega;Nofoali‘i,"Fasito‘outa|(-13.81163000,-171.94063000);Leulumoega|(-13.82297000,-171.96127000);Nofoali‘i|(-13.82170000,-171.95873000)"
+Samoa,WS,Aiga-i-le-Tai,Mulifanua,Apia,,,-13.83183000,-172.03602000,Mulifanua,"Mulifanua|(-13.83183000,-172.03602000)"
+Samoa,WS,Atua,Falefa,Apia,,,-13.88695000,-171.58805000,Falefa;Lotofagā;Lufilufi,"Falefa|(-13.88695000,-171.58805000);Lotofagā|(-13.97643000,-171.85781000);Lufilufi|(-13.87449000,-171.59857000)"
+Samoa,WS,Fa'asaleleaga,,Apia,,,,,,
+Samoa,WS,Gaga'emauga,,Apia,,,,,,
+Samoa,WS,Gaga'ifomauga,Matavai,Apia,,,-14.03208000,-171.64768000,Matavai;Safotu,"Matavai|(-14.03208000,-171.64768000);Safotu|(-13.45132000,-172.40177000)"
+Samoa,WS,Palauli,Gataivai,Apia,,,-13.77360000,-172.38802000,Gataivai;Vailoa,"Gataivai|(-13.77360000,-172.38802000);Vailoa|(-13.75551000,-172.30698000)"
+Samoa,WS,Satupa'itea,,Apia,,,,,,
+Samoa,WS,Tuamasaga,Afega,Apia,,,-13.79726000,-171.85308000,Afega;Apia;Malie,"Afega|(-13.79726000,-171.85308000);Apia|(-13.83333000,-171.76666000);Malie|(-13.80044000,-171.84690000)"
+Samoa,WS,Va'a-o-Fonoti,Samamea,Apia,,,-13.93375000,-171.53122000,Samamea,"Samamea|(-13.93375000,-171.53122000)"
+Samoa,WS,Vaisigano,Asau,Apia,,,-13.51963000,-172.63784000,Asau,"Asau|(-13.51963000,-172.63784000)"
+San Marino,SM,Acquaviva,Acquaviva,San Marino,,,43.94593000,12.41850000,Acquaviva,"Acquaviva|(43.94593000,12.41850000)"
+San Marino,SM,Borgo Maggiore,Borgo Maggiore,San Marino,,,43.94193000,12.44738000,Borgo Maggiore,"Borgo Maggiore|(43.94193000,12.44738000)"
+San Marino,SM,Chiesanuova,Poggio di Chiesanuova,San Marino,,,43.90451000,12.42142000,Poggio di Chiesanuova,"Poggio di Chiesanuova|(43.90451000,12.42142000)"
+San Marino,SM,Domagnano,Domagnano,San Marino,,,43.94961000,12.46828000,Domagnano,"Domagnano|(43.94961000,12.46828000)"
+San Marino,SM,Faetano,Faetano,San Marino,,,43.92831000,12.49798000,Faetano,"Faetano|(43.92831000,12.49798000)"
+San Marino,SM,Fiorentino,Fiorentino,San Marino,,,43.91001000,12.45738000,Fiorentino,"Fiorentino|(43.91001000,12.45738000)"
+San Marino,SM,Montegiardino,Monte Giardino,San Marino,,,43.90878000,12.48201000,Monte Giardino,"Monte Giardino|(43.90878000,12.48201000)"
+San Marino,SM,San Marino,San Marino,San Marino,,,43.93667000,12.44639000,San Marino,"San Marino|(43.93667000,12.44639000)"
+San Marino,SM,Serravalle,Serravalle,San Marino,,,43.96897000,12.48167000,Serravalle,"Serravalle|(43.96897000,12.48167000)"
+Sao Tome and Principe,ST,Príncipe,Santo António,Sao Tome,,,1.63943000,7.41951000,Santo António,"Santo António|(1.63943000,7.41951000)"
+Sao Tome and Principe,ST,São Tomé,São Tomé,Sao Tome,,,0.33654000,6.72732000,Cantagalo District;Caué District;São Tomé,"Cantagalo District|(0.21667000,6.70000000);Caué District|(0.13415000,6.63825000);São Tomé|(0.33654000,6.72732000)"
+Saudi Arabia,SA,'Asir,Abha,Riyadh,,,18.21639000,42.50528000,Abha;Al Majāridah;Al Qahab,"Abha|(18.21639000,42.50528000);Al Majāridah|(19.12361000,41.91111000);Al Qahab|(18.92560000,41.95500000)"
+Saudi Arabia,SA,Al Bahah,Al Bahah,Riyadh,,,20.01288000,41.46767000,Al Bahah;Al Mindak;Hajrah,"Al Bahah|(20.01288000,41.46767000);Al Mindak|(20.15880000,41.28337000);Hajrah|(20.23333333,41.05000000)"
+Saudi Arabia,SA,Al Jawf,Al Isawiyah,Riyadh,,,30.71681000,37.97767000,Al Isawiyah;Al-Haditha;Halat Ammar,"Al Isawiyah|(30.71681000,37.97767000);Al-Haditha|(31.45601100,37.14814000);Halat Ammar|(29.15944444,36.07500000)"
+Saudi Arabia,SA,Al Madinah,`Ajmiyah,Riyadh,,,24.21670000,38.50000000,`Ajmiyah;`Alya';`Ushash,"`Ajmiyah|(24.21670000,38.50000000);`Alya'|(23.82360000,38.88330000);`Ushash|(23.50000000,38.91670000)"
+Saudi Arabia,SA,Al-Qassim,Adh Dhibiyah,Riyadh,,,26.03018040,43.15758140,Adh Dhibiyah;Al Bukayrīyah;Al Fuwayliq,"Adh Dhibiyah|(26.03018040,43.15758140);Al Bukayrīyah|(26.13915000,43.65782000);Al Fuwayliq|(26.44360000,43.25164000)"
+Saudi Arabia,SA,Eastern Province,Abqaiq,Riyadh,,,25.93402000,49.66880000,Abqaiq;Al Awjām;Al Baţţālīyah,"Abqaiq|(25.93402000,49.66880000);Al Awjām|(26.56324000,49.94331000);Al Baţţālīyah|(25.43333000,49.63333000)"
+Saudi Arabia,SA,Ha'il,Jubbah,Riyadh,,,28.00620000,40.94160000,Jubbah;Mawqaq;Qufar,"Jubbah|(28.00620000,40.94160000);Mawqaq|(27.38398000,41.17635000);Qufar|(27.41534000,41.61903000)"
+Saudi Arabia,SA,Jizan,Jizan,Riyadh,,,16.88917000,42.55111000,Abū ‘Arīsh;Abu Radif;Ad Darb,"Abū ‘Arīsh|(16.96887000,42.83251000);Abu Radif|(16.61860000,43.13110000);Ad Darb|(17.72285000,42.25261000)"
+Saudi Arabia,SA,Makkah,Abu `Urwah,Riyadh,,,21.65000000,39.70000000,Abu `Urwah;Abu Hisani;Abu Qirfah,"Abu `Urwah|(21.65000000,39.70000000);Abu Hisani|(21.73060000,39.78330000);Abu Qirfah|(21.77303070,39.67959850)"
+Saudi Arabia,SA,Najran,Najrān,Riyadh,,,17.49326000,44.12766000,Najrān,"Najrān|(17.49326000,44.12766000)"
+Saudi Arabia,SA,Northern Borders,Arar,Riyadh,,,30.97531000,41.03808000,Arar;Nisab;Turaif,"Arar|(30.97531000,41.03808000);Nisab|(29.19274000,44.71598000);Turaif|(31.67252000,38.66374000)"
+Saudi Arabia,SA,Riyadh,Riyadh,Riyadh,,,24.68773000,46.72185000,Ad Dawādimī;Ad Dilam;Afif,"Ad Dawādimī|(24.49416700,44.38333300);Ad Dilam|(23.99104000,47.16181000);Afif|(23.90650000,42.91724000)"
+Saudi Arabia,SA,Tabuk,Tabuk,Riyadh,,,28.39980000,36.57151000,Al Wajh;Duba;Tabuk,"Al Wajh|(26.24551000,36.45249000);Duba|(27.35134000,35.69014000);Tabuk|(28.39980000,36.57151000)"
+Senegal,SN,Dakar,Dakar,Dakar,,,14.69370000,-17.44406000,Dakar;Dakar Department;Guédiawaye Department,"Dakar|(14.69370000,-17.44406000);Dakar Department|(14.71403000,-17.45534000);Guédiawaye Department|(14.77610000,-17.39560000)"
+Senegal,SN,Diourbel Region,Mbacké,Dakar,,,14.80828000,-15.86454000,Mbacké;Mbaké;Tiébo,"Mbacké|(14.80828000,-15.86454000);Mbaké|(14.79032000,-15.90803000);Tiébo|(14.63333000,-16.23333000)"
+Senegal,SN,Fatick,Diofior,Dakar,,,14.18333000,-16.66667000,Diofior;Fatick Department;Foundiougne,"Diofior|(14.18333000,-16.66667000);Fatick Department|(14.25909000,-16.49884000);Foundiougne|(14.13333000,-16.46667000)"
+Senegal,SN,Kaffrine,Kaffrine,Dakar,,,14.10594000,-15.55080000,Kaffrine;Koungheul,"Kaffrine|(14.10594000,-15.55080000);Koungheul|(13.98333000,-14.80000000)"
+Senegal,SN,Kaolack,Kaolack,Dakar,,,14.15197000,-16.07259000,Gandiaye;Kaolack;Ndofane,"Gandiaye|(14.23333000,-16.26667000);Kaolack|(14.15197000,-16.07259000);Ndofane|(13.91667000,-15.93333000)"
+Senegal,SN,Kédougou,Kédougou,Dakar,,,12.55561000,-12.18076000,Département de Salémata;Kédougou;Kédougou Department,"Département de Salémata|(12.59971000,-12.77619000);Kédougou|(12.55561000,-12.18076000);Kédougou Department|(12.81716000,-12.17834000)"
+Senegal,SN,Kolda,Kolda,Dakar,,,12.89390000,-14.94125000,Kolda;Kolda Department;Marsassoum,"Kolda|(12.89390000,-14.94125000);Kolda Department|(12.88300000,-14.95000000);Marsassoum|(12.82750000,-15.98056000)"
+Senegal,SN,Louga,Louga,Dakar,,,15.61867000,-16.22436000,Dara;Guéoul;Linguere Department,"Dara|(15.34844000,-15.47993000);Guéoul|(15.48333000,-16.35000000);Linguere Department|(15.35900000,-15.15800000)"
+Senegal,SN,Matam,Matam,Dakar,,,15.65587000,-13.25544000,Diawara;Kanel;Matam,"Diawara|(15.02196000,-12.54374000);Kanel|(15.49160000,-13.17627000);Matam|(15.65587000,-13.25544000)"
+Senegal,SN,Saint-Louis,Saint-Louis,Dakar,,,16.01793000,-16.48962000,Goléré;Ndioum;Polel Diaoubé,"Goléré|(16.25575000,-14.10165000);Ndioum|(16.51293000,-14.64706000);Polel Diaoubé|(15.26667000,-13.00000000)"
+Senegal,SN,Sédhiou,Sédhiou,Dakar,,,12.70806000,-15.55694000,Goudomp Department;Sédhiou,"Goudomp Department|(12.57778000,-15.87222000);Sédhiou|(12.70806000,-15.55694000)"
+Senegal,SN,Tambacounda Region,Tambacounda,Dakar,,,13.77073000,-13.66734000,Tambacounda;Tambacounda Department,"Tambacounda|(13.77073000,-13.66734000);Tambacounda Department|(13.60500000,-13.64700000)"
+Senegal,SN,Thiès Region,Joal-Fadiout,Dakar,,,14.16667000,-16.83333000,Joal-Fadiout;Kayar;Khombole,"Joal-Fadiout|(14.16667000,-16.83333000);Kayar|(14.91893000,-17.11978000);Khombole|(14.76667000,-16.70000000)"
+Senegal,SN,Ziguinchor,Ziguinchor,Dakar,,,12.56801000,-16.27326000,Adéane;Bignona;Oussouye,"Adéane|(12.63000000,-16.01694000);Bignona|(12.81028000,-16.22639000);Oussouye|(12.48500000,-16.54694000)"
+Serbia,RS,Belgrade,Barič,Belgrade,,,44.65070000,20.25941000,Barič;Bečmen;Dobanovci,"Barič|(44.65070000,20.25941000);Bečmen|(44.77983000,20.20577000);Dobanovci|(44.82631000,20.22487000)"
+Serbia,RS,Bor,Bor,Belgrade,,,44.36667000,22.25000000,Bor;Donji Milanovac;Kladovo,"Bor|(44.36667000,22.25000000);Donji Milanovac|(44.46593000,22.15170000);Kladovo|(44.60439890,22.50819420)"
+Serbia,RS,Braničevo,Golubac,Belgrade,,,44.63552160,21.59525590,Golubac;Klenje;Kučevo,"Golubac|(44.63552160,21.59525590);Klenje|(44.80794000,19.43508000);Kučevo|(44.48938750,21.63499770)"
+Serbia,RS,Central Banat,Aradac,Belgrade,,,45.38346000,20.30137000,Aradac;Banatski Despotovac;Banatski Dvor,"Aradac|(45.38346000,20.30137000);Banatski Despotovac|(45.36606000,20.66407000);Banatski Dvor|(45.51866000,20.51146000)"
+Serbia,RS,Jablanica,Bojnik,Belgrade,,,43.03962330,21.50229300,Bojnik;Crna Trava;Kamenica,"Bojnik|(43.03962330,21.50229300);Crna Trava|(42.81226490,22.26885720);Kamenica|(44.34300000,19.72333000)"
+Serbia,RS,Kolubara,Gornja Bukovica,Belgrade,,,44.33987000,19.81368000,Gornja Bukovica;Joševa;Lajkovac,"Gornja Bukovica|(44.33987000,19.81368000);Joševa|(44.58772000,19.40967000);Lajkovac|(44.36809950,20.14110360)"
+Serbia,RS,Mačva,Mačva,Belgrade,,,44.61472000,19.47222000,Badovinci;Banovo Polje;Belotić,"Badovinci|(44.78534000,19.37146000);Banovo Polje|(44.91040000,19.44916000);Belotić|(44.81782000,19.54801000)"
+Serbia,RS,Moravica,Čačak,Belgrade,,,43.89139000,20.34972000,Čačak;Gornji Milanovac;Ivanjica,"Čačak|(43.89139000,20.34972000);Gornji Milanovac|(44.02603000,20.46152000);Ivanjica|(43.58366500,20.21556940)"
+Serbia,RS,Nišava,Aleksandrovo,Belgrade,,,45.63755000,20.59288000,Aleksandrovo;Aleksinac;Doljevac,"Aleksandrovo|(45.63755000,20.59288000);Aleksinac|(43.55255480,21.63113320);Doljevac|(43.22262650,21.76288330)"
+Serbia,RS,North Bačka,Bačka Topola,Belgrade,,,45.81516000,19.63180000,Bačka Topola;Krivaja;Mali Iđoš,"Bačka Topola|(45.81516000,19.63180000);Krivaja|(44.55021000,19.59153000);Mali Iđoš|(45.71406240,19.58678580)"
+Serbia,RS,North Banat,Ada,Belgrade,,,45.78604090,19.84788560,Ada;Adorjan;Banatska Topola,"Ada|(45.78604090,19.84788560);Adorjan|(46.00333000,20.04007000);Banatska Topola|(45.67248000,20.46530000)"
+Serbia,RS,Pčinja,Biljača,Belgrade,,,42.35518000,21.74781000,Biljača;Bosilegrad;Bujanovac,"Biljača|(42.35518000,21.74781000);Bosilegrad|(42.50233740,22.41940440);Bujanovac|(42.45675480,21.74726470)"
+Serbia,RS,Pirot,Pirot,Belgrade,,,43.17528000,22.59278000,Babušnica;Bela Palanka;Dimitrovgrad,"Babušnica|(43.06573340,22.38719690);Bela Palanka|(43.21421070,22.29898440);Dimitrovgrad|(43.02140830,22.73950980)"
+Serbia,RS,Podunavlje,Lugavčina,Belgrade,,,44.52314000,21.07083000,Lugavčina;Smederevo;Smederevska Palanka,"Lugavčina|(44.52314000,21.07083000);Smederevo|(44.66436000,20.92763000);Smederevska Palanka|(44.36548000,20.95885000)"
+Serbia,RS,Pomoravlje,Ćuprija,Belgrade,,,43.92750000,21.37000000,Ćuprija;Despotovac;Drenovac,"Ćuprija|(43.92750000,21.37000000);Despotovac|(44.09472620,21.39913490);Drenovac|(44.86649000,19.70943000)"
+Serbia,RS,Rasina,Aleksandrovac,Belgrade,,,43.45989420,21.03087890,Aleksandrovac;Brus;Ćićevac,"Aleksandrovac|(43.45989420,21.03087890);Brus|(43.38376200,21.00656730);Ćićevac|(43.71882000,21.44085000)"
+Serbia,RS,Raška,Raška,Belgrade,,,43.26694000,20.65278000,Jarebice;Kraljevo;Novi Pazar,"Jarebice|(44.53995000,19.42418000);Kraljevo|(43.72583000,20.68944000);Novi Pazar|(43.13667000,20.51222000)"
+Serbia,RS,South Bačka,Bač,Belgrade,,,45.35619150,19.14208630,Bač;Bačka Palanka;Bački Petrovac,"Bač|(45.35619150,19.14208630);Bačka Palanka|(45.24966000,19.39664000);Bački Petrovac|(45.36056000,19.59167000)"
+Serbia,RS,South Banat,Alibunar,Belgrade,,,45.08083000,20.96583000,Alibunar;Banatski Karlovac;Baranda,"Alibunar|(45.08083000,20.96583000);Banatski Karlovac|(45.04987000,21.01800000);Baranda|(45.08459000,20.44264000)"
+Serbia,RS,Srem,Belegiš,Belgrade,,,45.01920000,20.33323000,Belegiš;Beška;Bosut,"Belegiš|(45.01920000,20.33323000);Beška|(45.13092000,20.06698000);Bosut|(44.92977000,19.36086000)"
+Serbia,RS,Šumadija,Aranđelovac,Belgrade,,,44.30694000,20.56000000,Aranđelovac;Batočina;Knić,"Aranđelovac|(44.30694000,20.56000000);Batočina|(44.15465720,21.02491300);Knić|(43.92755740,20.67905830)"
+Serbia,RS,Toplica,Blace,Belgrade,,,43.29874190,21.24844850,Blace;Ðurići;Kupinovo,"Blace|(43.29874190,21.24844850);Ðurići|(43.82533000,19.41233000);Kupinovo|(44.70708000,20.04959000)"
+Serbia,RS,Vojvodina,,Belgrade,,,,,,
+Serbia,RS,West Bačka,Apatin,Belgrade,,,45.67260000,18.97800000,Apatin;Bački Breg;Bogojevo,"Apatin|(45.67260000,18.97800000);Bački Breg|(45.92034000,18.92944000);Bogojevo|(45.53015000,19.13022000)"
+Serbia,RS,Zaječar,Zaječar,Belgrade,,,43.69917000,21.98778000,Boljevac;Boljevci;Knjazevac,"Boljevac|(43.83114320,21.92158620);Boljevci|(44.72355000,20.22348000);Knjazevac|(43.56634000,22.25701000)"
+Serbia,RS,Zlatibor,Arilje,Belgrade,,,43.75306000,20.09556000,Arilje;Bajina Bašta;Čajetina,"Arilje|(43.75306000,20.09556000);Bajina Bašta|(43.97083000,19.56750000);Čajetina|(43.74977000,19.71273000)"
+Seychelles,SC,Anse Boileau,Anse Boileau,Victoria,EMEA,14,-4.71667000,55.48333000,Anse Boileau,"Anse Boileau|(-4.71667000,55.48333000)"
+Seychelles,SC,Anse Royale,Anse Royale,Victoria,EMEA,14,-4.73333000,55.51667000,Anse Royale,"Anse Royale|(-4.73333000,55.51667000)"
+Seychelles,SC,Anse-aux-Pins,,Victoria,EMEA,14,,,,
+Seychelles,SC,Au Cap,,Victoria,EMEA,14,,,,
+Seychelles,SC,Baie Lazare,,Victoria,EMEA,14,,,,
+Seychelles,SC,Baie Sainte Anne,,Victoria,EMEA,14,,,,
+Seychelles,SC,Beau Vallon,Beau Vallon,Victoria,EMEA,14,-4.62091000,55.43015000,Beau Vallon,"Beau Vallon|(-4.62091000,55.43015000)"
+Seychelles,SC,Bel Air,,Victoria,EMEA,14,,,,
+Seychelles,SC,Bel Ombre,Bel Ombre,Victoria,EMEA,14,-4.61667000,55.41667000,Bel Ombre,"Bel Ombre|(-4.61667000,55.41667000)"
+Seychelles,SC,Cascade,Cascade,Victoria,EMEA,14,-4.66667000,55.50000000,Cascade,"Cascade|(-4.66667000,55.50000000)"
+Seychelles,SC,Glacis,,Victoria,EMEA,14,,,,
+Seychelles,SC,Grand'Anse Mahé,,Victoria,EMEA,14,,,,
+Seychelles,SC,Grand'Anse Praslin,,Victoria,EMEA,14,,,,
+Seychelles,SC,La Digue,,Victoria,EMEA,14,,,,
+Seychelles,SC,La Rivière Anglaise,Victoria,Victoria,EMEA,14,-4.62001000,55.45501000,Victoria,"Victoria|(-4.62001000,55.45501000)"
+Seychelles,SC,Les Mamelles,,Victoria,EMEA,14,,,,
+Seychelles,SC,Mont Buxton,,Victoria,EMEA,14,,,,
+Seychelles,SC,Mont Fleuri,,Victoria,EMEA,14,,,,
+Seychelles,SC,Plaisance,,Victoria,EMEA,14,,,,
+Seychelles,SC,Pointe La Rue,,Victoria,EMEA,14,,,,
+Seychelles,SC,Port Glaud,Port Glaud,Victoria,EMEA,14,-4.66667000,55.41667000,Port Glaud,"Port Glaud|(-4.66667000,55.41667000)"
+Seychelles,SC,Roche Caiman,,Victoria,EMEA,14,,,,
+Seychelles,SC,Saint Louis,,Victoria,EMEA,14,,,,
+Seychelles,SC,Takamaka,Takamaka,Victoria,EMEA,14,-4.76667000,55.50000000,Takamaka,"Takamaka|(-4.76667000,55.50000000)"
+Sierra Leone,SL,Eastern,Barma,Freetown,EMEA,11,8.34959000,-11.33059000,Barma;Blama;Boajibu,"Barma|(8.34959000,-11.33059000);Blama|(7.87481000,-11.34548000);Boajibu|(8.18763000,-11.34026000)"
+Sierra Leone,SL,Northern,Alikalia,Freetown,EMEA,11,9.15356000,-11.38712000,Alikalia;Bindi;Binkolo,"Alikalia|(9.15356000,-11.38712000);Bindi|(9.91376000,-11.44669000);Binkolo|(8.95225000,-11.98029000)"
+Sierra Leone,SL,Southern,Baiima,Freetown,EMEA,11,8.10826000,-11.84772000,Baiima;Baoma;Bo,"Baiima|(8.10826000,-11.84772000);Baoma|(7.99344000,-11.71468000);Bo|(7.96472000,-11.73833000)"
+Sierra Leone,SL,Western,Freetown,Freetown,EMEA,11,8.48714000,-13.23560000,Freetown;Hastings;Kent,"Freetown|(8.48714000,-13.23560000);Hastings|(8.37994000,-13.13693000);Kent|(8.33333000,-13.06667000)"
+Singapore,SG,Central Singapore,Bukit Timah,Singapur,,,1.32940000,103.80210000,Bukit Timah;Downtown Core;Geylang,"Bukit Timah|(1.32940000,103.80210000);Downtown Core|(1.27800000,103.85200000);Geylang|(1.31820000,103.88710000)"
+Singapore,SG,North East,Ang Mo Kio,Singapur,,,1.36980000,103.84610000,Ang Mo Kio;Hougang;Punggol,"Ang Mo Kio|(1.36980000,103.84610000);Hougang|(1.37360000,103.88670000);Punggol|(1.40510000,103.90230000)"
+Singapore,SG,North West,Sembawang,Singapur,,,1.44910000,103.82010000,Sembawang;Woodlands;Yishun,"Sembawang|(1.44910000,103.82010000);Woodlands|(1.43801000,103.78877000);Yishun|(1.42930000,103.83550000)"
+Singapore,SG,South East,Bedok,Singapur,,,1.32360000,103.92730000,Bedok;Pasir Ris;Tampines,"Bedok|(1.32360000,103.92730000);Pasir Ris|(1.37390000,103.94930000);Tampines|(1.35470000,103.94370000)"
+Singapore,SG,South West,Bukit Batok,Singapur,,,1.34960000,103.75280000,Bukit Batok;Bukit Panjang;Jurong West,"Bukit Batok|(1.34960000,103.75280000);Bukit Panjang|(1.37860000,103.76260000);Jurong West|(1.33960000,103.70730000)"
+Slovakia,SK,Banská Bystrica,Banská Bystrica,Bratislava,,,48.73946000,19.15349000,Banská Bystrica;Banská Štiavnica;Brezno,"Banská Bystrica|(48.73946000,19.15349000);Banská Štiavnica|(48.44858000,18.91003000);Brezno|(48.80431000,19.63631000)"
+Slovakia,SK,Bratislava,Bratislava,Bratislava,,,48.14816000,17.10674000,Bratislava;Bratislava - Vajnory;Dunajská Lužná,"Bratislava|(48.14816000,17.10674000);Bratislava - Vajnory|(48.20563000,17.20759000);Dunajská Lužná|(48.08347000,17.26072000)"
+Slovakia,SK,Košice,Košice,Bratislava,,,48.71395000,21.25808000,Čierna nad Tisou;Dobšiná;Gelnica,"Čierna nad Tisou|(48.41704000,22.08865000);Dobšiná|(48.82073000,20.36988000);Gelnica|(48.85584000,20.93713000)"
+Slovakia,SK,Nitra,Nitra,Bratislava,,,48.30763000,18.08453000,Hurbanovo;Kolárovo;Komárno,"Hurbanovo|(47.86984000,18.19233000);Kolárovo|(47.92294000,17.98467000);Komárno|(47.76356000,18.12263000)"
+Slovakia,SK,Prešov,Prešov,Bratislava,,,48.99839000,21.23393000,Bardejov;Chlmec;Giraltovce,"Bardejov|(49.29175000,21.27271000);Chlmec|(48.88628000,21.93930000);Giraltovce|(49.11398000,21.51731000)"
+Slovakia,SK,Trenčín,Trenčín,Bratislava,,,48.89452000,18.04436000,Bánovce nad Bebravou;Bojnice;Brezová pod Bradlom,"Bánovce nad Bebravou|(48.72130000,18.25754000);Bojnice|(48.78511000,18.58640000);Brezová pod Bradlom|(48.66349000,17.53905000)"
+Slovakia,SK,Trnava,Trnava,Bratislava,,,48.37741000,17.58723000,Dunajská Streda;Gabčíkovo;Galanta,"Dunajská Streda|(47.99268000,17.61211000);Gabčíkovo|(47.89211000,17.57884000);Galanta|(48.19001000,17.72747000)"
+Slovakia,SK,Žilina,Žilina,Bratislava,,,49.22315000,18.73941000,Bytča;Čadca;Dolný Kubín,"Bytča|(49.22404000,18.55878000);Čadca|(49.43503000,18.78895000);Dolný Kubín|(49.20983000,19.30341000)"
+Slovenia,SI,Ajdovščina,Ajdovščina,Ljubljana,,,45.88601000,13.90946000,Ajdovščina;Cirkulane;Lokavec,"Ajdovščina|(45.88601000,13.90946000);Cirkulane|(46.34408000,15.99472000);Lokavec|(45.90167000,13.87972000)"
+Slovenia,SI,Ankaran,Ankaran,Ljubljana,,,45.57861000,13.73611000,Ankaran,"Ankaran|(45.57861000,13.73611000)"
+Slovenia,SI,Apače,Apače,Ljubljana,,,46.69722000,15.91056000,Apače,"Apače|(46.69722000,15.91056000)"
+Slovenia,SI,Beltinci,Beltinci,Ljubljana,,,46.60528000,16.24056000,Beltinci;Gančani;Lipovci,"Beltinci|(46.60528000,16.24056000);Gančani|(46.63250000,16.25111000);Lipovci|(46.62833000,16.22806000)"
+Slovenia,SI,Benedikt,Benedikt,Ljubljana,,,46.60861000,15.88833000,Benedikt,"Benedikt|(46.60861000,15.88833000)"
+Slovenia,SI,Bistrica ob Sotli,Bistrica ob Sotli,Ljubljana,,,46.05889000,15.66417000,Bistrica ob Sotli,"Bistrica ob Sotli|(46.05889000,15.66417000)"
+Slovenia,SI,Bled,Bled,Ljubljana,,,46.36917000,14.11361000,Bled;Kostanjevica na Krki;Zasip,"Bled|(46.36917000,14.11361000);Kostanjevica na Krki|(45.84611000,15.42222000);Zasip|(46.39284000,14.10869000)"
+Slovenia,SI,Bloke,Nova Vas,Ljubljana,,,45.77167000,14.50583000,Nova Vas,"Nova Vas|(45.77167000,14.50583000)"
+Slovenia,SI,Bohinj,Bohinjska Bistrica,Ljubljana,,,46.27216000,13.95350000,Bohinjska Bistrica;Dragomer;Log pri Brezovici,"Bohinjska Bistrica|(46.27216000,13.95350000);Dragomer|(46.01667000,14.38333000);Log pri Brezovici|(46.01667000,14.36667000)"
+Slovenia,SI,Borovnica,Borovnica,Ljubljana,,,45.91583000,14.36306000,Borovnica;Makole,"Borovnica|(45.91583000,14.36306000);Makole|(46.31722000,15.66722000)"
+Slovenia,SI,Bovec,Bovec,Ljubljana,,,46.33808000,13.55245000,Bovec;Mirna,"Bovec|(46.33808000,13.55245000);Mirna|(45.95528000,15.06194000)"
+Slovenia,SI,Braslovče,Braslovče,Ljubljana,,,46.28972000,15.03889000,Braslovče,"Braslovče|(46.28972000,15.03889000)"
+Slovenia,SI,Brda,Dobrovo,Ljubljana,,,45.99639000,13.52639000,Dobrovo;Mokronog,"Dobrovo|(45.99639000,13.52639000);Mokronog|(45.93417000,15.14083000)"
+Slovenia,SI,Brežice,Brežice,Ljubljana,,,45.90333000,15.59111000,Brežice;Poljčane,"Brežice|(45.90333000,15.59111000);Poljčane|(46.31194000,15.57917000)"
+Slovenia,SI,Brezovica,Brezovica pri Ljubljani,Ljubljana,,,46.03333000,14.40000000,Brezovica pri Ljubljani;Notranje Gorice;Opština Ljubljana-Vič-Rudnik,"Brezovica pri Ljubljani|(46.03333000,14.40000000);Notranje Gorice|(45.98750000,14.39889000);Opština Ljubljana-Vič-Rudnik|(46.03333000,14.41667000)"
+Slovenia,SI,Cankova,Cankova,Ljubljana,,,46.72083000,16.02250000,Cankova,"Cankova|(46.72083000,16.02250000)"
+Slovenia,SI,Celje,Celje,Ljubljana,,,46.23092000,15.26044000,Celje;Ljubečna;Trnovlje pri Celju,"Celje|(46.23092000,15.26044000);Ljubečna|(46.25567000,15.32430000);Trnovlje pri Celju|(46.25667000,15.29528000)"
+Slovenia,SI,Cerklje na Gorenjskem,Cerklje na Gorenjskem,Ljubljana,,,46.25417000,14.48861000,Cerklje na Gorenjskem,"Cerklje na Gorenjskem|(46.25417000,14.48861000)"
+Slovenia,SI,Cerknica,Cerknica,Ljubljana,,,45.79306000,14.36250000,Cerknica;Rakek,"Cerknica|(45.79306000,14.36250000);Rakek|(45.81333000,14.31111000)"
+Slovenia,SI,Cerkno,Cerkno,Ljubljana,,,46.12556000,13.98167000,Cerkno,"Cerkno|(46.12556000,13.98167000)"
+Slovenia,SI,Cerkvenjak,Cerkvenjak,Ljubljana,,,46.57056000,15.94361000,Cerkvenjak,"Cerkvenjak|(46.57056000,15.94361000)"
+Slovenia,SI,Cirkulane,,Ljubljana,,,,,,
+Slovenia,SI,Črenšovci,Črenšovci,Ljubljana,,,46.55794000,16.30410000,Črenšovci,"Črenšovci|(46.55794000,16.30410000)"
+Slovenia,SI,Črna na Koroškem,Črna na Koroškem,Ljubljana,,,46.47045000,14.85009000,Črna na Koroškem,"Črna na Koroškem|(46.47045000,14.85009000)"
+Slovenia,SI,Črnomelj,Črnomelj,Ljubljana,,,45.57111000,15.18889000,Črnomelj,"Črnomelj|(45.57111000,15.18889000)"
+Slovenia,SI,Destrnik,Destrnik,Ljubljana,,,46.49254000,15.87893000,Destrnik,"Destrnik|(46.49254000,15.87893000)"
+Slovenia,SI,Divača,Divača,Ljubljana,,,45.68472000,13.97028000,Divača,"Divača|(45.68472000,13.97028000)"
+Slovenia,SI,Dobje,Dobje pri Planini,Ljubljana,,,46.13747000,15.39412000,Dobje pri Planini,"Dobje pri Planini|(46.13747000,15.39412000)"
+Slovenia,SI,Dobrepolje,Videm,Ljubljana,,,45.85000000,14.69417000,Videm,"Videm|(45.85000000,14.69417000)"
+Slovenia,SI,Dobrna,Dobrna,Ljubljana,,,46.33750000,15.22639000,Dobrna,"Dobrna|(46.33750000,15.22639000)"
+Slovenia,SI,Dobrova–Polhov Gradec,Dobrova,Ljubljana,,,46.04580000,14.39186000,Dobrova,"Dobrova|(46.04580000,14.39186000)"
+Slovenia,SI,Dobrovnik,Dobrovnik,Ljubljana,,,46.65139000,16.35250000,Dobrovnik,"Dobrovnik|(46.65139000,16.35250000)"
+Slovenia,SI,Dol pri Ljubljani,Dol pri Ljubljani,Ljubljana,,,46.08861000,14.60083000,Dol pri Ljubljani,"Dol pri Ljubljani|(46.08861000,14.60083000)"
+Slovenia,SI,Dolenjske Toplice,Dolenjske Toplice,Ljubljana,,,45.75657000,15.05917000,Dolenjske Toplice,"Dolenjske Toplice|(45.75657000,15.05917000)"
+Slovenia,SI,Domžale,Domžale,Ljubljana,,,46.13774000,14.59371000,Dob;Domžale;Radomlje,"Dob|(46.15194000,14.62861000);Domžale|(46.13774000,14.59371000);Radomlje|(46.17361000,14.61222000)"
+Slovenia,SI,Dornava,Dornava,Ljubljana,,,46.43667000,15.95361000,Dornava,"Dornava|(46.43667000,15.95361000)"
+Slovenia,SI,Dravograd,Dravograd,Ljubljana,,,46.58806000,15.01917000,Dravograd,"Dravograd|(46.58806000,15.01917000)"
+Slovenia,SI,Duplek,Spodnji Duplek,Ljubljana,,,46.50306000,15.74528000,Spodnji Duplek;Zgornji Duplek,"Spodnji Duplek|(46.50306000,15.74528000);Zgornji Duplek|(46.51361000,15.72083000)"
+Slovenia,SI,Gorenja Vas–Poljane,Gorenja Vas,Ljubljana,,,46.10722000,14.14806000,Gorenja Vas,"Gorenja Vas|(46.10722000,14.14806000)"
+Slovenia,SI,Gorišnica,Gorišnica,Ljubljana,,,46.41472000,16.01389000,Gorišnica,"Gorišnica|(46.41472000,16.01389000)"
+Slovenia,SI,Gorje,,Ljubljana,,,,,,
+Slovenia,SI,Gornja Radgona,Gornja Radgona,Ljubljana,,,46.67333000,15.99222000,Gornja Radgona,"Gornja Radgona|(46.67333000,15.99222000)"
+Slovenia,SI,Gornji Grad,Gornji Grad,Ljubljana,,,46.29528000,14.80833000,Gornji Grad,"Gornji Grad|(46.29528000,14.80833000)"
+Slovenia,SI,Gornji Petrovci,Gornji Petrovci,Ljubljana,,,46.80528000,16.22250000,Gornji Petrovci,"Gornji Petrovci|(46.80528000,16.22250000)"
+Slovenia,SI,Grad,Grad,Ljubljana,,,46.80000000,16.10000000,Grad,"Grad|(46.80000000,16.10000000)"
+Slovenia,SI,Grosuplje,Grosuplje,Ljubljana,,,45.95556000,14.65889000,Grosuplje;Šmarje-Sap,"Grosuplje|(45.95556000,14.65889000);Šmarje-Sap|(45.97618000,14.61177000)"
+Slovenia,SI,Hajdina,Spodnja Hajdina,Ljubljana,,,46.40889000,15.84694000,Spodnja Hajdina,"Spodnja Hajdina|(46.40889000,15.84694000)"
+Slovenia,SI,Hoče–Slivnica,Hotinja Vas,Ljubljana,,,46.46667000,15.66667000,Hotinja Vas;Radizel;Rogoza,"Hotinja Vas|(46.46667000,15.66667000);Radizel|(46.47444000,15.65583000);Rogoza|(46.50000000,15.68333000)"
+Slovenia,SI,Hodoš,Hodoš,Ljubljana,,,46.82333000,16.33417000,Hodoš,"Hodoš|(46.82333000,16.33417000)"
+Slovenia,SI,Horjul,Horjul,Ljubljana,,,46.02361000,14.29917000,Horjul,"Horjul|(46.02361000,14.29917000)"
+Slovenia,SI,Hrastnik,Hrastnik,Ljubljana,,,46.14611000,15.08139000,Dol pri Hrastniku;Hrastnik,"Dol pri Hrastniku|(46.14194000,15.11278000);Hrastnik|(46.14611000,15.08139000)"
+Slovenia,SI,Hrpelje–Kozina,Kozina,Ljubljana,,,45.61000000,13.93556000,Kozina,"Kozina|(45.61000000,13.93556000)"
+Slovenia,SI,Idrija,Idrija,Ljubljana,,,46.00278000,14.03056000,Idrija;Spodnja Idrija,"Idrija|(46.00278000,14.03056000);Spodnja Idrija|(46.03194000,14.02722000)"
+Slovenia,SI,Ig,Ig,Ljubljana,,,45.96028000,14.52889000,Ig,"Ig|(45.96028000,14.52889000)"
+Slovenia,SI,Ilirska Bistrica,Ilirska Bistrica,Ljubljana,,,45.56757000,14.24571000,Ilirska Bistrica,"Ilirska Bistrica|(45.56757000,14.24571000)"
+Slovenia,SI,Ivančna Gorica,Ivančna Gorica,Ljubljana,,,45.93833000,14.80444000,Ivančna Gorica;Šentvid pri Stični,"Ivančna Gorica|(45.93833000,14.80444000);Šentvid pri Stični|(45.95004000,14.84344000)"
+Slovenia,SI,Izola,Izola,Ljubljana,,,45.53694000,13.66194000,Izola;Jagodje,"Izola|(45.53694000,13.66194000);Jagodje|(45.52845000,13.64721000)"
+Slovenia,SI,Jesenice,Jesenice,Ljubljana,,,46.43056000,14.06694000,Hrušica;Jesenice;Koroška Bela,"Hrušica|(46.44500000,14.01778000);Jesenice|(46.43056000,14.06694000);Koroška Bela|(46.44913000,14.11135000)"
+Slovenia,SI,Jezersko,Zgornje Jezersko,Ljubljana,,,46.39410000,14.50659000,Zgornje Jezersko,"Zgornje Jezersko|(46.39410000,14.50659000)"
+Slovenia,SI,Juršinci,Juršinci,Ljubljana,,,46.48472000,15.97139000,Juršinci,"Juršinci|(46.48472000,15.97139000)"
+Slovenia,SI,Kamnik,Kamnik,Ljubljana,,,46.22587000,14.61207000,Kamnik;Mekinje;Šmarca,"Kamnik|(46.22587000,14.61207000);Mekinje|(46.23333000,14.61667000);Šmarca|(46.19333000,14.59667000)"
+Slovenia,SI,Kanal ob Soči,Deskle,Ljubljana,,,46.05307000,13.61382000,Deskle;Kanal,"Deskle|(46.05307000,13.61382000);Kanal|(46.08861000,13.63972000)"
+Slovenia,SI,Kidričevo,Kidričevo,Ljubljana,,,46.40361000,15.79111000,Kidričevo,"Kidričevo|(46.40361000,15.79111000)"
+Slovenia,SI,Kobarid,Kobarid,Ljubljana,,,46.24761000,13.57907000,Kobarid,"Kobarid|(46.24761000,13.57907000)"
+Slovenia,SI,Kobilje,Kobilje,Ljubljana,,,46.68472000,16.39778000,Kobilje,"Kobilje|(46.68472000,16.39778000)"
+Slovenia,SI,Kočevje,Kočevje,Ljubljana,,,45.64333000,14.86333000,Kočevje,"Kočevje|(45.64333000,14.86333000)"
+Slovenia,SI,Komen,Komen,Ljubljana,,,45.81528000,13.74833000,Komen,"Komen|(45.81528000,13.74833000)"
+Slovenia,SI,Komenda,Komenda,Ljubljana,,,46.20484000,14.53839000,Komenda;Moste,"Komenda|(46.20484000,14.53839000);Moste|(46.19500000,14.55139000)"
+Slovenia,SI,Koper,Koper,Ljubljana,,,45.54694000,13.72944000,Dekani;Hrvatini;Koper,"Dekani|(45.54972000,13.81361000);Hrvatini|(45.58278000,13.75667000);Koper|(45.54694000,13.72944000)"
+Slovenia,SI,Kostanjevica na Krki,,Ljubljana,,,,,,
+Slovenia,SI,Kostel,Kostel,Ljubljana,,,45.50842000,14.91005000,Kostel,"Kostel|(45.50842000,14.91005000)"
+Slovenia,SI,Kozje,Kozje,Ljubljana,,,46.07500000,15.56028000,Kozje,"Kozje|(46.07500000,15.56028000)"
+Slovenia,SI,Kranj,Kranj,Ljubljana,,,46.23887000,14.35561000,Britof;Golnik;Kokrica,"Britof|(46.26024000,14.39037000);Golnik|(46.33333000,14.33333000);Kokrica|(46.27028000,14.36111000)"
+Slovenia,SI,Kranjska Gora,Kranjska Gora,Ljubljana,,,46.45689000,13.77824000,Kranjska Gora;Mojstrana,"Kranjska Gora|(46.45689000,13.77824000);Mojstrana|(46.42383000,13.87520000)"
+Slovenia,SI,Križevci,Križevci pri Ljutomeru,Ljubljana,,,46.56833000,16.13861000,Križevci pri Ljutomeru,"Križevci pri Ljutomeru|(46.56833000,16.13861000)"
+Slovenia,SI,Krško,Krško,Ljubljana,,,45.95915000,15.49167000,Krško;Leskovec pri Krškem;Senovo,"Krško|(45.95915000,15.49167000);Leskovec pri Krškem|(45.93566000,15.47184000);Senovo|(46.02361000,15.47694000)"
+Slovenia,SI,Kungota,Zgornja Kungota,Ljubljana,,,46.63917000,15.61556000,Zgornja Kungota,"Zgornja Kungota|(46.63917000,15.61556000)"
+Slovenia,SI,Kuzma,Kuzma,Ljubljana,,,46.83694000,16.08333000,Kuzma,"Kuzma|(46.83694000,16.08333000)"
+Slovenia,SI,Laško,Laško,Ljubljana,,,46.15463000,15.23555000,Laško,"Laško|(46.15463000,15.23555000)"
+Slovenia,SI,Lenart,Lenart v Slov. Goricah,Ljubljana,,,46.57611000,15.83139000,Lenart v Slov. Goricah,"Lenart v Slov. Goricah|(46.57611000,15.83139000)"
+Slovenia,SI,Lendava,Lendava,Ljubljana,,,46.56494000,16.45091000,Lendava,"Lendava|(46.56494000,16.45091000)"
+Slovenia,SI,Litija,Litija,Ljubljana,,,46.05861000,14.82250000,Litija,"Litija|(46.05861000,14.82250000)"
+Slovenia,SI,Ljubljana,Ljubljana,Ljubljana,,,46.05108000,14.50513000,Dravlje District;Jarše District;Ljubljana,"Dravlje District|(46.07290000,14.44741000);Jarše District|(46.07345000,14.55431000);Ljubljana|(46.05108000,14.50513000)"
+Slovenia,SI,Ljubno,Ljubno ob Savinji,Ljubljana,,,46.34358000,14.83377000,Ljubno ob Savinji,"Ljubno ob Savinji|(46.34358000,14.83377000)"
+Slovenia,SI,Ljutomer,Ljutomer,Ljubljana,,,46.52083000,16.19750000,Ljutomer,"Ljutomer|(46.52083000,16.19750000)"
+Slovenia,SI,Log–Dragomer,,Ljubljana,,,,,,
+Slovenia,SI,Logatec,Logatec,Ljubljana,,,45.91444000,14.22583000,Logatec,"Logatec|(45.91444000,14.22583000)"
+Slovenia,SI,Loška Dolina,Leskova Dolina,Ljubljana,,,45.62139000,14.46056000,Leskova Dolina,"Leskova Dolina|(45.62139000,14.46056000)"
+Slovenia,SI,Loški Potok,Hrib-Loški Potok,Ljubljana,,,45.70688000,14.61674000,Hrib-Loški Potok,"Hrib-Loški Potok|(45.70688000,14.61674000)"
+Slovenia,SI,Lovrenc na Pohorju,Lovrenc na Pohorju,Ljubljana,,,46.54056000,15.39306000,Lovrenc na Pohorju,"Lovrenc na Pohorju|(46.54056000,15.39306000)"
+Slovenia,SI,Luče,Luče,Ljubljana,,,46.35611000,14.74667000,Luče,"Luče|(46.35611000,14.74667000)"
+Slovenia,SI,Lukovica,Lukovica pri Domžalah,Ljubljana,,,46.16988000,14.69179000,Lukovica pri Domžalah,"Lukovica pri Domžalah|(46.16988000,14.69179000)"
+Slovenia,SI,Majšperk,Majšperk,Ljubljana,,,46.35167000,15.73361000,Majšperk,"Majšperk|(46.35167000,15.73361000)"
+Slovenia,SI,Makole,,Ljubljana,,,,,,
+Slovenia,SI,Maribor,Maribor,Ljubljana,,,46.55472000,15.64667000,Bresternica;Kamnica;Limbuš,"Bresternica|(46.56972000,15.57500000);Kamnica|(46.57444000,15.61417000);Limbuš|(46.55361000,15.58361000)"
+Slovenia,SI,Markovci,Markovci,Ljubljana,,,46.39557000,15.92831000,Markovci,"Markovci|(46.39557000,15.92831000)"
+Slovenia,SI,Medvode,Medvode,Ljubljana,,,46.14220000,14.41114000,Medvode;Opština [historical] Ljubljana-Šiška;Zgornje Pirniče,"Medvode|(46.14220000,14.41114000);Opština [historical] Ljubljana-Šiška|(46.16667000,14.43333000);Zgornje Pirniče|(46.14251000,14.43158000)"
+Slovenia,SI,Mengeš,Mengeš,Ljubljana,,,46.16694000,14.57500000,Mengeš;Preserje pri Radomljah,"Mengeš|(46.16694000,14.57500000);Preserje pri Radomljah|(46.16911000,14.59698000)"
+Slovenia,SI,Metlika,Metlika,Ljubljana,,,45.64722000,15.31417000,Metlika,"Metlika|(45.64722000,15.31417000)"
+Slovenia,SI,Mežica,Mežica,Ljubljana,,,46.52139000,14.85444000,Mežica,"Mežica|(46.52139000,14.85444000)"
+Slovenia,SI,Miklavž na Dravskem Polju,Miklavž na Dravskem Polju,Ljubljana,,,46.50583000,15.69722000,Miklavž na Dravskem Polju,"Miklavž na Dravskem Polju|(46.50583000,15.69722000)"
+Slovenia,SI,Miren–Kostanjevica,Bilje,Ljubljana,,,45.89444000,13.63222000,Bilje;Miren,"Bilje|(45.89444000,13.63222000);Miren|(45.89556000,13.60750000)"
+Slovenia,SI,Mirna,,Ljubljana,,,,,,
+Slovenia,SI,Mirna Peč,Mirna Peč,Ljubljana,,,45.86028000,15.08333000,Mirna Peč,"Mirna Peč|(45.86028000,15.08333000)"
+Slovenia,SI,Mislinja,Mislinja,Ljubljana,,,46.44141000,15.20027000,Mislinja,"Mislinja|(46.44141000,15.20027000)"
+Slovenia,SI,Mokronog–Trebelno,,Ljubljana,,,,,,
+Slovenia,SI,Moravče,Moravče,Ljubljana,,,46.13694000,14.74500000,Moravče,"Moravče|(46.13694000,14.74500000)"
+Slovenia,SI,Moravske Toplice,Moravske Toplice,Ljubljana,,,46.68313000,16.22080000,Moravske Toplice,"Moravske Toplice|(46.68313000,16.22080000)"
+Slovenia,SI,Mozirje,Mozirje,Ljubljana,,,46.33944000,14.96333000,Mozirje,"Mozirje|(46.33944000,14.96333000)"
+Slovenia,SI,Murska Sobota,Murska Sobota,Ljubljana,,,46.66250000,16.16639000,Bakovci;Černelavci;Krog,"Bakovci|(46.61889000,16.15028000);Černelavci|(46.66667000,16.13333000);Krog|(46.63806000,16.14139000)"
+Slovenia,SI,Muta,Muta,Ljubljana,,,46.61139000,15.16611000,Muta,"Muta|(46.61139000,15.16611000)"
+Slovenia,SI,Naklo,Naklo,Ljubljana,,,46.27278000,14.31722000,Naklo,"Naklo|(46.27278000,14.31722000)"
+Slovenia,SI,Nazarje,Nazarje,Ljubljana,,,46.31757000,14.94674000,Nazarje,"Nazarje|(46.31757000,14.94674000)"
+Slovenia,SI,Nova Gorica,Nova Gorica,Ljubljana,,,45.95604000,13.64837000,Kromberk;Nova Gorica;Prvačina,"Kromberk|(45.96083000,13.66556000);Nova Gorica|(45.95604000,13.64837000);Prvačina|(45.89000000,13.71806000)"
+Slovenia,SI,Novo Mesto,Novo Mesto,Ljubljana,,,45.80397000,15.16886000,Novo Mesto,"Novo Mesto|(45.80397000,15.16886000)"
+Slovenia,SI,Odranci,Odranci,Ljubljana,,,46.58667000,16.28028000,Odranci,"Odranci|(46.58667000,16.28028000)"
+Slovenia,SI,Oplotnica,Oplotnica,Ljubljana,,,46.38778000,15.44667000,Oplotnica,"Oplotnica|(46.38778000,15.44667000)"
+Slovenia,SI,Ormož,Ormož,Ljubljana,,,46.41139000,16.15444000,Ormož,"Ormož|(46.41139000,16.15444000)"
+Slovenia,SI,Osilnica,Osilnica,Ljubljana,,,45.52914000,14.69838000,Osilnica,"Osilnica|(45.52914000,14.69838000)"
+Slovenia,SI,Pesnica,Pesnica pri Mariboru,Ljubljana,,,46.60694000,15.67667000,Pesnica pri Mariboru,"Pesnica pri Mariboru|(46.60694000,15.67667000)"
+Slovenia,SI,Piran,Piran,Ljubljana,,,45.52778000,13.57056000,Lucija;Piran;Portorož,"Lucija|(45.50526000,13.60240000);Piran|(45.52778000,13.57056000);Portorož|(45.51429000,13.59206000)"
+Slovenia,SI,Pivka,Pivka,Ljubljana,,,45.68292000,14.19588000,Pivka,"Pivka|(45.68292000,14.19588000)"
+Slovenia,SI,Podčetrtek,Podčetrtek,Ljubljana,,,46.15694000,15.59861000,Podčetrtek,"Podčetrtek|(46.15694000,15.59861000)"
+Slovenia,SI,Podlehnik,Podlehnik,Ljubljana,,,46.33528000,15.88000000,Podlehnik,"Podlehnik|(46.33528000,15.88000000)"
+Slovenia,SI,Podvelka,Podvelka,Ljubljana,,,46.58694000,15.33056000,Podvelka,"Podvelka|(46.58694000,15.33056000)"
+Slovenia,SI,Poljčane,,Ljubljana,,,,,,
+Slovenia,SI,Polzela,Polzela,Ljubljana,,,46.28333000,15.06667000,Polzela,"Polzela|(46.28333000,15.06667000)"
+Slovenia,SI,Postojna,Postojna,Ljubljana,,,45.77435000,14.21528000,Postojna,"Postojna|(45.77435000,14.21528000)"
+Slovenia,SI,Prebold,Prebold,Ljubljana,,,46.23694000,15.09250000,Prebold,"Prebold|(46.23694000,15.09250000)"
+Slovenia,SI,Preddvor,Preddvor,Ljubljana,,,46.30250000,14.42306000,Preddvor,"Preddvor|(46.30250000,14.42306000)"
+Slovenia,SI,Prevalje,Prevalje,Ljubljana,,,46.54694000,14.92083000,Prevalje,"Prevalje|(46.54694000,14.92083000)"
+Slovenia,SI,Ptuj,Ptuj,Ljubljana,,,46.42005000,15.87018000,Ptuj,"Ptuj|(46.42005000,15.87018000)"
+Slovenia,SI,Puconci,Puconci,Ljubljana,,,46.70667000,16.15639000,Puconci,"Puconci|(46.70667000,16.15639000)"
+Slovenia,SI,Rače–Fram,Fram,Ljubljana,,,46.45600000,15.63007000,Fram;Morje;Rače,"Fram|(46.45600000,15.63007000);Morje|(46.44444000,15.62139000);Rače|(46.45194000,15.68139000)"
+Slovenia,SI,Radeče,Radeče,Ljubljana,,,46.06806000,15.18389000,Radeče,"Radeče|(46.06806000,15.18389000)"
+Slovenia,SI,Radenci,Radenci,Ljubljana,,,46.64201000,16.03781000,Radenci,"Radenci|(46.64201000,16.03781000)"
+Slovenia,SI,Radlje ob Dravi,Radlje ob Dravi,Ljubljana,,,46.61417000,15.22639000,Radlje ob Dravi,"Radlje ob Dravi|(46.61417000,15.22639000)"
+Slovenia,SI,Radovljica,Radovljica,Ljubljana,,,46.34444000,14.17444000,Lesce;Radovljica,"Lesce|(46.36111000,14.15778000);Radovljica|(46.34444000,14.17444000)"
+Slovenia,SI,Ravne na Koroškem,Ravne na Koroškem,Ljubljana,,,46.54306000,14.96917000,Kotlje;Ravne na Koroškem,"Kotlje|(46.52139000,14.98694000);Ravne na Koroškem|(46.54306000,14.96917000)"
+Slovenia,SI,Razkrižje,Razkrižje,Ljubljana,,,46.52167000,16.28111000,Razkrižje,"Razkrižje|(46.52167000,16.28111000)"
+Slovenia,SI,Rečica ob Savinji,,Ljubljana,,,,,,
+Slovenia,SI,Renče–Vogrsko,Renče,Ljubljana,,,45.89000000,13.66861000,Renče;Volčja Draga,"Renče|(45.89000000,13.66861000);Volčja Draga|(45.90694000,13.67750000)"
+Slovenia,SI,Ribnica,Ribnica,Ljubljana,,,45.73861000,14.72750000,Ribnica,"Ribnica|(45.73861000,14.72750000)"
+Slovenia,SI,Ribnica na Pohorju,Ribnica na Pohorju,Ljubljana,,,46.53500000,15.27278000,Ribnica na Pohorju,"Ribnica na Pohorju|(46.53500000,15.27278000)"
+Slovenia,SI,Rogaška Slatina,Rogaška Slatina,Ljubljana,,,46.23750000,15.63972000,Rogaška Slatina,"Rogaška Slatina|(46.23750000,15.63972000)"
+Slovenia,SI,Rogašovci,Rogašovci,Ljubljana,,,46.80000000,16.03333000,Rogašovci,"Rogašovci|(46.80000000,16.03333000)"
+Slovenia,SI,Rogatec,Rogatec,Ljubljana,,,46.22944000,15.70028000,Rogatec,"Rogatec|(46.22944000,15.70028000)"
+Slovenia,SI,Ruše,Ruše,Ljubljana,,,46.53944000,15.51583000,Bistrica ob Dravi;Ruše,"Bistrica ob Dravi|(46.55419000,15.54855000);Ruše|(46.53944000,15.51583000)"
+Slovenia,SI,Šalovci,Šalovci,Ljubljana,,,46.82500000,16.29806000,Šalovci,"Šalovci|(46.82500000,16.29806000)"
+Slovenia,SI,Selnica ob Dravi,Selnica ob Dravi,Ljubljana,,,46.55000000,15.49500000,Selnica ob Dravi,"Selnica ob Dravi|(46.55000000,15.49500000)"
+Slovenia,SI,Semič,Semič,Ljubljana,,,45.64611000,15.18222000,Semič,"Semič|(45.64611000,15.18222000)"
+Slovenia,SI,Šempeter–Vrtojba,Rožna Dolina,Ljubljana,,,45.94194000,13.66779000,Rožna Dolina;Šempeter pri Gorici;Vrtojba,"Rožna Dolina|(45.94194000,13.66779000);Šempeter pri Gorici|(45.92750000,13.64111000);Vrtojba|(45.91250000,13.63417000)"
+Slovenia,SI,Šenčur,Šenčur,Ljubljana,,,46.24556000,14.41972000,Hrastje;Šenčur,"Hrastje|(46.21667000,14.40000000);Šenčur|(46.24556000,14.41972000)"
+Slovenia,SI,Šentilj,Selnica ob Muri,Ljubljana,,,46.68333000,15.70000000,Selnica ob Muri;Šentilj v Slov. Goricah,"Selnica ob Muri|(46.68333000,15.70000000);Šentilj v Slov. Goricah|(46.68167000,15.64806000)"
+Slovenia,SI,Šentjernej,Šentjernej,Ljubljana,,,45.84000000,15.33611000,Šentjernej,"Šentjernej|(45.84000000,15.33611000)"
+Slovenia,SI,Šentjur,Šentjur,Ljubljana,,,46.21722000,15.39750000,Šentjur,"Šentjur|(46.21722000,15.39750000)"
+Slovenia,SI,Šentrupert,Šentrupert,Ljubljana,,,45.97778000,15.09556000,Šentrupert,"Šentrupert|(45.97778000,15.09556000)"
+Slovenia,SI,Sevnica,Sevnica,Ljubljana,,,46.00778000,15.31556000,Sevnica,"Sevnica|(46.00778000,15.31556000)"
+Slovenia,SI,Sežana,Sežana,Ljubljana,,,45.70924000,13.87333000,Sežana,"Sežana|(45.70924000,13.87333000)"
+Slovenia,SI,Škocjan,Škocjan,Ljubljana,,,45.90667000,15.29139000,Škocjan,"Škocjan|(45.90667000,15.29139000)"
+Slovenia,SI,Škofja Loka,Škofja Loka,Ljubljana,,,46.16551000,14.30626000,Škofja Loka;Sv. Duh,"Škofja Loka|(46.16551000,14.30626000);Sv. Duh|(46.18333000,14.33333000)"
+Slovenia,SI,Škofljica,Škofljica,Ljubljana,,,45.98333000,14.57667000,Lavrica;Škofljica,"Lavrica|(46.00002000,14.55730000);Škofljica|(45.98333000,14.57667000)"
+Slovenia,SI,Slovenj Gradec,Slovenj Gradec,Ljubljana,,,46.51028000,15.08056000,Legen;Pameče;Slovenj Gradec,"Legen|(46.50651000,15.14424000);Pameče|(46.53417000,15.07917000);Slovenj Gradec|(46.51028000,15.08056000)"
+Slovenia,SI,Slovenska Bistrica,Slovenska Bistrica,Ljubljana,,,46.39278000,15.57444000,Pragersko;Slovenska Bistrica;Zgornja Polskava,"Pragersko|(46.39667000,15.66000000);Slovenska Bistrica|(46.39278000,15.57444000);Zgornja Polskava|(46.42556000,15.61222000)"
+Slovenia,SI,Slovenske Konjice,Slovenske Konjice,Ljubljana,,,46.33667000,15.42583000,Slovenske Konjice,"Slovenske Konjice|(46.33667000,15.42583000)"
+Slovenia,SI,Šmarje pri Jelšah,Šmarje pri Jelšah,Ljubljana,,,46.22722000,15.51917000,Šmarje pri Jelšah,"Šmarje pri Jelšah|(46.22722000,15.51917000)"
+Slovenia,SI,Šmarješke Toplice,Šmarjeta,Ljubljana,,,45.88333000,15.25000000,Šmarjeta,"Šmarjeta|(45.88333000,15.25000000)"
+Slovenia,SI,Šmartno ob Paki,Šmartno ob Paki,Ljubljana,,,46.33333000,15.03333000,Šmartno ob Paki,"Šmartno ob Paki|(46.33333000,15.03333000)"
+Slovenia,SI,Šmartno pri Litiji,Šmartno pri Litiji,Ljubljana,,,46.04444000,14.84417000,Šmartno pri Litiji,"Šmartno pri Litiji|(46.04444000,14.84417000)"
+Slovenia,SI,Sodražica,Sodražica,Ljubljana,,,45.76111000,14.63556000,Sodražica,"Sodražica|(45.76111000,14.63556000)"
+Slovenia,SI,Solčava,Solčava,Ljubljana,,,46.41944000,14.69361000,Solčava,"Solčava|(46.41944000,14.69361000)"
+Slovenia,SI,Šoštanj,Šoštanj,Ljubljana,,,46.38000000,15.04861000,Ravne;Šoštanj;Topolšica,"Ravne|(46.41413000,15.06087000);Šoštanj|(46.38000000,15.04861000);Topolšica|(46.40028000,15.02157000)"
+Slovenia,SI,Središče ob Dravi,Središče ob Dravi,Ljubljana,,,46.39417000,16.26806000,Središče ob Dravi,"Središče ob Dravi|(46.39417000,16.26806000)"
+Slovenia,SI,Starše,Starše,Ljubljana,,,46.46583000,15.76722000,Starše,"Starše|(46.46583000,15.76722000)"
+Slovenia,SI,Štore,Štore,Ljubljana,,,46.22083000,15.31389000,Štore,"Štore|(46.22083000,15.31389000)"
+Slovenia,SI,Straža,Straža,Ljubljana,,,45.78000000,15.07278000,Straža,"Straža|(45.78000000,15.07278000)"
+Slovenia,SI,Sveta Ana,Sv. Ana v Slov. Goricah,Ljubljana,,,46.64917000,15.84417000,Sv. Ana v Slov. Goricah,"Sv. Ana v Slov. Goricah|(46.64917000,15.84417000)"
+Slovenia,SI,Sveta Trojica v Slovenskih Goricah,Sv. Trojica v Slov. Goricah,Ljubljana,,,46.57667000,15.87694000,Sv. Trojica v Slov. Goricah,"Sv. Trojica v Slov. Goricah|(46.57667000,15.87694000)"
+Slovenia,SI,Sveti Andraž v Slovenskih Goricah,Vitomarci,Ljubljana,,,46.52750000,15.93944000,Vitomarci,"Vitomarci|(46.52750000,15.93944000)"
+Slovenia,SI,Sveti Jurij ob Ščavnici,,Ljubljana,,,,,,
+Slovenia,SI,Sveti Jurij v Slovenskih Goricah,Sveti Jurij ob Ščavnici,Ljubljana,,,46.56950000,16.02347000,Sveti Jurij ob Ščavnici,"Sveti Jurij ob Ščavnici|(46.56950000,16.02347000)"
+Slovenia,SI,Sveti Tomaž,Sveti Tomaž,Ljubljana,,,46.48417000,16.08361000,Sveti Tomaž,"Sveti Tomaž|(46.48417000,16.08361000)"
+Slovenia,SI,Tabor,Tabor,Ljubljana,,,46.23611000,15.01833000,Tabor,"Tabor|(46.23611000,15.01833000)"
+Slovenia,SI,Tišina,Tišina,Ljubljana,,,46.65806000,16.09167000,Tišina,"Tišina|(46.65806000,16.09167000)"
+Slovenia,SI,Tolmin,Tolmin,Ljubljana,,,46.18304000,13.73321000,Tolmin,"Tolmin|(46.18304000,13.73321000)"
+Slovenia,SI,Trbovlje,Trbovlje,Ljubljana,,,46.15500000,15.05333000,Trbovlje,"Trbovlje|(46.15500000,15.05333000)"
+Slovenia,SI,Trebnje,Trebnje,Ljubljana,,,45.90417000,15.02167000,Trebnje,"Trebnje|(45.90417000,15.02167000)"
+Slovenia,SI,Trnovska Vas,Trnovska Vas,Ljubljana,,,46.52019000,15.88657000,Trnovska Vas,"Trnovska Vas|(46.52019000,15.88657000)"
+Slovenia,SI,Tržič,Tržič,Ljubljana,,,46.36357000,14.31046000,Bistrica pri Tržiču;Tržič,"Bistrica pri Tržiču|(46.35472000,14.29167000);Tržič|(46.36357000,14.31046000)"
+Slovenia,SI,Trzin,Trzin,Ljubljana,,,46.13333000,14.56667000,Črnuče District;Trzin,"Črnuče District|(46.11506000,14.55371000);Trzin|(46.13333000,14.56667000)"
+Slovenia,SI,Turnišče,Turnišče,Ljubljana,,,46.62778000,16.32028000,Turnišče,"Turnišče|(46.62778000,16.32028000)"
+Slovenia,SI,Velika Polana,Velika Polana,Ljubljana,,,46.57194000,16.34694000,Velika Polana,"Velika Polana|(46.57194000,16.34694000)"
+Slovenia,SI,Velike Lašče,Velike Lašče,Ljubljana,,,45.83222000,14.63639000,Velike Lašče,"Velike Lašče|(45.83222000,14.63639000)"
+Slovenia,SI,Veržej,Veržej,Ljubljana,,,46.58361000,16.16528000,Veržej,"Veržej|(46.58361000,16.16528000)"
+Slovenia,SI,Videm,Videm pri Ptuju,Ljubljana,,,46.36861000,15.90639000,Videm pri Ptuju,"Videm pri Ptuju|(46.36861000,15.90639000)"
+Slovenia,SI,Vipava,Vipava,Ljubljana,,,45.84667000,13.96306000,Vipava,"Vipava|(45.84667000,13.96306000)"
+Slovenia,SI,Vitanje,Vitanje,Ljubljana,,,46.38167000,15.29583000,Vitanje,"Vitanje|(46.38167000,15.29583000)"
+Slovenia,SI,Vodice,Vodice,Ljubljana,,,46.18987000,14.49492000,Vodice,"Vodice|(46.18987000,14.49492000)"
+Slovenia,SI,Vojnik,Vojnik,Ljubljana,,,46.29333000,15.30333000,Vojnik,"Vojnik|(46.29333000,15.30333000)"
+Slovenia,SI,Vransko,Vransko,Ljubljana,,,46.24389000,14.95139000,Vransko,"Vransko|(46.24389000,14.95139000)"
+Slovenia,SI,Vrhnika,Vrhnika,Ljubljana,,,45.96350000,14.29484000,Verd;Vrhnika,"Verd|(45.95667000,14.30583000);Vrhnika|(45.96350000,14.29484000)"
+Slovenia,SI,Vuzenica,Vuzenica,Ljubljana,,,46.59639000,15.16722000,Vuzenica,"Vuzenica|(46.59639000,15.16722000)"
+Slovenia,SI,Zagorje ob Savi,Zagorje ob Savi,Ljubljana,,,46.13179000,14.99694000,Izlake;Kisovec;Zagorje ob Savi,"Izlake|(46.15000000,14.95000000);Kisovec|(46.13911000,14.96295000);Zagorje ob Savi|(46.13179000,14.99694000)"
+Slovenia,SI,Žalec,Žalec,Ljubljana,,,46.25151000,15.16482000,Gotovlje;Šempeter v Savinj. Dolini;Zabukovica,"Gotovlje|(46.27418000,15.15186000);Šempeter v Savinj. Dolini|(46.25639000,15.12194000);Zabukovica|(46.21408000,15.15954000)"
+Slovenia,SI,Zavrč,Zavrč,Ljubljana,,,46.39167000,16.04972000,Zavrč,"Zavrč|(46.39167000,16.04972000)"
+Slovenia,SI,Železniki,Železniki,Ljubljana,,,46.22482000,14.17205000,Železniki,"Železniki|(46.22482000,14.17205000)"
+Slovenia,SI,Žetale,Žetale,Ljubljana,,,46.27356000,15.82658000,Žetale,"Žetale|(46.27356000,15.82658000)"
+Slovenia,SI,Žiri,Žiri,Ljubljana,,,46.04222000,14.10722000,Žiri,"Žiri|(46.04222000,14.10722000)"
+Slovenia,SI,Žirovnica,Žirovnica,Ljubljana,,,46.40472000,14.14000000,Žirovnica,"Žirovnica|(46.40472000,14.14000000)"
+Slovenia,SI,Zreče,Zreče,Ljubljana,,,46.38222000,15.37917000,Zreče,"Zreče|(46.38222000,15.37917000)"
+Slovenia,SI,Žužemberk,Žužemberk,Ljubljana,,,45.83389000,14.92917000,Žužemberk,"Žužemberk|(45.83389000,14.92917000)"
+Solomon Islands,SB,Central,Tulagi,Honiara,,,-9.10306000,160.15056000,Tulagi,"Tulagi|(-9.10306000,160.15056000)"
+Solomon Islands,SB,Choiseul,,Honiara,,,,,,
+Solomon Islands,SB,Guadalcanal,Honiara,Honiara,,,-9.43333000,159.95000000,Honiara,"Honiara|(-9.43333000,159.95000000)"
+Solomon Islands,SB,Honiara,,Honiara,,,,,,
+Solomon Islands,SB,Isabel,Buala,Honiara,,,-8.14497000,159.59212000,Buala,"Buala|(-8.14497000,159.59212000)"
+Solomon Islands,SB,Makira-Ulawa,Kirakira,Honiara,,,-10.45442000,161.92045000,Kirakira,"Kirakira|(-10.45442000,161.92045000)"
+Solomon Islands,SB,Malaita,Auki,Honiara,,,-8.76778000,160.69778000,Auki,"Auki|(-8.76778000,160.69778000)"
+Solomon Islands,SB,Rennell and Bellona,,Honiara,,,,,,
+Solomon Islands,SB,Temotu,Lata,Honiara,,,-10.72500000,165.79722000,Lata,"Lata|(-10.72500000,165.79722000)"
+Solomon Islands,SB,Western,Gizo,Honiara,,,-8.10303000,156.84186000,Gizo,"Gizo|(-8.10303000,156.84186000)"
+Somalia,SO,Awdal,,Mogadishu,,,,,,
+Somalia,SO,Bakool,Tayeeglow,Mogadishu,,,4.01897000,44.51111000,Tayeeglow;Waajid;Xuddur,"Tayeeglow|(4.01897000,44.51111000);Waajid|(3.80958000,43.24627000);Xuddur|(4.12129000,43.88945000)"
+Somalia,SO,Banaadir,Mogadishu,Mogadishu,,,2.03711000,45.34375000,Mogadishu,"Mogadishu|(2.03711000,45.34375000)"
+Somalia,SO,Bari,Bandarbeyla,Mogadishu,,,9.49420000,50.81220000,Bandarbeyla;Bargaal;Bereeda,"Bandarbeyla|(9.49420000,50.81220000);Bargaal|(11.28636000,51.07730000);Bereeda|(11.87037000,51.05795000)"
+Somalia,SO,Bay,Baidoa,Mogadishu,,,3.11383000,43.64980000,Baidoa;Buurhakaba,"Baidoa|(3.11383000,43.64980000);Buurhakaba|(2.80257000,44.07805000)"
+Somalia,SO,Galguduud,Ceelbuur,Mogadishu,,,4.68501000,46.61760000,Ceelbuur;Ceeldheer;Dhuusamarreeb,"Ceelbuur|(4.68501000,46.61760000);Ceeldheer|(3.84878000,47.18064000);Dhuusamarreeb|(5.53597000,46.38666000)"
+Somalia,SO,Gedo,Baardheere,Mogadishu,,,2.34464000,42.27644000,Baardheere;Garbahaarrey;Luuq,"Baardheere|(2.34464000,42.27644000);Garbahaarrey|(3.32892000,42.22091000);Luuq|(3.80315000,42.54417000)"
+Somalia,SO,Hiran,Beledweyne,Mogadishu,,,4.73583000,45.20361000,Beledweyne;Buulobarde;Jalalaqsi,"Beledweyne|(4.73583000,45.20361000);Buulobarde|(3.85375000,45.56744000);Jalalaqsi|(3.37660000,45.59960000)"
+Somalia,SO,Lower Juba,Buur Gaabo,Mogadishu,,,-1.21917000,41.83725000,Buur Gaabo;Jamaame;Kismayo,"Buur Gaabo|(-1.21917000,41.83725000);Jamaame|(0.06968000,42.74497000);Kismayo|(-0.35817000,42.54536000)"
+Somalia,SO,Lower Shebelle,Afgooye,Mogadishu,,,2.13810000,45.12120000,Afgooye;Marka;Qoryooley,"Afgooye|(2.13810000,45.12120000);Marka|(1.71594000,44.77166000);Qoryooley|(1.78784000,44.52999000)"
+Somalia,SO,Middle Juba,Dujuuma,Mogadishu,,,1.25311000,42.57377000,Dujuuma;Jilib;Saacow,"Dujuuma|(1.25311000,42.57377000);Jilib|(0.48829000,42.78535000);Saacow|(1.62794000,42.44067000)"
+Somalia,SO,Middle Shebelle,Cadale,Mogadishu,,,2.76030000,46.32220000,Cadale;Jawhar;Mahaddayweyne,"Cadale|(2.76030000,46.32220000);Jawhar|(2.78087000,45.50048000);Mahaddayweyne|(2.97260000,45.53470000)"
+Somalia,SO,Mudug,Gaalkacyo,Mogadishu,,,6.76972000,47.43083000,Gaalkacyo;Hobyo;Xarardheere,"Gaalkacyo|(6.76972000,47.43083000);Hobyo|(5.35050000,48.52680000);Xarardheere|(4.65440000,47.85750000)"
+Somalia,SO,Nugal,Eyl,Mogadishu,,,7.98030000,49.81640000,Eyl;Garoowe,"Eyl|(7.98030000,49.81640000);Garoowe|(8.40207000,48.48284000)"
+Somalia,SO,Sanaag,Ceerigaabo,Mogadishu,,,10.61616000,47.36795000,Ceerigaabo;Las Khorey,"Ceerigaabo|(10.61616000,47.36795000);Las Khorey|(11.15950000,48.19670000)"
+Somalia,SO,Togdheer,Burao,Mogadishu,,,9.52213000,45.53363000,Burao;Ceek;Oodweyne,"Burao|(9.52213000,45.53363000);Ceek|(8.99907000,45.35824000);Oodweyne|(9.40920000,45.06397000)"
+South Africa,ZA,Eastern Cape,Adelaide,Pretoria,,,-32.70747000,26.29564000,Adelaide;Alfred Nzo District Municipality;Alice,"Adelaide|(-32.70747000,26.29564000);Alfred Nzo District Municipality|(-30.66803000,29.15490000);Alice|(-32.78749000,26.83440000)"
+South Africa,ZA,Free State,Allanridge,Pretoria,,,-27.75431000,26.64382000,Allanridge;Bethlehem;Bloemfontein,"Allanridge|(-27.75431000,26.64382000);Bethlehem|(-28.23078000,28.30707000);Bloemfontein|(-29.12107000,26.21400000)"
+South Africa,ZA,Gauteng,Alberton,Pretoria,,,-26.26786000,28.12225000,Alberton;Benoni;Boksburg,"Alberton|(-26.26786000,28.12225000);Benoni|(-26.18848000,28.32078000);Boksburg|(-26.21197000,28.25958000)"
+South Africa,ZA,KwaZulu-Natal,Amajuba District Municipality,Pretoria,,,-27.73558000,30.13537000,Amajuba District Municipality;Ballito;Berea,"Amajuba District Municipality|(-27.73558000,30.13537000);Ballito|(-29.53897000,31.21439000);Berea|(-29.85185000,30.99337000)"
+South Africa,ZA,Limpopo,Bochum,Pretoria,,,-23.28609000,29.13964000,Bochum;Capricorn District Municipality;Duiwelskloof,"Bochum|(-23.28609000,29.13964000);Capricorn District Municipality|(-23.48163000,29.18350000);Duiwelskloof|(-23.69339000,30.14002000)"
+South Africa,ZA,Mpumalanga,Balfour,Pretoria,,,-26.66331000,28.59016000,Balfour;Barberton;Belfast,"Balfour|(-26.66331000,28.59016000);Barberton|(-25.78842000,31.05319000);Belfast|(-25.68991000,30.03504000)"
+South Africa,ZA,North West,Bloemhof,Pretoria,,,-27.64685000,25.60697000,Bloemhof;Bojanala Platinum District Municipality;Brits,"Bloemhof|(-27.64685000,25.60697000);Bojanala Platinum District Municipality|(-25.42612000,27.22430000);Brits|(-25.63473000,27.78022000)"
+South Africa,ZA,Northern Cape,Barkly West,Pretoria,,,-28.53537000,24.52151000,Barkly West;Brandvlei;Calvinia,"Barkly West|(-28.53537000,24.52151000);Brandvlei|(-30.46532000,20.48659000);Calvinia|(-31.47069000,19.77601000)"
+South Africa,ZA,Western Cape,Albertina,Pretoria,,,-34.20544000,21.58001000,Albertina;Arniston;Atlantis,"Albertina|(-34.20544000,21.58001000);Arniston|(-34.66739000,20.23086000);Atlantis|(-33.56668000,18.48335000)"
+South Korea,KR,Busan,Busan,Seoul,,,35.10168000,129.03004000,Buk-gu;Busan;Dongnae-gu,"Buk-gu|(35.19724000,128.99134000);Busan|(35.10168000,129.03004000);Dongnae-gu|(35.20447000,129.07800000)"
+South Korea,KR,Daegu,Daegu,Seoul,,,35.87028000,128.59111000,Daegu;Dalseo-gu;Dalseong-gun,"Daegu|(35.87028000,128.59111000);Dalseo-gu|(35.82569000,128.52403000);Dalseong-gun|(35.77467000,128.42955000)"
+South Korea,KR,Daejeon,Daejeon,Seoul,,,36.34913000,127.38493000,Daejeon;Seo-gu;Sintansin,"Daejeon|(36.34913000,127.38493000);Seo-gu|(36.27211000,127.33100000);Sintansin|(36.45361000,127.43111000)"
+South Korea,KR,Gangwon,Cheorwon-gun,Seoul,,,38.24391000,127.44522000,Cheorwon-gun;Chuncheon;Chuncheon-si,"Cheorwon-gun|(38.24391000,127.44522000);Chuncheon|(37.87472000,127.73417000);Chuncheon-si|(37.88048000,127.72776000)"
+South Korea,KR,Gwangju,Gwangju,Seoul,,,35.15472000,126.91556000,Gwangju;Gwangsan-gu;Masan,"Gwangju|(35.15472000,126.91556000);Gwangsan-gu|(35.16158000,126.80810000);Masan|(35.12725000,126.83149000)"
+South Korea,KR,Gyeonggi,Ansan-si,Seoul,,,37.32361000,126.82194000,Ansan-si;Anseong;Anyang-si,"Ansan-si|(37.32361000,126.82194000);Anseong|(37.01083000,127.27028000);Anyang-si|(37.39250000,126.92694000)"
+South Korea,KR,Incheon,Incheon,Seoul,,,37.45646000,126.70515000,Bupyeong-gu;Incheon;Michuhol,"Bupyeong-gu|(37.49720000,126.71107000);Incheon|(37.45646000,126.70515000);Michuhol|(37.46362000,126.65000000)"
+South Korea,KR,Jeju,Gaigeturi,Seoul,,,33.46444000,126.31833000,Gaigeturi;Jeju City;Jeju-si,"Gaigeturi|(33.46444000,126.31833000);Jeju City|(33.50972000,126.52194000);Jeju-si|(33.45578000,126.53928000)"
+South Korea,KR,North Chungcheong,Boeun-gun,Seoul,,,36.49489000,127.72865000,Boeun-gun;Cheongju-si;Chinch'ŏn,"Boeun-gun|(36.49489000,127.72865000);Cheongju-si|(36.63722000,127.48972000);Chinch'ŏn|(36.85667000,127.44333000)"
+South Korea,KR,North Gyeongsang,Andong,Seoul,,,36.56636000,128.72275000,Andong;Andong-si;Bonghwa-gun,"Andong|(36.56636000,128.72275000);Andong-si|(36.56667000,128.71667000);Bonghwa-gun|(36.88951000,128.73573000)"
+South Korea,KR,North Jeolla,Buan-gun,Seoul,,,35.70000000,126.66667000,Buan-gun;Changsu;Gimje-si,"Buan-gun|(35.70000000,126.66667000);Changsu|(35.64842000,127.51523000);Gimje-si|(35.80701000,126.90755000)"
+South Korea,KR,Sejong City,Sejong,Seoul,,,36.59245000,127.29223000,Sejong,"Sejong|(36.59245000,127.29223000)"
+South Korea,KR,Seoul,Seoul,Seoul,,,37.56600000,126.97840000,Dobong-gu;Dongdaemun-gu;Dongjak-gu,"Dobong-gu|(37.65066000,127.03011000);Dongdaemun-gu|(37.58189000,127.05408000);Dongjak-gu|(37.50056000,126.95149000)"
+South Korea,KR,South Chungcheong,Asan,Seoul,,,36.78361000,127.00417000,Asan;Asan-si;Boryeong,"Asan|(36.78361000,127.00417000);Asan-si|(36.80791000,126.97769000);Boryeong|(36.34931000,126.59772000)"
+South Korea,KR,South Gyeongsang,Changnyeong,Seoul,,,35.54145000,128.49506000,Changnyeong;Changnyeong-gun;Changwon,"Changnyeong|(35.54145000,128.49506000);Changnyeong-gun|(35.50822000,128.49020000);Changwon|(35.22806000,128.68111000)"
+South Korea,KR,South Jeolla,Beolgyo,Seoul,,,34.84897000,127.34052000,Beolgyo;Boseong-gun;Damyang-gun,"Beolgyo|(34.84897000,127.34052000);Boseong-gun|(34.84622000,127.22189000);Damyang-gun|(35.33976000,126.99125000)"
+South Korea,KR,Ulsan,Ulsan,Seoul,,,35.53722000,129.31667000,Buk-gu;Dong-gu;Jung-gu,"Buk-gu|(35.58243000,129.36049000);Dong-gu|(35.50470000,129.41860000);Jung-gu|(35.56840000,129.33226000)"
+South Sudan,SS,Central Equatoria,,Juba,,,,,,
+South Sudan,SS,Eastern Equatoria,,Juba,,,,,,
+South Sudan,SS,Jonglei State,,Juba,,,,,,
+South Sudan,SS,Lakes,Yirol,Juba,,,6.55250000,30.49806000,Yirol,"Yirol|(6.55250000,30.49806000)"
+South Sudan,SS,Northern Bahr el Ghazal,,Juba,,,,,,
+South Sudan,SS,Unity,,Juba,,,,,,
+South Sudan,SS,Upper Nile,,Juba,,,,,,
+South Sudan,SS,Warrap,,Juba,,,,,,
+South Sudan,SS,Western Bahr el Ghazal,,Juba,,,,,,
+South Sudan,SS,Western Equatoria,,Juba,,,,,,
+Spain,ES,A Coruña,Abegondo,Madrid,,,43.21667000,-8.28333000,Abegondo;Amés;Aranga,"Abegondo|(43.21667000,-8.28333000);Amés|(42.90426000,-8.65551000);Aranga|(43.23469000,-8.01705000)"
+Spain,ES,Albacete,Albacete,Madrid,,,38.99439830,-1.86017300,Abengibre;Alatoz;Albacete,"Abengibre|(39.21050490,-1.54144360);Alatoz|(39.09504990,-1.36199520);Albacete|(38.99439830,-1.86017300)"
+Spain,ES,Alicante,Adsubia,Madrid,,,38.84819000,-0.15324000,Adsubia;Agost;Agres,"Adsubia|(38.84819000,-0.15324000);Agost|(38.44003000,-0.63836000);Agres|(38.78333000,-0.51667000)"
+Spain,ES,Almeria,Abla,Madrid,,,37.14245000,-2.77808000,Abla;Abrucena;Adra,"Abla|(37.14245000,-2.77808000);Abrucena|(37.13226000,-2.79711000);Adra|(36.74961000,-3.02055000)"
+Spain,ES,Andalusia,,Madrid,,,,,,
+Spain,ES,Araba,Alegría-Dulantzi,Madrid,,,42.84409400,-2.51195500,Alegría-Dulantzi;Amurrio;Añana,"Alegría-Dulantzi|(42.84409400,-2.51195500);Amurrio|(43.05000000,-3.00000000);Añana|(42.81518910,-2.98755650)"
+Spain,ES,Aragon,,Madrid,,,,,,
+Spain,ES,Asturias,,Madrid,,,,,,
+Spain,ES,Asturias,Allande,Madrid,,,43.24883760,-6.70659140,Allande;Aller;Amieva,"Allande|(43.24883760,-6.70659140);Aller|(43.14970190,-5.68787360);Amieva|(43.24428340,-5.07244540)"
+Spain,ES,Ávila,Ávila,Madrid,,,40.65724000,-4.69951000,Adanero;Adrada La;Albornos,"Adanero|(40.94487000,-4.60561000);Adrada La|(40.29955820,-4.63653420);Albornos|(40.83795000,-4.88129000)"
+Spain,ES,Badajoz,Badajoz,Madrid,,,38.87789000,-6.97061000,Acedera;Aceuchal;Ahillones,"Acedera|(39.07678000,-5.57384000);Aceuchal|(38.64627000,-6.48636000);Ahillones|(38.26667000,-5.85000000)"
+Spain,ES,Balearic Islands,,Madrid,,,,,,
+Spain,ES,Barcelona,Barcelona,Madrid,,,41.38879000,2.15899000,Abrera;Aguilar de Segarra;Aiguafreda,"Abrera|(41.51682000,1.90100000);Aguilar de Segarra|(41.74822000,1.62919000);Aiguafreda|(41.76807000,2.25051000)"
+Spain,ES,Basque Country,,Madrid,,,,,,
+Spain,ES,Bizkaia,Abadiño,Madrid,,,43.15102980,-2.61126240,Abadiño;Abanto y Ciérvana-Abanto Zierbena;Ajangiz,"Abadiño|(43.15102980,-2.61126240);Abanto y Ciérvana-Abanto Zierbena|(43.31687940,-3.08767830);Ajangiz|(43.30337950,-2.66360660)"
+Spain,ES,Burgos,Burgos,Madrid,,,42.34106000,-3.70184000,Abajas;Adrada de Haza;Aguas Cándidas,"Abajas|(42.62310000,-3.58086000);Adrada de Haza|(41.59454000,-3.82327000);Aguas Cándidas|(42.71617380,-3.50318810)"
+Spain,ES,Caceres,Abadía,Madrid,,,40.25922000,-5.97828000,Abadía;Abertura;Acebo,"Abadía|(40.25922000,-5.97828000);Abertura|(39.24352000,-5.81394000);Acebo|(40.20105000,-6.71689000)"
+Spain,ES,Cádiz,Alcalá de los Gazules,Madrid,,,36.46212000,-5.72382000,Alcalá de los Gazules;Alcalá del Valle;Algar,"Alcalá de los Gazules|(36.46212000,-5.72382000);Alcalá del Valle|(36.90448000,-5.17240000);Algar|(36.65748000,-5.65558000)"
+Spain,ES,Canary Islands,,Madrid,,,,,,
+Spain,ES,Cantabria,,Madrid,,,,,,
+Spain,ES,Cantabria,Alfoz de Lloredo,Madrid,,,43.37858300,-4.18209610,Alfoz de Lloredo;Ampuero;Anievas,"Alfoz de Lloredo|(43.37858300,-4.18209610);Ampuero|(43.34268000,-3.41667000);Anievas|(43.19215360,-3.99804850)"
+Spain,ES,Castellón,Aín,Madrid,,,39.90015430,-0.34101070,Aín;Albocàsser;Alcalà de Xivert,"Aín|(39.90015430,-0.34101070);Albocàsser|(40.35000000,0.03333000);Alcalà de Xivert|(40.30000000,0.23333000)"
+Spain,ES,Castile and Leon,,Madrid,,,,,,
+Spain,ES,Castilla-La Mancha,,Madrid,,,,,,
+Spain,ES,Catalonia,,Madrid,,,,,,
+Spain,ES,Ceuta,,Madrid,,,,,,
+Spain,ES,Ciudad Real,Ciudad Real,Madrid,,,38.98626000,-3.92907000,Abenójar;Agudo;Alamillo,"Abenójar|(38.88032000,-4.35702000);Agudo|(38.98183000,-4.87133000);Alamillo|(38.67842000,-4.79008000)"
+Spain,ES,Community of Madrid,,Madrid,,,,,,
+Spain,ES,Córdoba,Córdoba,Madrid,,,37.89155000,-4.77275000,Adamuz;Aguilar de la Frontera;Alcaracejos,"Adamuz|(38.02674000,-4.52231000);Aguilar de la Frontera|(37.48289080,-4.66570270);Alcaracejos|(38.38333000,-4.96667000)"
+Spain,ES,Cuenca,Cuenca,Madrid,,,40.06667000,-2.13333000,Abia de la Obispalía;Acebrón El;Alarcón,"Abia de la Obispalía|(40.01863040,-2.39536820);Acebrón El|(39.90894430,-2.98443110);Alarcón|(39.55000000,-2.08333000)"
+Spain,ES,Estremadura,,Madrid,,,,,,
+Spain,ES,Galicia,,Madrid,,,,,,
+Spain,ES,Gipuzkoa,Abaltzisketa,Madrid,,,43.04844360,-2.10544830,Abaltzisketa;Aduna;Aia,"Abaltzisketa|(43.04844360,-2.10544830);Aduna|(43.20375000,-2.05033000);Aia|(43.23721000,-2.14833000)"
+Spain,ES,Girona,Girona,Madrid,,,41.98311000,2.82493000,Agullana;Aiguaviva;Albanyà,"Agullana|(42.39408000,2.84666000);Aiguaviva|(41.93840000,2.76217000);Albanyà|(42.30478540,2.72044830)"
+Spain,ES,Granada,Granada,Madrid,,,37.18817000,-3.60667000,Agrón;Alamedilla;Albolote,"Agrón|(37.03023000,-3.82870000);Alamedilla|(37.58232000,-3.24241000);Albolote|(37.23088000,-3.65510000)"
+Spain,ES,Guadalajara,Guadalajara,Madrid,,,40.62862000,-3.16185000,Abánades;Ablanque;Adobes,"Abánades|(40.89261000,-2.48526000);Ablanque|(40.89818000,-2.22523000);Adobes|(40.67584000,-1.67916000)"
+Spain,ES,Huelva,Huelva,Madrid,,,37.26638000,-6.94004000,Alájar;Aljaraque;Almendro El,"Alájar|(37.87408000,-6.66536000);Aljaraque|(37.26989000,-7.02313000);Almendro El|(37.50732000,-7.26966440)"
+Spain,ES,Huesca,Huesca,Madrid,,,42.13615000,-0.40870000,Abiego;Abizanda;Adahuesca,"Abiego|(42.12094000,-0.06873000);Abizanda|(42.24236000,0.19717000);Adahuesca|(42.14610000,-0.00804000)"
+Spain,ES,Islas Baleares,Alaior,Madrid,,,39.93034000,4.14039000,Alaior;Alaró;Alcúdia,"Alaior|(39.93034000,4.14039000);Alaró|(39.70441000,2.79181000);Alcúdia|(39.85316000,3.12138000)"
+Spain,ES,Jaén,Jaén,Madrid,,,37.76922000,-3.79028000,Albanchez de Mágina;Alcalá la Real;Alcaudete,"Albanchez de Mágina|(37.79188780,-3.46812120);Alcalá la Real|(37.46140000,-3.92301000);Alcaudete|(37.59091000,-4.08237000)"
+Spain,ES,La Rioja,,Madrid,,,,,,
+Spain,ES,La Rioja,Ábalos,Madrid,,,42.57154000,-2.70956000,Ábalos;Agoncillo;Aguilar del Río Alhama,"Ábalos|(42.57154000,-2.70956000);Agoncillo|(42.44667000,-2.28980000);Aguilar del Río Alhama|(41.96212000,-1.99340000)"
+Spain,ES,Las Palmas,Agaete,Madrid,,,28.10023000,-15.69998000,Agaete;Agüimes;Aldea de San Nicolás La,"Agaete|(28.10023000,-15.69998000);Agüimes|(27.90539000,-15.44609000);Aldea de San Nicolás La|(27.98222180,-15.77937410)"
+Spain,ES,León,León,Madrid,,,42.60003000,-5.57032000,Acebedo;Algadefe;Alija del Infantado,"Acebedo|(43.03969000,-5.11600000);Algadefe|(42.21931000,-5.58419000);Alija del Infantado|(42.13870900,-5.83406510)"
+Spain,ES,Lleida,Lleida,Madrid,,,41.61674000,0.62218000,Abella de la Conca;Àger;Agramunt,"Abella de la Conca|(42.16150740,1.09199750);Àger|(42.00000000,0.76667000);Agramunt|(41.78686000,1.09683000)"
+Spain,ES,Lugo,Lugo,Madrid,,,43.00992000,-7.55602000,Abadín;Alfoz;Antas de Ulla,"Abadín|(43.36667000,-7.48333000);Alfoz|(43.50188580,-7.42731950);Antas de Ulla|(43.00991000,-7.55886000)"
+Spain,ES,Madrid,Madrid,Madrid,,,40.41650000,-3.70256000,Acebeda La;Ajalvir;Alameda del Valle,"Acebeda La|(41.08637910,-3.62384900);Ajalvir|(40.53205000,-3.47841000);Alameda del Valle|(40.91870000,-3.84243000)"
+Spain,ES,Málaga,Málaga,Madrid,,,36.72016000,-4.42034000,Alameda;Alcaucín;Alfarnate,"Alameda|(37.20870000,-4.65860000);Alcaucín|(36.90301000,-4.11406000);Alfarnate|(36.99426000,-4.25929000)"
+Spain,ES,Melilla,,Madrid,,,,,,
+Spain,ES,Murcia,Murcia,Madrid,,,37.98662000,-1.14146000,Abanilla;Abarán;Águilas,"Abanilla|(38.20537000,-1.04153000);Abarán|(38.20551000,-1.39907000);Águilas|(37.40630000,-1.58289000)"
+Spain,ES,Navarra,Abáigar,Madrid,,,42.64823000,-2.14182000,Abáigar;Abárzuza/Abartzuza;Abaurregaina/Abaurrea Alta,"Abáigar|(42.64823000,-2.14182000);Abárzuza/Abartzuza|(42.72684650,-2.02165970);Abaurregaina/Abaurrea Alta|(42.90307740,-1.21032990)"
+Spain,ES,Navarre,,Madrid,,,,,,
+Spain,ES,Ourense,Ourense,Madrid,,,42.33669000,-7.86407000,Allariz;Ambía;Amoeiro,"Allariz|(42.19044000,-7.80175000);Ambía|(42.20578000,-7.73707000);Amoeiro|(42.41667000,-7.95000000)"
+Spain,ES,Palencia,Palencia,Madrid,,,42.00955000,-4.52406000,Abarca de Campos;Abia de las Torres;Aguilar de Campoo,"Abarca de Campos|(42.06249640,-4.84136960);Abia de las Torres|(42.42016000,-4.42131000);Aguilar de Campoo|(42.79452000,-4.25892000)"
+Spain,ES,Pontevedra,Pontevedra,Madrid,,,42.43100000,-8.64435000,Agolada;Arbo;Baiona,"Agolada|(42.76170210,-8.02061040);Arbo|(42.11667000,-8.31667000);Baiona|(42.11667000,-8.85000000)"
+Spain,ES,Region of Murcia,,Madrid,,,,,,
+Spain,ES,Salamanca,Salamanca,Madrid,,,40.96882000,-5.66388000,Abusejo;Agallas;Ahigal de los Aceiteros,"Abusejo|(40.70900000,-6.14074000);Agallas|(40.44867000,-6.44176000);Ahigal de los Aceiteros|(40.87231000,-6.74702000)"
+Spain,ES,Santa Cruz de Tenerife,Santa Cruz de Tenerife,Madrid,,,28.46824000,-16.25462000,Adeje;Agulo;Alajeró,"Adeje|(28.12271000,-16.72600000);Agulo|(28.18778000,-17.19678000);Alajeró|(28.06205000,-17.24073000)"
+Spain,ES,Segovia,Segovia,Madrid,,,40.94808000,-4.11839000,Abades;Adrada de Pirón;Adrados,"Abades|(40.91646000,-4.26937000);Adrada de Pirón|(41.05257000,-4.05107000);Adrados|(41.36816000,-4.11186000)"
+Spain,ES,Sevilla,Sevilla,Madrid,,,37.38283000,-5.97317000,Aguadulce;Alanís;Albaida del Aljarafe,"Aguadulce|(37.25273000,-4.99269000);Alanís|(38.03333000,-5.71667000);Albaida del Aljarafe|(37.42354000,-6.16675000)"
+Spain,ES,Soria,Soria,Madrid,,,41.76401000,-2.46883000,Abejar;Adradas;Ágreda,"Abejar|(41.80755000,-2.78407000);Adradas|(41.35098000,-2.47373000);Ágreda|(41.85588000,-1.92244000)"
+Spain,ES,Tarragona,Tarragona,Madrid,,,41.11667000,1.25000000,Aiguamúrcia;Albinyana;Albiol,"Aiguamúrcia|(41.32962240,1.35867930);Albinyana|(41.24498070,1.48623900);Albiol|(41.25203050,1.08960140)"
+Spain,ES,Teruel,Teruel,Madrid,,,40.34560000,-1.10646000,Ababuj;Abejuela;Aguatón,"Ababuj|(40.54908000,-0.80758000);Abejuela|(39.91007410,-0.89343890);Aguatón|(40.67158000,-1.23475000)"
+Spain,ES,Toledo,Toledo,Madrid,,,39.85810000,-4.02263000,Ajofrín;Alameda de la Sagra;Albarreal de Tajo,"Ajofrín|(39.71088000,-3.98220000);Alameda de la Sagra|(40.01287580,-3.79558650);Albarreal de Tajo|(39.89698000,-4.22895000)"
+Spain,ES,Valencia,Valencia,Madrid,,,39.46975000,-0.37739000,Ademuz;Ador;Adzaneta,"Ademuz|(40.06139000,-1.28677000);Ador|(38.91823000,-0.22247000);Adzaneta|(40.21616000,-0.17028000)"
+Spain,ES,Valencian Community,,Madrid,,,,,,
+Spain,ES,Valladolid,Valladolid,Madrid,,,41.65518000,-4.72372000,Adalia;Aguasal;Aguilar de Campos,"Adalia|(41.64894000,-5.12107000);Aguasal|(41.27495000,-4.65290000);Aguilar de Campos|(41.98375000,-5.18117000)"
+Spain,ES,Zamora,Zamora,Madrid,,,41.50633000,-5.74456000,Abezames;Alcañices;Alcubilla de Nogales,"Abezames|(41.62642000,-5.42577000);Alcañices|(41.69940000,-6.34647000);Alcubilla de Nogales|(42.12787000,-5.92184000)"
+Spain,ES,Zaragoza,Zaragoza,Madrid,,,41.65606000,-0.87734000,Abanto;Acered;Agón,"Abanto|(41.13751000,-1.69818000);Acered|(41.17113740,-1.60385270);Agón|(41.85574000,-1.45233000)"
+Sri Lanka,LK,Ampara,,Colombo,,,,,,
+Sri Lanka,LK,Anuradhapura,,Colombo,,,,,,
+Sri Lanka,LK,Badulla,,Colombo,,,,,,
+Sri Lanka,LK,Batticaloa,,Colombo,,,,,,
+Sri Lanka,LK,Central,Dambulla,Colombo,,,7.86000000,80.65167000,Dambulla;Hatton;Kandy,"Dambulla|(7.86000000,80.65167000);Hatton|(6.89160000,80.59550000);Kandy|(7.29060000,80.63360000)"
+Sri Lanka,LK,Colombo,Dehiwala-Mount Lavinia,Colombo,,,6.84019000,79.87116000,Dehiwala-Mount Lavinia;Homagama;Kaduwela,"Dehiwala-Mount Lavinia|(6.84019000,79.87116000);Homagama|(6.84879896,80.00467300);Kaduwela|(6.93106260,79.97944220)"
+Sri Lanka,LK,Eastern,Ampara,Colombo,,,7.29754000,81.68202000,Ampara;Ampara District;Batticaloa,"Ampara|(7.29754000,81.68202000);Ampara District|(7.08330000,81.75000000);Batticaloa|(7.71020000,81.69240000)"
+Sri Lanka,LK,Galle,,Colombo,,,,,,
+Sri Lanka,LK,Gampaha,,Colombo,,,,,,
+Sri Lanka,LK,Hambantota,,Colombo,,,,,,
+Sri Lanka,LK,Jaffna,,Colombo,,,,,,
+Sri Lanka,LK,Kalutara,,Colombo,,,,,,
+Sri Lanka,LK,Kandy,Akurana,Colombo,,,7.36500000,80.61722200,Akurana;Alawatugoda;Ambatenna,"Akurana|(7.36500000,80.61722200);Alawatugoda|(7.41048962,80.60918933);Ambatenna|(7.35252855,80.61378113)"
+Sri Lanka,LK,Kegalle,,Colombo,,,,,,
+Sri Lanka,LK,Kilinochchi,,Colombo,,,,,,
+Sri Lanka,LK,Kurunegala,,Colombo,,,,,,
+Sri Lanka,LK,Mannar,,Colombo,,,,,,
+Sri Lanka,LK,Matale,,Colombo,,,,,,
+Sri Lanka,LK,Matara,,Colombo,,,,,,
+Sri Lanka,LK,Monaragala,,Colombo,,,,,,
+Sri Lanka,LK,Mullaitivu,,Colombo,,,,,,
+Sri Lanka,LK,North Central,Anuradhapura,Colombo,,,8.31223000,80.41306000,Anuradhapura;Anuradhapura District;Mihintale,"Anuradhapura|(8.31223000,80.41306000);Anuradhapura District|(8.33333000,80.50000000);Mihintale|(8.35930000,80.51030000)"
+Sri Lanka,LK,North Western,Chilaw,Colombo,,,7.57583000,79.79528000,Chilaw;Kuliyapitiya;Kurunegala,"Chilaw|(7.57583000,79.79528000);Kuliyapitiya|(7.46880000,80.04010000);Kurunegala|(7.48390000,80.36830000)"
+Sri Lanka,LK,Northern,Jaffna,Colombo,,,9.66845000,80.00742000,Jaffna;Jaffna District;Kilinochchi,"Jaffna|(9.66845000,80.00742000);Jaffna District|(9.75000000,80.08333000);Kilinochchi|(9.39610000,80.39820000)"
+Sri Lanka,LK,Nuwara Eliya,,Colombo,,,,,,
+Sri Lanka,LK,Polonnaruwa,,Colombo,,,,,,
+Sri Lanka,LK,Puttalam,,Colombo,,,,,,
+Sri Lanka,LK,Ratnapura,,Colombo,,,,,,
+Sri Lanka,LK,Sabaragamuwa,Kegalle,Colombo,,,7.25230000,80.34360000,Kegalle;Kegalle District;Ratnapura,"Kegalle|(7.25230000,80.34360000);Kegalle District|(7.11670000,80.33330000);Ratnapura|(6.68580000,80.40360000)"
+Sri Lanka,LK,Southern,Ambalangoda,Colombo,,,6.23550000,80.05380000,Ambalangoda;Bentota;Devinuwara,"Ambalangoda|(6.23550000,80.05380000);Bentota|(6.42598000,79.99575000);Devinuwara|(5.92825000,80.58880000)"
+Sri Lanka,LK,Trincomalee,,Colombo,,,,,,
+Sri Lanka,LK,Uva,Badulla,Colombo,,,6.98020000,81.05770000,Badulla;Badulla District;Ella Town,"Badulla|(6.98020000,81.05770000);Badulla District|(6.98472000,81.05639000);Ella Town|(6.87560000,81.04630000)"
+Sri Lanka,LK,Vavuniya,,Colombo,,,,,,
+Sri Lanka,LK,Western,Battaramulla South,Colombo,,,6.89640000,79.91810000,Battaramulla South;Beruwala;Colombo,"Battaramulla South|(6.89640000,79.91810000);Beruwala|(6.47880000,79.98280000);Colombo|(6.93548000,79.84868000)"
+Sudan,SD,Al Jazirah,Al Hasaheisa,Khartoum,,,14.75264000,33.29836000,Al Hasaheisa;Al Hilāliyya;Al Kiremit al ‘Arakiyyīn,"Al Hasaheisa|(14.75264000,33.29836000);Al Hilāliyya|(14.93980000,33.23400000);Al Kiremit al ‘Arakiyyīn|(14.34760000,32.94370000)"
+Sudan,SD,Al Qadarif,Al Qadarif,Khartoum,,,14.03493000,35.38344000,Al Ḩawātah;Al Qadarif;Doka,"Al Ḩawātah|(13.41667000,34.63333000);Al Qadarif|(14.03493000,35.38344000);Doka|(13.51667000,35.76667000)"
+Sudan,SD,Blue Nile,Ad-Damazin,Khartoum,,,11.78910000,34.35920000,Ad-Damazin;Ar Ruseris;Kurmuk,"Ad-Damazin|(11.78910000,34.35920000);Ar Ruseris|(11.86590000,34.38690000);Kurmuk|(10.55000000,34.28333000)"
+Sudan,SD,Central Darfur,Zalingei,Khartoum,,,12.90918000,23.47058000,Zalingei,"Zalingei|(12.90918000,23.47058000)"
+Sudan,SD,East Darfur,El Daein,Khartoum,,,11.46186000,26.12583000,El Daein,"El Daein|(11.46186000,26.12583000)"
+Sudan,SD,Kassala,Kassala,Khartoum,,,15.45099000,36.39998000,Aroma;Kassala;Wagar,"Aroma|(15.81667000,36.13333000);Kassala|(15.45099000,36.39998000);Wagar|(16.15250000,36.20320000)"
+Sudan,SD,Khartoum,Khartoum,Khartoum,,,15.55177000,32.53241000,Khartoum;Omdurman,"Khartoum|(15.55177000,32.53241000);Omdurman|(15.64453000,32.47773000)"
+Sudan,SD,North Darfur,El Fasher,Khartoum,,,13.62793000,25.34936000,El Fasher;Kutum;Umm Kaddadah,"El Fasher|(13.62793000,25.34936000);Kutum|(14.20000000,24.66667000);Umm Kaddadah|(13.60169000,26.68759000)"
+Sudan,SD,North Kordofan,Ar Rahad,Khartoum,,,12.71667000,30.65000000,Ar Rahad;Bārah;El Obeid,"Ar Rahad|(12.71667000,30.65000000);Bārah|(13.70000000,30.36667000);El Obeid|(13.18421000,30.21669000)"
+Sudan,SD,Northern,Ad Dabbah,Khartoum,,,18.05000000,30.95000000,Ad Dabbah;Argo;Dongola,"Ad Dabbah|(18.05000000,30.95000000);Argo|(19.51667000,30.41667000);Dongola|(19.18163000,30.47689000)"
+Sudan,SD,Red Sea,Gebeit,Khartoum,,,21.06667000,36.31667000,Gebeit;Port Sudan;Sawākin,"Gebeit|(21.06667000,36.31667000);Port Sudan|(19.61745000,37.21644000);Sawākin|(19.10590000,37.33210000)"
+Sudan,SD,River Nile,Atbara,Khartoum,,,17.70217000,33.98638000,Atbara;Berber;Ed Damer,"Atbara|(17.70217000,33.98638000);Berber|(18.02158000,33.98299000);Ed Damer|(17.59898000,33.97205000)"
+Sudan,SD,Sennar,Ad Dindar,Khartoum,,,13.20000000,34.16667000,Ad Dindar;As Sūkī;Jalqani,"Ad Dindar|(13.20000000,34.16667000);As Sūkī|(13.31667000,33.88333000);Jalqani|(12.44860000,34.21860000)"
+Sudan,SD,South Darfur,Gereida,Khartoum,,,11.27543000,25.14026000,Gereida;Nyala,"Gereida|(11.27543000,25.14026000);Nyala|(12.04888000,24.88069000)"
+Sudan,SD,South Kordofan,Abu Jibeha,Khartoum,,,11.45620000,31.22850000,Abu Jibeha;Al Fūlah;Dilling,"Abu Jibeha|(11.45620000,31.22850000);Al Fūlah|(11.73292000,28.35786000);Dilling|(12.05000000,29.65000000)"
+Sudan,SD,West Darfur,Geneina,Khartoum,,,13.45262000,22.44725000,Geneina,"Geneina|(13.45262000,22.44725000)"
+Sudan,SD,West Kordofan,Abū Zabad,Khartoum,,,12.35000000,29.25000000,Abū Zabad;Al Lagowa;Al Mijlad,"Abū Zabad|(12.35000000,29.25000000);Al Lagowa|(11.40000000,29.13333000);Al Mijlad|(11.03333000,27.73333000)"
+Sudan,SD,White Nile,Ad Douiem,Khartoum,,,14.00120000,32.31160000,Ad Douiem;Al Kawa;Al Qiţena,"Ad Douiem|(14.00120000,32.31160000);Al Kawa|(13.74630000,32.49960000);Al Qiţena|(14.86480000,32.36680000)"
+Suriname,SR,Brokopondo,Brokopondo,Paramaribo,EMEA,5,5.05594000,-54.98043000,Brokopondo;Brownsweg,"Brokopondo|(5.05594000,-54.98043000);Brownsweg|(5.00435000,-55.15333000)"
+Suriname,SR,Commewijne,Mariënburg,Paramaribo,EMEA,5,5.87722000,-55.04322000,Mariënburg;Nieuw Amsterdam,"Mariënburg|(5.87722000,-55.04322000);Nieuw Amsterdam|(5.88573000,-55.08871000)"
+Suriname,SR,Coronie,Totness,Paramaribo,EMEA,5,5.87618000,-56.32572000,Totness,"Totness|(5.87618000,-56.32572000)"
+Suriname,SR,Marowijne,Albina,Paramaribo,EMEA,5,5.49788000,-54.05522000,Albina;Moengo,"Albina|(5.49788000,-54.05522000);Moengo|(5.61411000,-54.40121000)"
+Suriname,SR,Nickerie,Nieuw Nickerie,Paramaribo,EMEA,5,5.92606000,-56.97297000,Nieuw Nickerie;Wageningen,"Nieuw Nickerie|(5.92606000,-56.97297000);Wageningen|(5.76010000,-56.66523000)"
+Suriname,SR,Para,Onverwacht,Paramaribo,EMEA,5,5.58983000,-55.19462000,Onverwacht,"Onverwacht|(5.58983000,-55.19462000)"
+Suriname,SR,Paramaribo,Paramaribo,Paramaribo,EMEA,5,5.86638000,-55.16682000,Paramaribo,"Paramaribo|(5.86638000,-55.16682000)"
+Suriname,SR,Saramacca,Groningen,Paramaribo,EMEA,5,5.80000000,-55.46667000,Groningen,"Groningen|(5.80000000,-55.46667000)"
+Suriname,SR,Sipaliwini,,Paramaribo,EMEA,5,,,,
+Suriname,SR,Wanica,Lelydorp,Paramaribo,EMEA,5,5.70000000,-55.23333000,Lelydorp,"Lelydorp|(5.70000000,-55.23333000)"
+Sweden,SE,Blekinge,Bräkne-Hoby,Stockholm,,,56.23333000,15.11667000,Bräkne-Hoby;Hällevik;Hasslö,"Bräkne-Hoby|(56.23333000,15.11667000);Hällevik|(56.01667000,14.70000000);Hasslö|(56.11667000,15.48333000)"
+Sweden,SE,Dalarna,Abborrberget,Stockholm,,,60.15000000,14.80000000,Abborrberget;Älvdalen;Avesta,"Abborrberget|(60.15000000,14.80000000);Älvdalen|(61.22774000,14.03935000);Avesta|(60.14274000,16.16295000)"
+Sweden,SE,Gävleborg,Alfta,Stockholm,,,61.34675000,16.07499000,Alfta;Arbrå;Årsunda,"Alfta|(61.34675000,16.07499000);Arbrå|(61.46667000,16.38333000);Årsunda|(60.51644000,16.73436000)"
+Sweden,SE,Gotland,Gotland,Stockholm,,,57.50000000,18.50000000,Gotland;Hemse;Klintehamn,"Gotland|(57.50000000,18.50000000);Hemse|(57.23788000,18.37443000);Klintehamn|(57.38667000,18.20371000)"
+Sweden,SE,Halland,Åled,Stockholm,,,56.75000000,12.93333000,Åled;Åsa;Bua,"Åled|(56.75000000,12.93333000);Åsa|(57.35000000,12.11667000);Bua|(57.23780000,12.12187000)"
+Sweden,SE,Jämtland,,Stockholm,,,,,,
+Sweden,SE,Jönköping,Jönköping,Stockholm,,,57.78145000,14.15618000,Anderstorp;Aneby;Bankeryd,"Anderstorp|(57.28333000,13.63333000);Aneby|(57.83895000,14.81016000);Bankeryd|(57.86021000,14.12400000)"
+Sweden,SE,Kalmar,Kalmar,Stockholm,,,56.66157000,16.36163000,Ankarsrum;Bergkvara;Blomstermåla,"Ankarsrum|(57.69896000,16.33407000);Bergkvara|(56.39063000,16.07274000);Blomstermåla|(56.98333000,16.33333000)"
+Sweden,SE,Kronoberg,Älmhult,Stockholm,,,56.55146000,14.13827000,Älmhult;Alvesta;Åseda,"Älmhult|(56.55146000,14.13827000);Alvesta|(56.89935000,14.55559000);Åseda|(57.17010000,15.34430000)"
+Sweden,SE,Norrbotten,Älvsbyn,Stockholm,,,65.67624000,21.00162000,Älvsbyn;Arjeplog;Arvidsjaur,"Älvsbyn|(65.67624000,21.00162000);Arjeplog|(66.05173000,17.88606000);Arvidsjaur|(65.59033000,19.16682000)"
+Sweden,SE,Örebro,Örebro,Stockholm,,,59.27412000,15.20660000,Åsbro;Askersund;Degerfors,"Åsbro|(59.00000000,15.05000000);Askersund|(58.87988000,14.90230000);Degerfors|(59.23797000,14.43077000)"
+Sweden,SE,Östergötland,Åby,Stockholm,,,58.66214850,16.17592570,Åby;Åtvidaberg;Berg,"Åby|(58.66214850,16.17592570);Åtvidaberg|(58.20152000,15.99770000);Berg|(58.48831000,15.52969000)"
+Sweden,SE,Skåne,Åhus,Stockholm,,,55.91667000,14.28333000,Åhus;Åkarp;Anderslöv,"Åhus|(55.91667000,14.28333000);Åkarp|(55.65396000,13.11107000);Anderslöv|(55.43836000,13.31966000)"
+Sweden,SE,Södermanland,Åkers Styckebruk,Stockholm,,,59.25000000,17.08333000,Åkers Styckebruk;Ärla;Arnö,"Åkers Styckebruk|(59.25000000,17.08333000);Ärla|(59.27983000,16.67896000);Arnö|(58.72675000,17.02322000)"
+Sweden,SE,Stockholm,Stockholm,Stockholm,,,59.33258000,18.06490000,Akalla;Åkersberga;Alby,"Akalla|(59.41465000,17.91398000);Åkersberga|(59.47944000,18.29967000);Alby|(59.23350000,17.85380000)"
+Sweden,SE,Uppsala,Uppsala,Stockholm,,,59.85882000,17.63889000,Alsike;Alunda;Älvkarleby,"Alsike|(59.75324000,17.77331000);Alunda|(60.26667000,18.40000000);Älvkarleby|(60.57081000,17.44895000)"
+Sweden,SE,Värmland,Åmotfors,Stockholm,,,59.76191000,12.36211000,Åmotfors;Årjäng;Arvika,"Åmotfors|(59.76191000,12.36211000);Årjäng|(59.39217000,12.13336000);Arvika|(59.65528000,12.58518000)"
+Sweden,SE,Västerbotten,Åsele,Stockholm,,,64.16026000,17.34762000,Åsele;Backa;Bjurholm,"Åsele|(64.16026000,17.34762000);Backa|(64.98333000,21.06667000);Bjurholm|(63.93027000,19.21369000)"
+Sweden,SE,Västernorrland,Ånge,Stockholm,,,62.52495000,15.65904000,Ånge;Ås;Bergeforsen,"Ånge|(62.52495000,15.65904000);Ås|(63.36667000,16.58333000);Bergeforsen|(62.53074000,17.38123000)"
+Sweden,SE,Västmanland,Arboga,Stockholm,,,59.39387000,15.83882000,Arboga;Barkarö;Dingtuna,"Arboga|(59.39387000,15.83882000);Barkarö|(59.54935000,16.50740000);Dingtuna|(59.57279000,16.38722000)"
+Sweden,SE,Västra Götaland,Åkarp,Stockholm,,,58.23333000,13.65000000,Åkarp;Alafors;Alingsås,"Åkarp|(58.23333000,13.65000000);Alafors|(57.92579000,12.07835000);Alingsås|(57.93033000,12.53345000)"
+Switzerland,CH,Aargau,Aarau,Bern,,,47.39254000,8.04422000,Aarau;Aarburg;Aristau,"Aarau|(47.39254000,8.04422000);Aarburg|(47.32067000,7.89986000);Aristau|(47.28692000,8.36356000)"
+Switzerland,CH,Appenzell Ausserrhoden,Bezirk Hinterland,Bern,,,47.36470000,9.27350000,Bezirk Hinterland;Bezirk Mittelland;Bezirk Vorderland,"Bezirk Hinterland|(47.36470000,9.27350000);Bezirk Mittelland|(47.37700000,9.43469000);Bezirk Vorderland|(47.44167000,9.53869000)"
+Switzerland,CH,Appenzell Innerrhoden,Appenzell,Bern,,,47.33103000,9.40996000,Appenzell;Gonten;Haslen,"Appenzell|(47.33103000,9.40996000);Gonten|(47.32725000,9.34705000);Haslen|(47.36931000,9.36752000)"
+Switzerland,CH,Basel-Land,Aesch,Bern,,,47.47104000,7.59730000,Aesch;Allschwil;Arisdorf,"Aesch|(47.47104000,7.59730000);Allschwil|(47.55074000,7.53599000);Arisdorf|(47.51323000,7.76515000)"
+Switzerland,CH,Basel-Stadt,Basel,Bern,,,47.55472200,7.59055600,Basel;Bettingen;Riehen,"Basel|(47.55472200,7.59055600);Bettingen|(47.57138900,7.66416700);Riehen|(47.58333300,7.63333300)"
+Switzerland,CH,Bern,Bern,Bern,,,46.94809000,7.44744000,Aarberg;Aarwangen;Adelboden,"Aarberg|(47.04439000,7.27578000);Aarwangen|(47.23845000,7.76854000);Adelboden|(46.49142000,7.56031000)"
+Switzerland,CH,Fribourg,Fribourg,Bern,,,46.80237000,7.15128000,Alterswil;Attalens;Avry-sur-Matran,"Alterswil|(46.79587000,7.25877000);Attalens|(46.50555000,6.85039000);Avry-sur-Matran|(46.78753000,7.06735000)"
+Switzerland,CH,Geneva,Geneva,Bern,,,46.20222000,6.14569000,Aire-la-Ville;Anières;Bellevue,"Aire-la-Ville|(46.19057000,6.04287000);Anières|(46.27673000,6.22204000);Bellevue|(46.25739000,6.15475000)"
+Switzerland,CH,Glarus,Glarus,Bern,,,47.04057000,9.06804000,Bilten;Ennenda;Glarus,"Bilten|(47.14995000,9.02551000);Ennenda|(47.03363000,9.07888000);Glarus|(47.04057000,9.06804000)"
+Switzerland,CH,Graubünden,Arosa,Bern,,,46.77793000,9.67621000,Arosa;Arvigo;Bonaduz,"Arosa|(46.77793000,9.67621000);Arvigo|(46.30211000,9.11300000);Bonaduz|(46.81103000,9.39821000)"
+Switzerland,CH,Jura,Alle,Bern,,,47.42542000,7.13018000,Alle;Bassecourt;Boncourt,"Alle|(47.42542000,7.13018000);Bassecourt|(47.33808000,7.24373000);Boncourt|(47.49493000,7.01297000)"
+Switzerland,CH,Lucerne,Adligenswil,Bern,,,47.06521000,8.36124000,Adligenswil;Altishofen;Ballwil,"Adligenswil|(47.06521000,8.36124000);Altishofen|(47.19916000,7.96964000);Ballwil|(47.15371000,8.32233000)"
+Switzerland,CH,Neuchâtel,Neuchâtel,Bern,,,46.99179000,6.93100000,Auvernier;Bevaix;Boudry,"Auvernier|(46.97545000,6.87903000);Bevaix|(46.92958000,6.81470000);Boudry|(46.94991000,6.83757000)"
+Switzerland,CH,Nidwalden,Beckenried,Bern,,,46.96653000,8.47575000,Beckenried;Buochs;Dallenwil,"Beckenried|(46.96653000,8.47575000);Buochs|(46.97398000,8.42279000);Dallenwil|(46.92420000,8.38785000)"
+Switzerland,CH,Obwalden,Alpnach,Bern,,,46.94227000,8.27180000,Alpnach;Engelberg;Giswil,"Alpnach|(46.94227000,8.27180000);Engelberg|(46.82107000,8.40133000);Giswil|(46.83333000,8.18065000)"
+Switzerland,CH,Schaffhausen,Schaffhausen,Bern,,,47.69732000,8.63493000,Beringen;Bezirk Oberklettgau;Bezirk Reiat,"Beringen|(47.69763000,8.57431000);Bezirk Oberklettgau|(47.69893000,8.51774000);Bezirk Reiat|(47.74752000,8.70821000)"
+Switzerland,CH,Schwyz,Schwyz,Bern,,,47.02076000,8.65414000,Altendorf;Arth;Bäch,"Altendorf|(47.18994000,8.83823000);Arth|(47.06337000,8.52349000);Bäch|(47.20388000,8.73224000)"
+Switzerland,CH,Solothurn,Solothurn,Bern,,,47.20791000,7.53714000,Balsthal;Bettlach;Bezirk Bucheggberg,"Balsthal|(47.31613000,7.69318000);Bettlach|(47.20062000,7.42405000);Bezirk Bucheggberg|(47.13205000,7.47885000)"
+Switzerland,CH,St. Gallen,Altstätten,Bern,,,47.37766000,9.54746000,Altstätten;Amden;Andwil,"Altstätten|(47.37766000,9.54746000);Amden|(47.14888000,9.14233000);Andwil|(47.43855000,9.27436000)"
+Switzerland,CH,Thurgau,Aadorf,Bern,,,47.49204000,8.90099000,Aadorf;Affeltrangen;Altnau,"Aadorf|(47.49204000,8.90099000);Affeltrangen|(47.52581000,9.03307000);Altnau|(47.61052000,9.26160000)"
+Switzerland,CH,Ticino,Acquarossa,Bern,,,46.45473000,8.94261000,Acquarossa;Agno;Airolo,"Acquarossa|(46.45473000,8.94261000);Agno|(45.99863000,8.90030000);Airolo|(46.52855000,8.61189000)"
+Switzerland,CH,Uri,Altdorf,Bern,,,46.88042000,8.64441000,Altdorf;Andermatt;Attinghausen,"Altdorf|(46.88042000,8.64441000);Andermatt|(46.63565000,8.59388000);Attinghausen|(46.86255000,8.63036000)"
+Switzerland,CH,Valais,Ardon,Bern,,,46.20951000,7.26012000,Ardon;Ayent;Bagnes,"Ardon|(46.20951000,7.26012000);Ayent|(46.28249000,7.41028000);Bagnes|(46.08333000,7.21667000)"
+Switzerland,CH,Vaud,Aigle,Bern,,,46.31810000,6.96457000,Aigle;Aigle District;Apples,"Aigle|(46.31810000,6.96457000);Aigle District|(46.30577000,7.02974000);Apples|(46.55237000,6.42889000)"
+Switzerland,CH,Zug,Zug,Bern,,,47.17242000,8.51745000,Baar;Cham;Hünenberg,"Baar|(47.19625000,8.52954000);Cham|(47.18213000,8.46358000);Hünenberg|(47.17536000,8.42497000)"
+Switzerland,CH,Zürich,Zürich,Bern,,,47.36667000,8.55000000,Adliswil;Adliswil / Adliswil (Stadtkern);Adliswil / Hündli-Zopf,"Adliswil|(47.30997000,8.52462000);Adliswil / Adliswil (Stadtkern)|(47.31128000,8.52675000);Adliswil / Hündli-Zopf|(47.31637000,8.51888000)"
+Syria,SY,Al-Hasakah,Ad Darbāsīyah,Damascus,,,37.07279000,40.65199000,Ad Darbāsīyah;Al Ḩasakah;Al Mālikīyah,"Ad Darbāsīyah|(37.07279000,40.65199000);Al Ḩasakah|(36.50237000,40.74772000);Al Mālikīyah|(37.17701000,42.14006000)"
+Syria,SY,Al-Raqqah,Al-Thawrah District,Damascus,,,35.79843000,38.34550000,Al-Thawrah District;Ar Raqqah;Ar-Raqqah District,"Al-Thawrah District|(35.79843000,38.34550000);Ar Raqqah|(35.95283000,39.00788000);Ar-Raqqah District|(35.87204000,39.04706000)"
+Syria,SY,Aleppo,Aleppo,Damascus,,,36.20124000,37.16117000,‘Afrīn;‘Ayn al ‘Arab;Afrin District,"‘Afrīn|(36.51194000,36.86954000);‘Ayn al ‘Arab|(36.89095000,38.35347000);Afrin District|(36.54891000,36.79295000)"
+Syria,SY,As-Suwayda,As-Suwayda,Damascus,,,32.70896000,36.56951000,As-Suwayda;As-Suwayda District;Şalākhid,"As-Suwayda|(32.70896000,36.56951000);As-Suwayda District|(32.78127000,36.86502000);Şalākhid|(32.87271000,36.57271000)"
+Syria,SY,Damascus,Damascus,Damascus,,,33.51020000,36.29128000,Damascus,"Damascus|(33.51020000,36.29128000)"
+Syria,SY,Daraa,Al Ḩarāk,Damascus,,,32.74932000,36.30994000,Al Ḩarāk;Al Muzayrīb;Al-Sanamayn District,"Al Ḩarāk|(32.74932000,36.30994000);Al Muzayrīb|(32.71084000,36.02751000);Al-Sanamayn District|(33.12559000,36.27540000)"
+Syria,SY,Deir ez-Zor,Deir ez-Zor,Damascus,,,35.33588000,40.14084000,Al Mayādīn;Ālbū Kamāl;Deir ez-Zor,"Al Mayādīn|(35.01982000,40.45154000);Ālbū Kamāl|(34.45226000,40.91854000);Deir ez-Zor|(35.33588000,40.14084000)"
+Syria,SY,Hama,Al-Salamiyah District,Damascus,,,35.14398000,37.59235000,Al-Salamiyah District;As Salamīyah;As Suqaylibīyah,"Al-Salamiyah District|(35.14398000,37.59235000);As Salamīyah|(35.01127000,37.05324000);As Suqaylibīyah|(35.36674000,36.39359000)"
+Syria,SY,Homs,Homs,Damascus,,,34.72682000,36.72339000,Al Ghanţū;Al Qaryatayn;Al Quşayr,"Al Ghanţū|(34.82202000,36.69613000);Al Qaryatayn|(34.22956000,37.24066000);Al Quşayr|(34.50780000,36.58029000)"
+Syria,SY,Idlib,Idlib,Damascus,,,35.93062000,36.63393000,Ad Dānā;Arīḩā;Armanāz,"Ad Dānā|(36.21254000,36.76998000);Arīḩā|(35.81374000,36.60964000);Armanāz|(36.08363000,36.50310000)"
+Syria,SY,Latakia,Latakia,Damascus,,,35.53168000,35.79011000,Al-Haffah District;Jablah;Jableh District,"Al-Haffah District|(35.59687000,36.11198000);Jablah|(35.36211000,35.92759000);Jableh District|(35.29048000,36.04490000)"
+Syria,SY,Quneitra,Al Qunayţirah,Damascus,,,33.12595000,35.82461000,Al Qunayţirah,"Al Qunayţirah|(33.12595000,35.82461000)"
+Syria,SY,Rif Dimashq,‘Irbīn,Damascus,,,33.53719000,36.36635000,‘Irbīn;Al Kiswah;Al Quţayfah,"‘Irbīn|(33.53719000,36.36635000);Al Kiswah|(33.35810000,36.24190000);Al Quţayfah|(33.73848000,36.60071000)"
+Syria,SY,Tartus,Ad Duraykīsh,Damascus,,,34.89514000,36.14303000,Ad Duraykīsh;Bāniyās;Kaff al-Jaa,"Ad Duraykīsh|(34.89514000,36.14303000);Bāniyās|(35.18188000,35.94871000);Kaff al-Jaa|(35.08638000,36.20605000)"
+Taiwan,TW,Changhua,Changhua,Taipei,,,23.95361000,120.49083000,Changhua;Yuanlin,"Changhua|(23.95361000,120.49083000);Yuanlin|(23.95671000,120.57608000)"
+Taiwan,TW,Chiayi,Chiayi,Taipei,,,23.47722000,120.44527000,Chiayi;Pizitou,"Chiayi|(23.47722000,120.44527000);Pizitou|(23.48556000,120.44472000)"
+Taiwan,TW,Chiayi,Chiayi County,Taipei,,,23.46333000,120.58166000,Chiayi County,"Chiayi County|(23.46333000,120.58166000)"
+Taiwan,TW,Hsinchu,Hsinchu,Taipei,,,24.80361000,120.96861000,Hsinchu,"Hsinchu|(24.80361000,120.96861000)"
+Taiwan,TW,Hsinchu,Hsinchu County,Taipei,,,24.67416000,121.16111000,Hsinchu County,"Hsinchu County|(24.67416000,121.16111000)"
+Taiwan,TW,Hualien,Hualien,Taipei,,,23.78166000,121.39333000,Hualien,"Hualien|(23.78166000,121.39333000)"
+Taiwan,TW,Kaohsiung,Kaohsiung,Taipei,,,22.61626000,120.31333000,Kaohsiung,"Kaohsiung|(22.61626000,120.31333000)"
+Taiwan,TW,Keelung,,Taipei,,,,,,
+Taiwan,TW,Kinmen,Jincheng,Taipei,,,24.43415000,118.31712000,Jincheng;Kinmen County,"Jincheng|(24.43415000,118.31712000);Kinmen County|(24.45333000,118.38861000)"
+Taiwan,TW,Lienchiang,Lienchiang,Taipei,,,26.37004000,120.49545000,Lienchiang;Nangan,"Lienchiang|(26.37004000,120.49545000);Nangan|(26.15039000,119.93284000)"
+Taiwan,TW,Miaoli,Miaoli,Taipei,,,24.48972000,120.90638000,Miaoli,"Miaoli|(24.48972000,120.90638000)"
+Taiwan,TW,Nantou,Nantou,Taipei,,,23.83419000,120.92704000,Lugu;Nantou;Puli,"Lugu|(23.74639000,120.75250000);Nantou|(23.83419000,120.92704000);Puli|(23.96639000,120.96952000)"
+Taiwan,TW,New Taipei,,Taipei,,,,,,
+Taiwan,TW,Penghu,Magong,Taipei,,,23.56540000,119.58627000,Magong;Penghu County,"Magong|(23.56540000,119.58627000);Penghu County|(23.57111000,119.61138000)"
+Taiwan,TW,Pingtung,Pingtung,Taipei,,,22.49555000,120.61444000,Donggang;Hengchun;Pingtung,"Donggang|(22.46515000,120.44927000);Hengchun|(22.00417000,120.74389000);Pingtung|(22.49555000,120.61444000)"
+Taiwan,TW,Taichung,Taichung,Taipei,,,24.14690000,120.68390000,Taichung,"Taichung|(24.14690000,120.68390000)"
+Taiwan,TW,Tainan,Tainan,Taipei,,,22.99083000,120.21333000,Tainan;Yujing,"Tainan|(22.99083000,120.21333000);Yujing|(23.12493000,120.46138000)"
+Taiwan,TW,Taipei,Taipei,Taipei,,,25.04776000,121.53185000,Banqiao;Jiufen;Taipei,"Banqiao|(25.01427000,121.46719000);Jiufen|(25.10957000,121.84424000);Taipei|(25.04776000,121.53185000)"
+Taiwan,TW,Taitung,Taitung,Taipei,,,22.88361000,121.04833000,Taitung,"Taitung|(22.88361000,121.04833000)"
+Taiwan,TW,Taoyuan,Taoyuan,Taipei,,,24.89500000,121.24611000,Daxi;Taoyuan,"Daxi|(24.88373000,121.29043000);Taoyuan|(24.89500000,121.24611000)"
+Taiwan,TW,Yilan,Yilan,Taipei,,,24.54250000,121.63361000,Yilan,"Yilan|(24.54250000,121.63361000)"
+Taiwan,TW,Yunlin,Yunlin,Taipei,,,23.70701000,120.38481000,Douliu;Yunlin,"Douliu|(23.70944000,120.54333000);Yunlin|(23.70701000,120.38481000)"
+Tajikistan,TJ,Gorno-Badakhshan,Ishqoshim,Dushanbe,,,36.72484000,71.61331000,Ishqoshim;Khorugh;Murghob,"Ishqoshim|(36.72484000,71.61331000);Khorugh|(37.48974000,71.55304000);Murghob|(38.17023000,73.96674000)"
+Tajikistan,TJ,Khatlon,Abdurahmoni Jomí,Dushanbe,,,37.94636000,68.80878000,Abdurahmoni Jomí;Boshchorbogh;Bŭstonqal’a,"Abdurahmoni Jomí|(37.94636000,68.80878000);Boshchorbogh|(37.52027000,68.12825000);Bŭstonqal’a|(37.84783000,68.83125000)"
+Tajikistan,TJ,Nohiyahoi Tobei Jumhurí ,Darband,Dushanbe,,,38.86776000,69.96642000,Darband;Hisor;Karakenja,"Darband|(38.86776000,69.96642000);Hisor|(38.52504000,68.55124000);Karakenja|(39.23585000,71.52412000)"
+Tajikistan,TJ,Sughd ,Adrasmon,Dushanbe,,,40.64928000,69.98472000,Adrasmon;Ayní;Bŭston,"Adrasmon|(40.64928000,69.98472000);Ayní|(39.39406000,68.53766000);Bŭston|(40.52286000,69.33307000)"
+Tanzania,TZ,Arusha,Arusha,Dodoma,,,-3.36667000,36.68333000,Arusha;Kingori;Kiratu,"Arusha|(-3.36667000,36.68333000);Kingori|(-3.28333000,36.98333000);Kiratu|(-3.33333000,35.66667000)"
+Tanzania,TZ,Dar es Salaam,Dar es Salaam,Dodoma,,,-6.82349000,39.26951000,Dar es Salaam;Ilala;Kigamboni,"Dar es Salaam|(-6.82349000,39.26951000);Ilala|(-6.84873800,39.28471300);Kigamboni|(-6.84945500,39.31733300)"
+Tanzania,TZ,Dodoma,Dodoma,Dodoma,,,-6.17221000,35.73947000,Dodoma;Kibakwe;Kisasa,"Dodoma|(-6.17221000,35.73947000);Kibakwe|(-6.71667000,36.36667000);Kisasa|(-6.17526000,35.79266000)"
+Tanzania,TZ,Geita,Geita,Dodoma,,,-2.87250000,32.23250000,Buseresere;Chato;Geita,"Buseresere|(-3.02361000,31.87472000);Chato|(-2.63778000,31.76694000);Geita|(-2.87250000,32.23250000)"
+Tanzania,TZ,Iringa,Iringa,Dodoma,,,-7.76667000,35.70000000,Ilula;Iringa;Izazi,"Ilula|(-7.67660000,36.03658000);Iringa|(-7.76667000,35.70000000);Izazi|(-7.20000000,35.73333000)"
+Tanzania,TZ,Kagera,Biharamulo,Dodoma,,,-2.63194000,31.30889000,Biharamulo;Bugarama;Bugene,"Biharamulo|(-2.63194000,31.30889000);Bugarama|(-2.87056000,30.52806000);Bugene|(-1.59111000,31.14028000)"
+Tanzania,TZ,Katavi,Inyonga,Dodoma,,,-6.71667000,32.06667000,Inyonga;Karema;Mpanda,"Inyonga|(-6.71667000,32.06667000);Karema|(-6.82052000,30.43887000);Mpanda|(-6.34379000,31.06951000)"
+Tanzania,TZ,Kigoma,Kigoma,Dodoma,,,-4.87694000,29.62667000,Kakonko;Kasulu;Kibondo,"Kakonko|(-3.28278000,30.96417000);Kasulu|(-4.57667000,30.10250000);Kibondo|(-3.58639000,30.72028000)"
+Tanzania,TZ,Kilimanjaro,Hedaru,Dodoma,,,-4.50153290,37.91444740,Hedaru;Machame;Marangu,"Hedaru|(-4.50153290,37.91444740);Machame|(-3.20611000,37.22638890);Marangu|(-3.28376300,37.52298200)"
+Tanzania,TZ,Lindi,Lindi,Dodoma,,,-9.99709000,39.71649000,Lindi;Mbekenyera;Mingoyo,"Lindi|(-9.99709000,39.71649000);Mbekenyera|(-10.00000000,38.98333000);Mingoyo|(-10.10526000,39.61859000)"
+Tanzania,TZ,Manyara,Babati,Dodoma,,,-4.21667000,35.75000000,Babati;Bashanet;Basotu,"Babati|(-4.21667000,35.75000000);Bashanet|(-4.23333000,35.41667000);Basotu|(-4.36667000,35.08333000)"
+Tanzania,TZ,Mara,Bukonyo,Dodoma,,,-1.95000000,32.93333000,Bukonyo;Butiama;Issenye,"Bukonyo|(-1.95000000,32.93333000);Butiama|(-1.76667000,33.96667000);Issenye|(-2.00000000,34.33333000)"
+Tanzania,TZ,Mbeya,Mbeya,Dodoma,,,-8.90000000,33.45000000,Chimala;Ibaba;Ikama,"Chimala|(-8.85637000,34.02393000);Ibaba|(-9.40000000,33.35000000);Ikama|(-9.26666667,33.83333333)"
+Tanzania,TZ,Morogoro,Morogoro,Dodoma,,,-6.82102000,37.66122000,Geiro;Ifakara;Kidatu,"Geiro|(-6.15000000,36.86667000);Ifakara|(-8.13333000,36.68333000);Kidatu|(-7.69916000,36.95722000)"
+Tanzania,TZ,Mtwara,Mtwara,Dodoma,,,-10.26667000,40.18333000,Chiungutwa;Kitama;Kitangari,"Chiungutwa|(-10.88333000,38.98333000);Kitama|(-10.71667000,39.73333000);Kitangari|(-10.65000000,39.33333000)"
+Tanzania,TZ,Mwanza,Mwanza,Dodoma,,,-2.51667000,32.90000000,Ilemela District;Kihangara;Malya,"Ilemela District|(-2.44783000,33.03177000);Kihangara|(-2.58333000,33.35000000);Malya|(-2.98333000,33.51667000)"
+Tanzania,TZ,Njombe,Njombe,Dodoma,,,-9.34917000,34.77167000,Ilembula;Makumbako;Manda,"Ilembula|(-8.90000000,34.58333000);Makumbako|(-8.85000000,34.83333000);Manda|(-10.46667000,34.58333000)"
+Tanzania,TZ,Pemba North,Konde,Dodoma,,,-4.95000000,39.75000000,Konde;Micheweni;Wete,"Konde|(-4.95000000,39.75000000);Micheweni|(-4.96667000,39.83333000);Wete|(-5.05589000,39.72938000)"
+Tanzania,TZ,Pemba South,Chake Chake,Dodoma,,,-5.24586000,39.76659000,Chake Chake;Mtambile;Uwelini,"Chake Chake|(-5.24586000,39.76659000);Mtambile|(-5.38333000,39.70000000);Uwelini|(-5.40000000,39.68333000)"
+Tanzania,TZ,Pwani,Bagamoyo,Dodoma,,,-6.44222000,38.90422000,Bagamoyo;Bungu;Chalinze,"Bagamoyo|(-6.44222000,38.90422000);Bungu|(-7.63369000,39.05818000);Chalinze|(-6.63784000,38.35396000)"
+Tanzania,TZ,Rukwa,Chala,Dodoma,,,-7.58333000,31.26667000,Chala;Kirando;Laela,"Chala|(-7.58333000,31.26667000);Kirando|(-7.41667000,30.60000000);Laela|(-8.56667000,32.05000000)"
+Tanzania,TZ,Ruvuma,Kigonsera,Dodoma,,,-10.80000000,35.05000000,Kigonsera;Liuli;Mahanje,"Kigonsera|(-10.80000000,35.05000000);Liuli|(-11.08333000,34.63333000);Mahanje|(-9.93333000,35.33333000)"
+Tanzania,TZ,Shinyanga,Shinyanga,Dodoma,,,-3.66393000,33.42118000,Isaka;Kahama;Kishapu,"Isaka|(-3.90000000,32.93333000);Kahama|(-3.83333000,32.60000000);Kishapu|(-3.61667000,33.86667000)"
+Tanzania,TZ,Simiyu,Bariadi,Dodoma,,,-2.80000000,33.98333000,Bariadi;Kisesa;Lalago,"Bariadi|(-2.80000000,33.98333000);Kisesa|(-3.08333000,34.15000000);Lalago|(-3.45000000,33.95000000)"
+Tanzania,TZ,Singida,Singida,Dodoma,,,-4.81629000,34.74358000,Igugunu;Ikungi;Ilongero,"Igugunu|(-4.56667000,34.63333000);Ikungi|(-5.13333000,34.76667000);Ilongero|(-4.66667000,34.86667000)"
+Tanzania,TZ,Songwe,Ileje,Dodoma,,,-9.60000000,33.48330000,Ileje;Mbozi;Mkwajuni,"Ileje|(-9.60000000,33.48330000);Mbozi|(-9.08330000,33.45000000);Mkwajuni|(-8.42380000,33.02900000)"
+Tanzania,TZ,Tabora,Tabora,Dodoma,,,-5.01622000,32.82663000,Bukene;Igurubi;Kaliua,"Bukene|(-4.23333000,32.88333000);Igurubi|(-4.00000000,33.70000000);Kaliua|(-5.06056000,31.79361000)"
+Tanzania,TZ,Tanga,Tanga,Dodoma,,,-5.06893000,39.09875000,Chanika;Lushoto;Magomeni,"Chanika|(-5.41667000,38.01667000);Lushoto|(-4.78333000,38.28333000);Magomeni|(-5.23333000,38.11667000)"
+Tanzania,TZ,Zanzibar North,Gamba,Dodoma,,,-5.90000000,39.30000000,Gamba;Kijini;Kiwengwa,"Gamba|(-5.90000000,39.30000000);Kijini|(-5.85000000,39.31667000);Kiwengwa|(-5.98957000,39.37680000)"
+Tanzania,TZ,Zanzibar South,Koani,Dodoma,,,-6.13764180,39.28632640,Koani;Mahonda;Nganane,"Koani|(-6.13764180,39.28632640);Mahonda|(-6.45000000,39.46667000);Nganane|(-6.40000000,39.55000000)"
+Tanzania,TZ,Zanzibar West,Zanzibar,Dodoma,,,-6.16394000,39.19793000,Zanzibar,"Zanzibar|(-6.16394000,39.19793000)"
+Thailand,TH,Amnat Charoen,Amnat Charoen,Bangkok,,,15.85851000,104.62883000,Amnat Charoen;Amphoe Chanuman;Amphoe Hua Taphan,"Amnat Charoen|(15.85851000,104.62883000);Amphoe Chanuman|(16.12553000,104.92279000);Amphoe Hua Taphan|(15.67594000,104.52702000)"
+Thailand,TH,Ang Thong,Ang Thong,Bangkok,,,14.58839000,100.45283000,Amphoe Chaiyo;Amphoe Mueang Ang Thong;Amphoe Pa Mok,"Amphoe Chaiyo|(14.67225000,100.46786000);Amphoe Mueang Ang Thong|(14.57815000,100.44393000);Amphoe Pa Mok|(14.48620000,100.45730000)"
+Thailand,TH,Bangkok,Bangkok,Bangkok,,,13.75398000,100.50144000,Bang Bon;Bang Kapi;Bang Khae,"Bang Bon|(13.65920000,100.38801000);Bang Kapi|(13.77258000,100.63847000);Bang Khae|(13.71927000,100.39278000)"
+Thailand,TH,Bueng Kan,Bueng Kan,Bangkok,,,18.36303000,103.65194000,Amphoe Bueng Khong Long;Amphoe Bung Khla;Amphoe Mueang Bueng Kan,"Amphoe Bueng Khong Long|(18.00899000,104.07302000);Amphoe Bung Khla|(18.24726000,103.99427000);Amphoe Mueang Bueng Kan|(18.29950000,103.64016000)"
+Thailand,TH,Buri Ram,Buri Ram,Bangkok,,,14.99433000,103.10392000,Amphoe Ban Dan;Amphoe Ban Kruat;Amphoe Ban Mai Chaiyaphot,"Amphoe Ban Dan|(15.12363000,103.18937000);Amphoe Ban Kruat|(14.39205000,103.11494000);Amphoe Ban Mai Chaiyaphot|(15.57857000,102.84394000)"
+Thailand,TH,Chachoengsao,Chachoengsao,Bangkok,,,13.68820000,101.07156000,Amphoe Ban Pho;Amphoe Bang Khla;Amphoe Bang Nam Priao,"Amphoe Ban Pho|(13.61000000,101.07838000);Amphoe Bang Khla|(13.74186000,101.20754000);Amphoe Bang Nam Priao|(13.88034000,101.03232000)"
+Thailand,TH,Chai Nat,Chai Nat,Bangkok,,,15.18636000,100.12353000,Amphoe Hankha;Amphoe Manorom;Amphoe Mueang Chainat,"Amphoe Hankha|(15.05048000,99.96090000);Amphoe Manorom|(15.31894000,100.15677000);Amphoe Mueang Chainat|(15.19104000,100.13540000)"
+Thailand,TH,Chaiyaphum,Chaiyaphum,Bangkok,,,15.81047000,102.02881000,Bamnet Narong;Chaiyaphum;Kaeng Khro,"Bamnet Narong|(15.50189000,101.68982000);Chaiyaphum|(15.81047000,102.02881000);Kaeng Khro|(16.10861111,102.25805556)"
+Thailand,TH,Chanthaburi,Chanthaburi,Bangkok,,,12.60961000,102.10447000,Amphoe Kaeng Hang Maeo;Amphoe Khao Khitchakut;Amphoe Khlung,"Amphoe Kaeng Hang Maeo|(13.09690000,101.88543000);Amphoe Khao Khitchakut|(12.93726000,102.09762000);Amphoe Khlung|(12.57246000,102.30783000)"
+Thailand,TH,Chiang Mai,Chiang Mai,Bangkok,,,18.79038000,98.98468000,Amphoe Chai Prakan;Amphoe Chiang Dao;Amphoe Chom Thong,"Amphoe Chai Prakan|(19.67400000,99.17478000);Amphoe Chiang Dao|(19.51279000,98.94180000);Amphoe Chom Thong|(18.39242000,98.59761000)"
+Thailand,TH,Chiang Rai,Chiang Rai,Bangkok,,,19.90858000,99.83250000,Amphoe Chiang Khong;Amphoe Chiang Saen;Amphoe Doi Luang,"Amphoe Chiang Khong|(20.13587000,100.36527000);Amphoe Chiang Saen|(20.23572000,100.15537000);Amphoe Doi Luang|(20.14496000,100.15712000)"
+Thailand,TH,Chon Buri,Chon Buri,Bangkok,,,13.36220000,100.98345000,Amphoe Ban Bueng;Amphoe Bo Thong;Amphoe Ko Chan,"Amphoe Ban Bueng|(13.25280000,101.18151000);Amphoe Bo Thong|(13.24227000,101.50864000);Amphoe Ko Chan|(13.40253000,101.38800000)"
+Thailand,TH,Chumphon,Chumphon,Bangkok,,,10.49570000,99.17971000,Amphoe Lamae;Amphoe Lang Suan;Amphoe Mueang Chumphon,"Amphoe Lamae|(9.75567000,99.04378000);Amphoe Lang Suan|(9.93386000,99.05292000);Amphoe Mueang Chumphon|(10.46077000,99.10608000)"
+Thailand,TH,Kalasin,Kalasin,Bangkok,,,16.43281000,103.50658000,Amphoe Don Chan;Amphoe Huai Mek;Amphoe Huai Phueng,"Amphoe Don Chan|(16.46667000,103.71667000);Amphoe Huai Mek|(16.58868000,103.24098000);Amphoe Huai Phueng|(16.66972000,103.87997000)"
+Thailand,TH,Kamphaeng Phet,Kamphaeng Phet,Bangkok,,,16.48344000,99.52153000,Amphoe Bueng Samakkhi;Amphoe Khanu Woralaksaburi;Amphoe Khlong Khlung,"Amphoe Bueng Samakkhi|(16.21262000,99.96720000);Amphoe Khanu Woralaksaburi|(16.00233000,99.67618000);Amphoe Khlong Khlung|(16.22191000,99.67654000)"
+Thailand,TH,Kanchanaburi,Kanchanaburi,Bangkok,,,14.00412000,99.54832000,Amphoe Bo Phloi;Amphoe Dan Makham Tia;Amphoe Huai Krachao,"Amphoe Bo Phloi|(14.38723000,99.44990000);Amphoe Dan Makham Tia|(13.83422000,99.34125000);Amphoe Huai Krachao|(14.34056000,99.67633000)"
+Thailand,TH,Khon Kaen,Khon Kaen,Bangkok,,,16.44671000,102.83300000,Amphoe Ban Fang;Amphoe Ban Haet;Amphoe Ban Phai,"Amphoe Ban Fang|(16.49162000,102.61669000);Amphoe Ban Haet|(16.20067000,102.77465000);Amphoe Ban Phai|(16.04603000,102.77755000)"
+Thailand,TH,Krabi,Krabi,Bangkok,,,8.07257000,98.91052000,Amphoe Ao Luek;Amphoe Khao Phanom;Amphoe Khlong Thom,"Amphoe Ao Luek|(8.38526000,98.75378000);Amphoe Khao Phanom|(8.26953000,99.11813000);Amphoe Khlong Thom|(7.91470000,99.19935000)"
+Thailand,TH,Lampang,Lampang,Bangkok,,,18.29232000,99.49277000,Amphoe Chae Hom;Amphoe Hang Chat;Amphoe Ko Kha,"Amphoe Chae Hom|(18.75404000,99.66822000);Amphoe Hang Chat|(18.35497000,99.27978000);Amphoe Ko Kha|(18.14408000,99.35229000)"
+Thailand,TH,Lamphun,Lamphun,Bangkok,,,18.58054000,99.00745000,Amphoe Ban Hong;Amphoe Ban Thi;Amphoe Li,"Amphoe Ban Hong|(18.27422000,98.83794000);Amphoe Ban Thi|(18.65894000,99.15883000);Amphoe Li|(17.78639000,98.88674000)"
+Thailand,TH,Loei,Loei,Bangkok,,,17.49052000,101.72749000,Amphoe Chiang Khan;Amphoe Dan Sai;Amphoe Erawan,"Amphoe Chiang Khan|(17.82441000,101.73424000);Amphoe Dan Sai|(17.22101000,101.22373000);Amphoe Erawan|(17.28823000,101.97443000)"
+Thailand,TH,Lop Buri,Lop Buri,Bangkok,,,14.79808000,100.65397000,Amphoe Ban Mi;Amphoe Chai Badan;Amphoe Khok Charoen,"Amphoe Ban Mi|(15.06154000,100.55200000);Amphoe Chai Badan|(15.18944000,101.12682000);Amphoe Khok Charoen|(15.40384000,100.84968000)"
+Thailand,TH,Mae Hong Son,Mae Hong Son,Bangkok,,,19.30029000,97.96852000,Amphoe Khun Yuam;Amphoe Mae La Noi;Amphoe Mae Sariang,"Amphoe Khun Yuam|(18.82643000,97.93303000);Amphoe Mae La Noi|(18.47823000,97.98295000);Amphoe Mae Sariang|(18.26474000,97.77057000)"
+Thailand,TH,Maha Sarakham,Maha Sarakham,Bangkok,,,16.18483000,103.30067000,Amphoe Borabue;Amphoe Chiang Yuen;Amphoe Chuen Chom,"Amphoe Borabue|(15.98881000,103.12521000);Amphoe Chiang Yuen|(16.40942000,103.07005000);Amphoe Chuen Chom|(16.54801000,103.14796000)"
+Thailand,TH,Mukdahan,Mukdahan,Bangkok,,,16.54531000,104.72351000,Amphoe Don Tan;Amphoe Dong Luang;Amphoe Khamcha-i,"Amphoe Don Tan|(16.28796000,104.82231000);Amphoe Dong Luang|(16.79649000,104.35562000);Amphoe Khamcha-i|(16.61452000,104.35929000)"
+Thailand,TH,Nakhon Nayok,Nakhon Nayok,Bangkok,,,14.20463000,101.21295000,Amphoe Ban Na;Amphoe Mueang Nakhon Nayok;Amphoe Ongkharak,"Amphoe Ban Na|(14.26799000,101.06445000);Amphoe Mueang Nakhon Nayok|(14.27730000,101.23379000);Amphoe Ongkharak|(14.07554000,101.00891000)"
+Thailand,TH,Nakhon Pathom,Nakhon Pathom,Bangkok,,,13.81960000,100.04427000,Amphoe Bang Len;Amphoe Don Tum;Amphoe Mueang Nakhon Pathom,"Amphoe Bang Len|(14.05000000,100.18333000);Amphoe Don Tum|(13.94499000,100.09003000);Amphoe Mueang Nakhon Pathom|(13.81944000,100.02375000)"
+Thailand,TH,Nakhon Phanom,Nakhon Phanom,Bangkok,,,17.41081000,104.77856000,Amphoe Ban Phaeng;Amphoe Mueang Nakhon Phanom;Amphoe Na Kae,"Amphoe Ban Phaeng|(17.86955000,104.22744000);Amphoe Mueang Nakhon Phanom|(17.31965000,104.68232000);Amphoe Na Kae|(16.95737000,104.49349000)"
+Thailand,TH,Nakhon Ratchasima,Nakhon Ratchasima,Bangkok,,,14.97066000,102.10196000,Amphoe Ban Lueam;Amphoe Bua Lai;Amphoe Bua Yai,"Amphoe Ban Lueam|(15.57431000,102.14204000);Amphoe Bua Lai|(15.66917000,102.51761000);Amphoe Bua Yai|(15.58488000,102.38738000)"
+Thailand,TH,Nakhon Sawan,Nakhon Sawan,Bangkok,,,15.70472000,100.13717000,Amphoe Banphot Phisai;Amphoe Chum Ta Bong;Amphoe Chumsaeng,"Amphoe Banphot Phisai|(15.99714000,99.99409000);Amphoe Chum Ta Bong|(15.68311000,99.56908000);Amphoe Chumsaeng|(15.84745000,100.28971000)"
+Thailand,TH,Nakhon Si Thammarat,Nakhon Si Thammarat,Bangkok,,,8.43333000,99.96667000,Amphoe Bang Khan;Amphoe Cha-uat;Amphoe Chaloem Phra Kiat,"Amphoe Bang Khan|(8.01208000,99.48449000);Amphoe Cha-uat|(7.95645000,99.98929000);Amphoe Chaloem Phra Kiat|(8.18333000,100.05000000)"
+Thailand,TH,Nan,Nan,Bangkok,,,18.78378000,100.77899000,Amphoe Ban Luang;Amphoe Bo Kluea;Amphoe Chaloem Phra Kiat,"Amphoe Ban Luang|(18.88375000,100.46014000);Amphoe Bo Kluea|(19.08994000,101.18952000);Amphoe Chaloem Phra Kiat|(19.50618000,101.14249000)"
+Thailand,TH,Narathiwat,Narathiwat,Bangkok,,,6.42639000,101.82308000,Amphoe Ba Cho;Amphoe Chanae;Amphoe Cho-airong,"Amphoe Ba Cho|(6.54591000,101.64923000);Amphoe Chanae|(6.04591000,101.61765000);Amphoe Cho-airong|(6.23011000,101.84721000)"
+Thailand,TH,Nong Bua Lam Phu,Amphoe Mueang Nong Bua Lamphu,Bangkok,,,17.15818000,102.39860000,Amphoe Mueang Nong Bua Lamphu;Amphoe Na Klang;Amphoe Na Wang,"Amphoe Mueang Nong Bua Lamphu|(17.15818000,102.39860000);Amphoe Na Klang|(17.32466000,102.21456000);Amphoe Na Wang|(17.34290000,102.07157000)"
+Thailand,TH,Nong Khai,Nong Khai,Bangkok,,,17.87847000,102.74200000,Amphoe Fao Rai;Amphoe Mueang Nong Khai;Amphoe Pho Tak,"Amphoe Fao Rai|(18.00275000,103.29640000);Amphoe Mueang Nong Khai|(17.84661000,102.78911000);Amphoe Pho Tak|(17.88819000,102.43023000)"
+Thailand,TH,Nonthaburi,Amphoe Bang Bua Thong,Bangkok,,,13.92641000,100.39360000,Amphoe Bang Bua Thong;Amphoe Bang Kruai;Amphoe Bang Yai,"Amphoe Bang Bua Thong|(13.92641000,100.39360000);Amphoe Bang Kruai|(13.80249000,100.41525000);Amphoe Bang Yai|(13.85385000,100.37318000)"
+Thailand,TH,Pathum Thani,Pathum Thani,Bangkok,,,14.01346000,100.53049000,Amphoe Khlong Luang;Amphoe Lam Luk Ka;Amphoe Lat Lum Kaeo,"Amphoe Khlong Luang|(14.09323000,100.68106000);Amphoe Lam Luk Ka|(13.97744000,100.79244000);Amphoe Lat Lum Kaeo|(14.04459000,100.40948000)"
+Thailand,TH,Pattani,Pattani,Bangkok,,,6.86814000,101.25009000,Amphoe Kapho;Amphoe Khok Pho;Amphoe Mae Lan,"Amphoe Kapho|(6.60264000,101.54327000);Amphoe Khok Pho|(6.70858000,101.11693000);Amphoe Mae Lan|(6.66833000,101.23149000)"
+Thailand,TH,Pattaya,,Bangkok,,,,,,
+Thailand,TH,Phangnga,Amphoe Kapong,Bangkok,,,8.74139000,98.47542000,Amphoe Kapong;Amphoe Khura Buri;Amphoe Ko Yao,"Amphoe Kapong|(8.74139000,98.47542000);Amphoe Khura Buri|(9.18972000,98.40806000);Amphoe Ko Yao|(8.06549000,98.57851000)"
+Thailand,TH,Phatthalung,Phatthalung,Bangkok,,,7.61786000,100.07792000,Amphoe Bang Kaeo;Amphoe Khao Chaison;Amphoe Khuan Khanun,"Amphoe Bang Kaeo|(7.41775000,100.17164000);Amphoe Khao Chaison|(7.46305000,100.09055000);Amphoe Khuan Khanun|(7.76438000,100.04349000)"
+Thailand,TH,Phayao,Phayao,Bangkok,,,19.19203000,99.87883000,Amphoe Chiang Kham;Amphoe Chiang Muan;Amphoe Chun,"Amphoe Chiang Kham|(19.47061000,100.33868000);Amphoe Chiang Muan|(18.90385000,100.31792000);Amphoe Chun|(19.36803000,100.14492000)"
+Thailand,TH,Phetchabun,Phetchabun,Bangkok,,,16.41904000,101.16056000,Amphoe Bueng Sam Phan;Amphoe Chon Daen;Amphoe Khao Kho,"Amphoe Bueng Sam Phan|(15.81650000,101.00399000);Amphoe Chon Daen|(16.10735000,100.83572000);Amphoe Khao Kho|(16.66313000,100.99450000)"
+Thailand,TH,Phetchaburi,Phetchaburi,Bangkok,,,13.11189000,99.94467000,Amphoe Ban Laem;Amphoe Ban Lat;Amphoe Cha-am,"Amphoe Ban Laem|(13.16968000,99.98771000);Amphoe Ban Lat|(13.04533000,99.83788000);Amphoe Cha-am|(12.75374000,99.89828000)"
+Thailand,TH,Phichit,Phichit,Bangkok,,,16.44184000,100.34879000,Amphoe Bang Mun Nak;Amphoe Bueng Na Rang;Amphoe Dong Charoen,"Amphoe Bang Mun Nak|(16.02656000,100.43194000);Amphoe Bueng Na Rang|(16.18642000,100.14293000);Amphoe Dong Charoen|(15.99848000,100.59572000)"
+Thailand,TH,Phitsanulok,Phitsanulok,Bangkok,,,16.82481000,100.25858000,Amphoe Bang Krathum;Amphoe Bang Rakam;Amphoe Chat Trakan,"Amphoe Bang Krathum|(16.59323000,100.35042000);Amphoe Bang Rakam|(16.71844000,100.04217000);Amphoe Chat Trakan|(17.39357000,100.68460000)"
+Thailand,TH,Phra Nakhon Si Ayutthaya,Phra Nakhon Si Ayutthaya,Bangkok,,,14.35167000,100.57739000,Amphoe Ban Phraek;Amphoe Bang Ban;Amphoe Bang Pa-in,"Amphoe Ban Phraek|(14.64381000,100.54883000);Amphoe Bang Ban|(14.38333000,100.46667000);Amphoe Bang Pa-in|(14.23482000,100.59410000)"
+Thailand,TH,Phrae,Phrae,Bangkok,,,18.14589000,100.14103000,Amphoe Den Chai;Amphoe Long;Amphoe Mueang Phrae,"Amphoe Den Chai|(17.91667000,100.03333000);Amphoe Long|(18.14262000,99.90901000);Amphoe Mueang Phrae|(18.12258000,100.25620000)"
+Thailand,TH,Phuket,Phuket,Bangkok,,,7.89059000,98.39810000,Amphoe Kathu;Amphoe Mueang Phuket;Amphoe Thalang,"Amphoe Kathu|(7.91456000,98.33330000);Amphoe Mueang Phuket|(7.85609000,98.37183000);Amphoe Thalang|(8.03407000,98.33399000)"
+Thailand,TH,Prachin Buri,Prachin Buri,Bangkok,,,14.04992000,101.36864000,Amphoe Ban Sang;Amphoe Kabin Buri;Amphoe Mueang Prachin Buri,"Amphoe Ban Sang|(13.95005000,101.25063000);Amphoe Kabin Buri|(13.90000000,101.80000000);Amphoe Mueang Prachin Buri|(14.09335000,101.39776000)"
+Thailand,TH,Prachuap Khiri Khan,Prachuap Khiri Khan,Bangkok,,,11.82098000,99.78410000,Amphoe Bang Saphan;Amphoe Bang Saphan Noi;Amphoe Hua Hin,"Amphoe Bang Saphan|(11.29402000,99.44406000);Amphoe Bang Saphan Noi|(11.07057000,99.34105000);Amphoe Hua Hin|(12.53522000,99.70366000)"
+Thailand,TH,Ranong,Ranong,Bangkok,,,9.96583000,98.63476000,Amphoe Kapoe;Amphoe Kra Buri;Amphoe La-un,"Amphoe Kapoe|(9.53028000,98.62369000);Amphoe Kra Buri|(10.45895000,98.84373000);Amphoe La-un|(10.09691000,98.78498000)"
+Thailand,TH,Ratchaburi,Ratchaburi,Bangkok,,,13.53671000,99.81712000,Amphoe Ban Kha;Amphoe Ban Pong;Amphoe Bang Phae,"Amphoe Ban Kha|(13.32374000,99.37323000);Amphoe Ban Pong|(13.81660000,99.82147000);Amphoe Bang Phae|(13.68333000,99.98333000)"
+Thailand,TH,Rayong,Rayong,Bangkok,,,12.68095000,101.25798000,Amphoe Ban Chang;Amphoe Ban Khai;Amphoe Khao Chamao,"Amphoe Ban Chang|(12.73230000,101.04878000);Amphoe Ban Khai|(12.83827000,101.34210000);Amphoe Khao Chamao|(12.99042000,101.67847000)"
+Thailand,TH,Roi Et,Roi Et,Bangkok,,,16.05670000,103.65309000,Amphoe At Samat;Amphoe Changhan;Amphoe Chaturaphak Phiman,"Amphoe At Samat|(15.84014000,103.86619000);Amphoe Changhan|(16.16213000,103.61605000);Amphoe Chaturaphak Phiman|(15.82670000,103.54934000)"
+Thailand,TH,Sa Kaeo,Sa Kaeo,Bangkok,,,13.81411000,102.07222000,Amphoe Aranyaprathet;Amphoe Khao Chakan;Amphoe Khlong Hat,"Amphoe Aranyaprathet|(13.69086000,102.47693000);Amphoe Khao Chakan|(13.62293000,102.02665000);Amphoe Khlong Hat|(13.47396000,102.27604000)"
+Thailand,TH,Sakon Nakhon,Sakon Nakhon,Bangkok,,,17.16116000,104.14725000,Amphoe Akat Amnuai;Amphoe Ban Muang;Amphoe Charoen Sin,"Amphoe Akat Amnuai|(17.63589000,103.97590000);Amphoe Ban Muang|(17.89569000,103.52793000);Amphoe Charoen Sin|(17.63327000,103.52218000)"
+Thailand,TH,Samut Prakan,Samut Prakan,Bangkok,,,13.59934000,100.59675000,Amphoe Bang Bo;Amphoe Bang Phli;Amphoe Bang Sao Thong,"Amphoe Bang Bo|(13.58960000,100.86711000);Amphoe Bang Phli|(13.61972000,100.72582000);Amphoe Bang Sao Thong|(13.63286000,100.81038000)"
+Thailand,TH,Samut Sakhon,Samut Sakhon,Bangkok,,,13.54753000,100.27362000,Amphoe Ban Phaeo;Amphoe Krathum Baen;Amphoe Mueang Samut Sakhon,"Amphoe Ban Phaeo|(13.58747000,100.11789000);Amphoe Krathum Baen|(13.65570000,100.27282000);Amphoe Mueang Samut Sakhon|(13.53163000,100.25326000)"
+Thailand,TH,Samut Songkhram,Samut Songkhram,Bangkok,,,13.41456000,100.00264000,Amphoe Amphawa;Amphoe Bang Khonthi;Amphoe Mueang Samut Songkhram,"Amphoe Amphawa|(13.36721000,99.91232000);Amphoe Bang Khonthi|(13.47448000,99.94838000);Amphoe Mueang Samut Songkhram|(13.39587000,99.99929000)"
+Thailand,TH,Saraburi,Saraburi,Bangkok,,,14.53333000,100.91667000,Amphoe Ban Mo;Amphoe Chaloem Phra Kiat;Amphoe Don Phut,"Amphoe Ban Mo|(14.60804000,100.72404000);Amphoe Chaloem Phra Kiat|(14.65671000,100.90838000);Amphoe Don Phut|(14.60758000,100.61578000)"
+Thailand,TH,Satun,Satun,Bangkok,,,6.62314000,100.06676000,Amphoe Khuan Don;Amphoe Khuan Kalong;Amphoe La-Ngu,"Amphoe Khuan Don|(6.76978000,100.12216000);Amphoe Khuan Kalong|(6.90593000,100.04178000);Amphoe La-Ngu|(6.90392000,99.79836000)"
+Thailand,TH,Si Sa Ket,Si Sa Ket,Bangkok,,,15.11481000,104.32938000,Amphoe Benchalak;Amphoe Bueng Bun;Amphoe Huai Thap Than,"Amphoe Benchalak|(14.78319000,104.71879000);Amphoe Bueng Bun|(15.30288000,104.06166000);Amphoe Huai Thap Than|(15.01808000,104.03875000)"
+Thailand,TH,Sing Buri,Sing Buri,Bangkok,,,14.88786000,100.40464000,Amphoe Bang Rachan;Amphoe In Buri;Amphoe Khai Bang Rachan,"Amphoe Bang Rachan|(14.89959000,100.27795000);Amphoe In Buri|(15.02057000,100.34865000);Amphoe Khai Bang Rachan|(14.81438000,100.31389000)"
+Thailand,TH,Songkhla,Songkhla,Bangkok,,,7.19882000,100.59510000,Amphoe Bang Klam;Amphoe Chana;Amphoe Hat Yai,"Amphoe Bang Klam|(7.06404000,100.40664000);Amphoe Chana|(6.89584000,100.70126000);Amphoe Hat Yai|(6.98092000,100.46539000)"
+Thailand,TH,Sukhothai,Sukhothai,Bangkok,,,17.00778000,99.82300000,Amphoe Ban Dan Lan Hoi;Amphoe Khiri Mat;Amphoe Kong Krailat,"Amphoe Ban Dan Lan Hoi|(17.05278000,99.49148000);Amphoe Khiri Mat|(16.82923000,99.73976000);Amphoe Kong Krailat|(16.93115000,99.97414000)"
+Thailand,TH,Suphan Buri,Suphan Buri,Bangkok,,,14.47418000,100.12218000,Amphoe Bang Pla Ma;Amphoe Dan Chang;Amphoe Doembang Nangbuat,"Amphoe Bang Pla Ma|(14.34985000,100.14479000);Amphoe Dan Chang|(14.88388000,99.51642000);Amphoe Doembang Nangbuat|(14.87394000,100.04669000)"
+Thailand,TH,Surat Thani,Surat Thani,Bangkok,,,9.14011000,99.33311000,Amphoe Ban Na Doem;Amphoe Ban Na San;Amphoe Ban Takhun,"Amphoe Ban Na Doem|(8.90610000,99.28136000);Amphoe Ban Na San|(8.80063000,99.40201000);Amphoe Ban Takhun|(9.10423000,98.67222000)"
+Thailand,TH,Surin,Surin,Bangkok,,,14.88181000,103.49364000,Amphoe Bua Chet;Amphoe Chom Phra;Amphoe Chumphon Buri,"Amphoe Bua Chet|(14.48406000,103.97809000);Amphoe Chom Phra|(15.14356000,103.57881000);Amphoe Chumphon Buri|(15.37942000,103.37095000)"
+Thailand,TH,Tak,Tak,Bangkok,,,16.86968000,99.12898000,Amphoe Ban Tak;Amphoe Mae Ramat;Amphoe Mae Sot,"Amphoe Ban Tak|(17.09163000,99.06648000);Amphoe Mae Ramat|(17.11180000,98.58635000);Amphoe Mae Sot|(16.72154000,98.71074000)"
+Thailand,TH,Trang,Trang,Bangkok,,,7.55633000,99.61141000,Amphoe Hat Samran;Amphoe Huai Yot;Amphoe Kantang,"Amphoe Hat Samran|(7.25733000,99.58160000);Amphoe Huai Yot|(7.80063000,99.60500000);Amphoe Kantang|(7.38563000,99.47064000)"
+Thailand,TH,Trat,Trat,Bangkok,,,12.24364000,102.51514000,Amphoe Bo Rai;Amphoe Khao Saming;Amphoe Khlong Yai,"Amphoe Bo Rai|(12.55816000,102.56566000);Amphoe Khao Saming|(12.42885000,102.41784000);Amphoe Khlong Yai|(11.85540000,102.82596000)"
+Thailand,TH,Ubon Ratchathani,Ubon Ratchathani,Bangkok,,,15.23844000,104.84866000,Amphoe Buntharik;Amphoe Det Udom;Amphoe Don Mot Daeng,"Amphoe Buntharik|(14.70495000,105.40444000);Amphoe Det Udom|(14.85153000,105.07511000);Amphoe Don Mot Daeng|(15.37694000,105.02107000)"
+Thailand,TH,Udon Thani,Udon Thani,Bangkok,,,17.41567000,102.78589000,Amphoe Ban Dung;Amphoe Ban Phue;Amphoe Chai Wan,"Amphoe Ban Dung|(17.71134000,103.26729000);Amphoe Ban Phue|(17.67709000,102.44563000);Amphoe Chai Wan|(17.21581000,103.27832000)"
+Thailand,TH,Uthai Thani,Uthai Thani,Bangkok,,,15.37939000,100.02450000,Amphoe Ban Rai;Amphoe Huai Khot;Amphoe Lan Sak,"Amphoe Ban Rai|(15.24921000,99.32817000);Amphoe Huai Khot|(15.32761000,99.51941000);Amphoe Lan Sak|(15.52289000,99.46110000)"
+Thailand,TH,Uttaradit,Uttaradit,Bangkok,,,17.62557000,100.09421000,Amphoe Ban Khok;Amphoe Fak Tha;Amphoe Lap Lae,"Amphoe Ban Khok|(18.14680000,101.06610000);Amphoe Fak Tha|(18.00078000,100.88885000);Amphoe Lap Lae|(17.65741000,100.01484000)"
+Thailand,TH,Yala,Yala,Bangkok,,,6.53995000,101.28128000,Amphoe Bannang Sata;Amphoe Betong;Amphoe Kabang,"Amphoe Bannang Sata|(6.25643000,101.27852000);Amphoe Betong|(5.86362000,101.22737000);Amphoe Kabang|(6.37923000,100.98348000)"
+Thailand,TH,Yasothon,Yasothon,Bangkok,,,15.79408000,104.14510000,Amphoe Kham Khuan Kaeo;Amphoe Kho Wang;Amphoe Kut Chum,"Amphoe Kham Khuan Kaeo|(15.67197000,104.33372000);Amphoe Kho Wang|(15.38164000,104.34109000);Amphoe Kut Chum|(16.04620000,104.30545000)"
+The Bahamas,BS,Acklins,,Nassau,,,,,,
+The Bahamas,BS,Acklins and Crooked Islands,,Nassau,,,,,,
+The Bahamas,BS,Berry Islands,,Nassau,,,,,,
+The Bahamas,BS,Bimini,Alice Town,Nassau,,,25.72800000,-79.29721000,Alice Town,"Alice Town|(25.72800000,-79.29721000)"
+The Bahamas,BS,Black Point,,Nassau,,,,,,
+The Bahamas,BS,Cat Island,Arthur’s Town,Nassau,,,24.62240000,-75.67151000,Arthur’s Town,"Arthur’s Town|(24.62240000,-75.67151000)"
+The Bahamas,BS,Central Abaco,Marsh Harbour,Nassau,,,26.54124000,-77.06360000,Marsh Harbour,"Marsh Harbour|(26.54124000,-77.06360000)"
+The Bahamas,BS,Central Andros,,Nassau,,,,,,
+The Bahamas,BS,Central Eleuthera,,Nassau,,,,,,
+The Bahamas,BS,Crooked Island,Colonel Hill,Nassau,,,22.75450000,-74.20415000,Colonel Hill,"Colonel Hill|(22.75450000,-74.20415000)"
+The Bahamas,BS,East Grand Bahama,High Rock,Nassau,,,26.60999000,-78.27863000,High Rock,"High Rock|(26.60999000,-78.27863000)"
+The Bahamas,BS,Exuma,George Town,Nassau,,,23.51616000,-75.78665000,George Town,"George Town|(23.51616000,-75.78665000)"
+The Bahamas,BS,Freeport,Freeport,Nassau,,,26.53333000,-78.70000000,Freeport;Lucaya,"Freeport|(26.53333000,-78.70000000);Lucaya|(26.53333000,-78.66667000)"
+The Bahamas,BS,Fresh Creek,,Nassau,,,,,,
+The Bahamas,BS,Governor's Harbour,,Nassau,,,,,,
+The Bahamas,BS,Grand Cay,,Nassau,,,,,,
+The Bahamas,BS,Green Turtle Cay,,Nassau,,,,,,
+The Bahamas,BS,Harbour Island,Dunmore Town,Nassau,,,25.50216000,-76.63633000,Dunmore Town,"Dunmore Town|(25.50216000,-76.63633000)"
+The Bahamas,BS,High Rock,,Nassau,,,,,,
+The Bahamas,BS,Hope Town,,Nassau,,,,,,
+The Bahamas,BS,Inagua,Matthew Town,Nassau,,,20.94982000,-73.67346000,Matthew Town,"Matthew Town|(20.94982000,-73.67346000)"
+The Bahamas,BS,Kemps Bay,,Nassau,,,,,,
+The Bahamas,BS,Long Island,Clarence Town,Nassau,,,23.10000000,-74.98333000,Clarence Town,"Clarence Town|(23.10000000,-74.98333000)"
+The Bahamas,BS,Mangrove Cay,,Nassau,,,,,,
+The Bahamas,BS,Marsh Harbour,,Nassau,,,,,,
+The Bahamas,BS,Mayaguana,Abraham’s Bay,Nassau,,,22.36667000,-72.96667000,Abraham’s Bay,"Abraham’s Bay|(22.36667000,-72.96667000)"
+The Bahamas,BS,New Providence,Nassau,Nassau,,,25.06666667,-77.33333333,Nassau,"Nassau|(25.06666667,-77.33333333)"
+The Bahamas,BS,Nichollstown and Berry Islands,,Nassau,,,,,,
+The Bahamas,BS,North Abaco,Cooper’s Town,Nassau,,,26.87137000,-77.51131000,Cooper’s Town,"Cooper’s Town|(26.87137000,-77.51131000)"
+The Bahamas,BS,North Andros,Andros Town,Nassau,,,24.70502000,-77.76912000,Andros Town;San Andros,"Andros Town|(24.70502000,-77.76912000);San Andros|(25.06667000,-78.05000000)"
+The Bahamas,BS,North Eleuthera,,Nassau,,,,,,
+The Bahamas,BS,Ragged Island,Duncan Town,Nassau,,,22.19083000,-75.72583000,Duncan Town,"Duncan Town|(22.19083000,-75.72583000)"
+The Bahamas,BS,Rock Sound,,Nassau,,,,,,
+The Bahamas,BS,Rum Cay,Port Nelson,Nassau,,,23.64967000,-74.84157000,Port Nelson,"Port Nelson|(23.64967000,-74.84157000)"
+The Bahamas,BS,San Salvador and Rum Cay,,Nassau,,,,,,
+The Bahamas,BS,San Salvador Island,Cockburn Town,Nassau,,,24.05179000,-74.53138000,Cockburn Town,"Cockburn Town|(24.05179000,-74.53138000)"
+The Bahamas,BS,Sandy Point,,Nassau,,,,,,
+The Bahamas,BS,South Abaco,,Nassau,,,,,,
+The Bahamas,BS,South Andros,,Nassau,,,,,,
+The Bahamas,BS,South Eleuthera,,Nassau,,,,,,
+The Bahamas,BS,Spanish Wells,Spanish Wells,Nassau,,,25.54717000,-76.76405000,Spanish Wells,"Spanish Wells|(25.54717000,-76.76405000)"
+The Bahamas,BS,West Grand Bahama,West End,Nassau,,,26.68711000,-78.97702000,West End,"West End|(26.68711000,-78.97702000)"
+The Gambia,GM,Banjul,Banjul,Banjul,,,13.45274000,-16.57803000,Bakau;Banjul;Kombo Saint Mary District,"Bakau|(13.47806000,-16.68194000);Banjul|(13.45274000,-16.57803000);Kombo Saint Mary District|(13.44389000,-16.64583000)"
+The Gambia,GM,Central River,Bansang,Banjul,,,13.43333000,-14.65000000,Bansang;Brikama Nding;Dankunku,"Bansang|(13.43333000,-14.65000000);Brikama Nding|(13.53333000,-14.93333000);Dankunku|(13.56667000,-15.31667000)"
+The Gambia,GM,Lower River,Baro Kunda,Banjul,,,13.48333000,-15.26667000,Baro Kunda;Bureng;Jali,"Baro Kunda|(13.48333000,-15.26667000);Bureng|(13.41667000,-15.28333000);Jali|(13.35000000,-15.96667000)"
+The Gambia,GM,North Bank,Bambali,Banjul,,,13.48333000,-15.33333000,Bambali;Barra;Central Baddibu,"Bambali|(13.48333000,-15.33333000);Barra|(13.48278000,-16.54556000);Central Baddibu|(13.53333000,-15.91667000)"
+The Gambia,GM,Upper River,Bakadagy,Banjul,,,13.30000000,-14.38333000,Bakadagy;Basse Santa Su;Brifu,"Bakadagy|(13.30000000,-14.38333000);Basse Santa Su|(13.30995000,-14.21373000);Brifu|(13.50000000,-13.93333000)"
+The Gambia,GM,West Coast,Abuko,Banjul,,,13.40417000,-16.65583000,Abuko;Brikama;Foni Bondali,"Abuko|(13.40417000,-16.65583000);Brikama|(13.27136000,-16.64944000);Foni Bondali|(13.21667000,-15.93333000)"
+Timor-Leste,TL,Aileu,Aileu,Dili,,,-8.72806000,125.56639000,Aileu;Lequidoe;Remexio,"Aileu|(-8.72806000,125.56639000);Lequidoe|(-8.69139000,125.63611000);Remexio|(-8.61667000,125.66667000)"
+Timor-Leste,TL,Ainaro,Ainaro,Dili,,,-8.99241000,125.50816000,Ainaro;Hato-Udo,"Ainaro|(-8.99241000,125.50816000);Hato-Udo|(-9.12036000,125.58935000)"
+Timor-Leste,TL,Baucau,Baucau,Dili,,,-8.46667000,126.45000000,Baguia;Baucau;Baukau,"Baguia|(-8.62787000,126.65743000);Baucau|(-8.46667000,126.45000000);Baukau|(-8.47572000,126.45633000)"
+Timor-Leste,TL,Bobonaro,Maliana,Dili,,,-8.99167000,125.21972000,Maliana,"Maliana|(-8.99167000,125.21972000)"
+Timor-Leste,TL,Cova Lima,Fatumean,Dili,,,-9.22917000,125.03583000,Fatumean;Fohorem;Maucatar,"Fatumean|(-9.22917000,125.03583000);Fohorem|(-9.28361000,125.08944000);Maucatar|(-9.21772000,125.22981000)"
+Timor-Leste,TL,Dili,Dili,Dili,,,-8.55861000,125.57361000,Atauro Island;Cristo Rei;Dili,"Atauro Island|(-8.26785000,125.59699000);Cristo Rei|(-8.52047000,125.60837000);Dili|(-8.55861000,125.57361000)"
+Timor-Leste,TL,Ermera,Ermera Villa,Dili,,,-8.75222000,125.39694000,Ermera Villa;Gleno;Hatulia,"Ermera Villa|(-8.75222000,125.39694000);Gleno|(-8.72389000,125.43611000);Hatulia|(-8.81667000,125.31667000)"
+Timor-Leste,TL,Lautém,Iliomar,Dili,,,-8.70917000,126.82833000,Iliomar;Lautem;Lospalos,"Iliomar|(-8.70917000,126.82833000);Lautem|(-8.36514000,126.90389000);Lospalos|(-8.52167000,126.99833000)"
+Timor-Leste,TL,Liquiçá,Bazartete,Dili,,,-8.62464000,125.38168000,Bazartete;Likisá;Maubara,"Bazartete|(-8.62464000,125.38168000);Likisá|(-8.58750000,125.34194000);Maubara|(-8.61194000,125.20611000)"
+Timor-Leste,TL,Manatuto,Manatuto,Dili,,,-8.52207000,126.01516000,Barique;Laclo;Laclubar,"Barique|(-8.85472000,126.06556000);Laclo|(-8.55000000,125.91667000);Laclubar|(-8.74975000,125.91186000)"
+Timor-Leste,TL,Manufahi,Alas,Dili,,,-9.02730000,125.78680000,Alas;Fatuberliu;Same,"Alas|(-9.02730000,125.78680000);Fatuberliu|(-8.94790000,125.86633000);Same|(-9.00000000,125.65000000)"
+Timor-Leste,TL,Viqueque,Viqueque,Dili,,,-8.85908000,126.36972000,Lacluta;Ossu;Uatocarabau,"Lacluta|(-8.80000000,126.13333000);Ossu|(-8.73477000,126.38324000);Uatocarabau|(-8.75658000,126.68060000)"
+Togo,TG,Centrale,Sokodé,Lome,EMEA,11,8.98333000,1.13333000,Sokodé;Sotouboua;Tchamba,"Sokodé|(8.98333000,1.13333000);Sotouboua|(8.56340000,0.98399000);Tchamba|(9.03333000,1.41667000)"
+Togo,TG,Kara,Kara,Lome,EMEA,11,9.55111000,1.18611000,Bafilo;Bassar;Kandé,"Bafilo|(9.35000000,1.26667000);Bassar|(9.25025000,0.78213000);Kandé|(9.95778000,1.04472000)"
+Togo,TG,Maritime,Aného,Lome,EMEA,11,6.22798000,1.59190000,Aného;Lomé;Tabligbo,"Aného|(6.22798000,1.59190000);Lomé|(6.12874000,1.22154000);Tabligbo|(6.58333000,1.50000000)"
+Togo,TG,Plateaux,Amlamé,Lome,EMEA,11,7.46667000,0.90000000,Amlamé;Atakpamé;Badou,"Amlamé|(7.46667000,0.90000000);Atakpamé|(7.53333000,1.13333000);Badou|(7.58333000,0.60000000)"
+Togo,TG,Savanes,Dapaong,Lome,EMEA,11,10.86225000,0.20762000,Dapaong;Sansanné-Mango,"Dapaong|(10.86225000,0.20762000);Sansanné-Mango|(10.35917000,0.47083000)"
+Tonga,TO,Haʻapai,Pangai,Nuku'alofa,,,-19.81468000,-174.35423000,Pangai,"Pangai|(-19.81468000,-174.35423000)"
+Tonga,TO,ʻEua,‘Ohonua,Nuku'alofa,,,-21.33333000,-174.95000000,‘Ohonua,"‘Ohonua|(-21.33333000,-174.95000000)"
+Tonga,TO,Niuas,Hihifo,Nuku'alofa,,,-15.95440000,-173.79616000,Hihifo,"Hihifo|(-15.95440000,-173.79616000)"
+Tonga,TO,Tongatapu,Haveluloto,Nuku'alofa,,,-21.15216000,-175.21333000,Haveluloto;Kolonga;Nuku‘alofa,"Haveluloto|(-21.15216000,-175.21333000);Kolonga|(-21.13333000,-175.06667000);Nuku‘alofa|(-21.13938000,-175.20180000)"
+Tonga,TO,Vavaʻu,Neiafu,Nuku'alofa,,,-18.65060000,-173.98404000,Neiafu,"Neiafu|(-18.65060000,-173.98404000)"
+Trinidad and Tobago,TT,Arima,Arima,Port of Spain,,,10.63737000,-61.28228000,Arima,"Arima|(10.63737000,-61.28228000)"
+Trinidad and Tobago,TT,Chaguanas,Chaguanas,Port of Spain,,,10.51667000,-61.41667000,Chaguanas;Ward of Chaguanas,"Chaguanas|(10.51667000,-61.41667000);Ward of Chaguanas|(10.50000000,-61.38333000)"
+Trinidad and Tobago,TT,Couva-Tabaquite-Talparo,Couva,Port of Spain,,,10.42248000,-61.46748000,Couva;Tabaquite,"Couva|(10.42248000,-61.46748000);Tabaquite|(10.38824000,-61.29704000)"
+Trinidad and Tobago,TT,Diego Martin,Petit Valley,Port of Spain,,,10.69974000,-61.54717000,Petit Valley;Ward of Diego Martin,"Petit Valley|(10.69974000,-61.54717000);Ward of Diego Martin|(10.70000000,-61.58333000)"
+Trinidad and Tobago,TT,Eastern Tobago,Scarborough,Port of Spain,,,11.18229000,-60.73525000,Scarborough,"Scarborough|(11.18229000,-60.73525000)"
+Trinidad and Tobago,TT,Penal-Debe,Debe,Port of Spain,,,10.20846000,-61.45273000,Debe;Peñal,"Debe|(10.20846000,-61.45273000);Peñal|(10.16667000,-61.46667000)"
+Trinidad and Tobago,TT,Point Fortin,Point Fortin,Port of Spain,,,10.17411000,-61.68407000,Point Fortin,"Point Fortin|(10.17411000,-61.68407000)"
+Trinidad and Tobago,TT,Port of Spain,Port of Spain,Port of Spain,,,10.66668000,-61.51889000,Mucurapo;Port of Spain,"Mucurapo|(10.66253000,-61.53697000);Port of Spain|(10.66668000,-61.51889000)"
+Trinidad and Tobago,TT,Princes Town,Princes Town,Port of Spain,,,10.27184000,-61.37103000,Princes Town,"Princes Town|(10.27184000,-61.37103000)"
+Trinidad and Tobago,TT,Rio Claro-Mayaro,,Port of Spain,,,,,,
+Trinidad and Tobago,TT,San Fernando,San Fernando,Port of Spain,,,10.27969000,-61.46835000,Marabella;Mon Repos;San Fernando,"Marabella|(10.30618000,-61.44671000);Mon Repos|(10.27979000,-61.44590000);San Fernando|(10.27969000,-61.46835000)"
+Trinidad and Tobago,TT,San Juan-Laventille,Laventille,Port of Spain,,,10.64917000,-61.49889000,Laventille,"Laventille|(10.64917000,-61.49889000)"
+Trinidad and Tobago,TT,Sangre Grande,Sangre Grande,Port of Spain,,,10.58705000,-61.13008000,Sangre Grande,"Sangre Grande|(10.58705000,-61.13008000)"
+Trinidad and Tobago,TT,Siparia,Siparia,Port of Spain,,,10.14525000,-61.50740000,Siparia;Ward of Siparia,"Siparia|(10.14525000,-61.50740000);Ward of Siparia|(10.15000000,-61.46667000)"
+Trinidad and Tobago,TT,Tunapuna-Piarco,Arouca,Port of Spain,,,10.62877000,-61.33487000,Arouca;Paradise;Tunapuna,"Arouca|(10.62877000,-61.33487000);Paradise|(10.65298000,-61.36298000);Tunapuna|(10.65245000,-61.38878000)"
+Trinidad and Tobago,TT,Western Tobago,Rio Claro,Port of Spain,,,10.30594000,-61.17556000,Rio Claro,"Rio Claro|(10.30594000,-61.17556000)"
+Tunisia,TN,Ariana,Ariana,Tunis,,,36.86012000,10.19337000,Ariana;Ettadhamen-Mnihla;Kalaat el-Andalous,"Ariana|(36.86012000,10.19337000);Ettadhamen-Mnihla|(36.86250000,10.17030000);Kalaat el-Andalous|(36.88110000,10.26220000)"
+Tunisia,TN,Béja,Béja,Tunis,,,36.72564000,9.18169000,Amdoun;Béja;Goubellat,"Amdoun|(36.74420000,9.05130000);Béja|(36.72564000,9.18169000);Goubellat|(36.59560000,9.20780000)"
+Tunisia,TN,Ben Arous,Ben Arous,Tunis,,,36.75310000,10.22940000,Ben Arous;Hammam Lif;Mornag,"Ben Arous|(36.75310000,10.22940000);Hammam Lif|(36.72030000,10.32610000);Mornag|(36.66160000,10.14630000)"
+Tunisia,TN,Bizerte,Bizerte,Tunis,,,37.27442000,9.87391000,Al Matlīn;Bizerte;Bizerte Sud,"Al Matlīn|(37.24516000,10.05000000);Bizerte|(37.27442000,9.87391000);Bizerte Sud|(37.25528000,9.67915000)"
+Tunisia,TN,Gabès,Gabès,Tunis,,,33.88146000,10.09820000,Bou Attouche;El Hamma;Gabès,"Bou Attouche|(33.89927000,9.78496000);El Hamma|(33.89152000,9.79629000);Gabès|(33.88146000,10.09820000)"
+Tunisia,TN,Gafsa,Gafsa,Tunis,,,34.42500000,8.78417000,Ar Rudayyif;As Sanad;Gafsa,"Ar Rudayyif|(34.38270000,8.15549000);As Sanad|(34.46280000,9.26404000);Gafsa|(34.42500000,8.78417000)"
+Tunisia,TN,Jendouba,Jendouba,Tunis,,,36.48519000,8.82325000,Fernana;Jendouba;Oued Meliz,"Fernana|(36.65547000,8.69602000);Jendouba|(36.48519000,8.82325000);Oued Meliz|(36.46813000,8.54951000)"
+Tunisia,TN,Kairouan,Kairouan,Tunis,,,35.67810000,10.09633000,Haffouz;Kairouan;Sbikha,"Haffouz|(35.63235000,9.67624000);Kairouan|(35.67810000,10.09633000);Sbikha|(35.93325000,10.02081000)"
+Tunisia,TN,Kasserine,Kasserine,Tunis,,,35.16758000,8.83651000,Kasserine;Rohia;Sbiba,"Kasserine|(35.16758000,8.83651000);Rohia|(35.65129000,9.05306000);Sbiba|(35.54332000,9.07370000)"
+Tunisia,TN,Kebili,Kebili,Tunis,,,33.70439000,8.96903000,Douz;El Golaa;Jemna,"Douz|(33.46632000,9.02030000);El Golaa|(33.48485000,9.00678000);Jemna|(33.57778000,9.01472000)"
+Tunisia,TN,Kef,As Sars,Tunis,,,36.07640000,9.02117000,As Sars;El Kef;El Ksour,"As Sars|(36.07640000,9.02117000);El Kef|(36.17424000,8.70486000);El Ksour|(35.89607000,8.88493000)"
+Tunisia,TN,Mahdia,Mahdia,Tunis,,,35.50472000,11.06222000,Chebba;Chorbane;El Jem,"Chebba|(35.23722000,11.11500000);Chorbane|(35.28581000,10.38580000);El Jem|(35.30000000,10.71667000)"
+Tunisia,TN,Manouba,Manouba,Tunis,,,36.81006000,10.09557000,El Battan;Manouba;Mu‘tamadīyat Manūbah,"El Battan|(36.80368000,9.84424000);Manouba|(36.81006000,10.09557000);Mu‘tamadīyat Manūbah|(36.80907000,10.09467000)"
+Tunisia,TN,Medenine,Medenine,Tunis,,,33.35495000,10.50548000,Ben Gardane;Beni Kheddache;Erriadh,"Ben Gardane|(33.13783000,11.21965000);Beni Kheddache|(33.25279000,10.19883000);Erriadh|(33.82063000,10.85394000)"
+Tunisia,TN,Monastir,Monastir,Tunis,,,35.77799000,10.82617000,Banbalah;Bekalta;Beni Hassane,"Banbalah|(35.70000000,10.80000000);Bekalta|(35.61739000,10.99466000);Beni Hassane|(35.56720000,10.80869000)"
+Tunisia,TN,Nabeul,Nabeul,Tunis,,,36.45138900,10.73611100,Azmour;Beni Khalled;Béni Khiar,"Azmour|(36.92440000,11.00690000);Beni Khalled|(36.65038000,10.59004000);Béni Khiar|(36.46666667,10.78333333)"
+Tunisia,TN,Sfax,Sfax,Tunis,,,34.74056000,10.76028000,Agareb;Bir Ali Ben Khalifa;Djebeniana,"Agareb|(34.74406000,10.46110000);Bir Ali Ben Khalifa|(34.73592000,10.09240000);Djebeniana|(35.03500000,10.90809000)"
+Tunisia,TN,Sidi Bouzid,Sidi Bouzid,Tunis,,,35.03823000,9.48494000,Bir el Hafey;Er Regueb;Jilma,"Bir el Hafey|(34.93212000,9.19321000);Er Regueb|(34.85932000,9.78654000);Jilma|(35.27311000,9.42385000)"
+Tunisia,TN,Siliana,Siliana,Tunis,,,36.08497000,9.37082000,Bou Arada;Gafour;Kesra,"Bou Arada|(36.35251000,9.62175000);Gafour|(36.32045000,9.32424000);Kesra|(35.81363000,9.36434000)"
+Tunisia,TN,Sousse,Sousse,Tunis,,,35.82539000,10.63699000,Akouda;Hammam Sousse;Harqalah,"Akouda|(35.86910000,10.56530000);Hammam Sousse|(35.86090000,10.60313000);Harqalah|(36.03027000,10.50904000)"
+Tunisia,TN,Tataouine,Tataouine,Tunis,,,32.92967000,10.45177000,Remada;Tataouine,"Remada|(32.31662000,10.39551000);Tataouine|(32.92967000,10.45177000)"
+Tunisia,TN,Tozeur,Tozeur,Tunis,,,33.91968000,8.13352000,Chebika;Degache;Nefta,"Chebika|(34.31909000,7.93519000);Degache|(33.97606000,8.20810000);Nefta|(33.87309000,7.87765000)"
+Tunisia,TN,Tunis,Tunis,Tunis,,,36.81897000,10.16579000,Al Marsá;Carthage;La Goulette,"Al Marsá|(36.87818000,10.32466000);Carthage|(36.85961000,10.32978000);La Goulette|(36.81825000,10.30520000)"
+Tunisia,TN,Zaghouan,Zaghouan,Tunis,,,36.40291000,10.14292000,El Fahs;Zaghouan,"El Fahs|(36.37419000,9.90651000);Zaghouan|(36.40291000,10.14292000)"
+Turkey,TR,Adana,Adana,Ankara,,,36.99757530,35.12325260,Adana;Aladağ;Ceyhan,"Adana|(36.99757530,35.12325260);Aladağ|(37.55854000,35.40196000);Ceyhan|(37.02472000,35.81750000)"
+Turkey,TR,Adıyaman,Besni,Ankara,,,37.69278000,37.86111000,Besni;Çelikhan;Gerger,"Besni|(37.69278000,37.86111000);Çelikhan|(38.02560000,38.23665000);Gerger|(37.95000000,39.01667000)"
+Turkey,TR,Afyonkarahisar,Başmakçı,Ankara,,,37.89722000,30.01167000,Başmakçı;Bayat;Bolvadin,"Başmakçı|(37.89722000,30.01167000);Bayat|(38.98306000,30.92472000);Bolvadin|(38.71111000,31.04861000)"
+Turkey,TR,Ağrı,Diyadin,Ankara,,,39.54056000,43.67135000,Diyadin;Doğubayazıt;Eleşkirt,"Diyadin|(39.54056000,43.67135000);Doğubayazıt|(39.54694000,44.08417000);Eleşkirt|(39.79803000,42.67574000)"
+Turkey,TR,Aksaray,Ağaçören,Ankara,,,38.87484000,33.91674000,Ağaçören;Eskil;Gülağaç,"Ağaçören|(38.87484000,33.91674000);Eskil|(38.41158000,33.41994000);Gülağaç|(38.40641000,34.35071000)"
+Turkey,TR,Amasya,Göynücek,Ankara,,,40.39917000,35.52500000,Göynücek;Gümüşhacıköy;Hamamözü,"Göynücek|(40.39917000,35.52500000);Gümüşhacıköy|(40.87306000,35.21472000);Hamamözü|(40.79539000,35.03367000)"
+Turkey,TR,Ankara,Ankara,Ankara,,,39.90343670,32.43310030,Akyurt;Altındağ;Ankara,"Akyurt|(40.13512000,33.08614000);Altındağ|(40.00110000,32.97022000);Ankara|(39.90343670,32.43310030)"
+Turkey,TR,Antalya,Antalya,Ankara,,,36.89809830,30.55329070,Akseki;Aksu;Alanya,"Akseki|(37.04861000,31.79000000);Aksu|(36.95389000,30.84778000);Alanya|(36.54375000,31.99982000)"
+Turkey,TR,Ardahan,Çıldır,Ankara,,,41.13783000,43.14169000,Çıldır;Damal;Göle,"Çıldır|(41.13783000,43.14169000);Damal|(41.34145000,42.83680000);Göle|(40.78746000,42.60603000)"
+Turkey,TR,Artvin,Ardanuç,Ankara,,,41.12738000,42.06292000,Ardanuç;Arhavi;Borçka,"Ardanuç|(41.12738000,42.06292000);Arhavi|(41.35121000,41.30456000);Borçka|(41.35792000,41.66579000)"
+Turkey,TR,Aydın,Bozdoğan,Ankara,,,37.67134000,28.31395000,Bozdoğan;Buharkent;Çine,"Bozdoğan|(37.67134000,28.31395000);Buharkent|(37.96397000,28.74270000);Çine|(37.61266000,28.05912000)"
+Turkey,TR,Balıkesir,Altıeylül,Ankara,,,39.64099000,27.88639000,Altıeylül;Ayvalık;Balya,"Altıeylül|(39.64099000,27.88639000);Ayvalık|(39.31927000,26.69341000);Balya|(39.74861000,27.57889000)"
+Turkey,TR,Bartın,Amasra,Ankara,,,41.74633000,32.38633000,Amasra;Kurucaşile;Merkez,"Amasra|(41.74633000,32.38633000);Kurucaşile|(41.83781000,32.71621000);Merkez|(41.63583000,32.33750000)"
+Turkey,TR,Batman,Beşiri,Ankara,,,37.91573000,41.28650000,Beşiri;Gercüş;Hasankeyf,"Beşiri|(37.91573000,41.28650000);Gercüş|(37.59139000,41.33278000);Hasankeyf|(37.70612000,41.40480000)"
+Turkey,TR,Bayburt,Aydıntepe,Ankara,,,40.38325000,40.14272000,Aydıntepe;Demirözü;Merkez,"Aydıntepe|(40.38325000,40.14272000);Demirözü|(40.16560000,39.89343000);Merkez|(40.25631000,40.22289000)"
+Turkey,TR,Bilecik,Bozüyük,Ankara,,,39.90778000,30.03667000,Bozüyük;Gölpazarı;İnhisar,"Bozüyük|(39.90778000,30.03667000);Gölpazarı|(40.28472000,30.31722000);İnhisar|(40.04932000,30.38521000)"
+Turkey,TR,Bingöl,Adaklı,Ankara,,,39.22870000,40.48252000,Adaklı;Genç;Karlıova,"Adaklı|(39.22870000,40.48252000);Genç|(38.74773000,40.55343000);Karlıova|(39.29044000,41.00594000)"
+Turkey,TR,Bitlis,Adilcevaz,Ankara,,,38.79911000,42.73159000,Adilcevaz;Ahlat;Güroymak,"Adilcevaz|(38.79911000,42.73159000);Ahlat|(38.74890000,42.48007000);Güroymak|(38.57580000,42.01558000)"
+Turkey,TR,Bolu,Dörtdivan,Ankara,,,40.72052000,32.06314000,Dörtdivan;Gerede;Göynük,"Dörtdivan|(40.72052000,32.06314000);Gerede|(40.71364000,32.31263000);Göynük|(40.40028000,30.78833000)"
+Turkey,TR,Burdur,Ağlasun,Ankara,,,37.64944000,30.53417000,Ağlasun;Altınyayla;Bucak,"Ağlasun|(37.64944000,30.53417000);Altınyayla|(36.99722000,29.54579000);Bucak|(37.45917000,30.59500000)"
+Turkey,TR,Bursa,Büyükorhan,Ankara,,,39.78223000,28.89338000,Büyükorhan;Gemlik;Gürsu,"Büyükorhan|(39.78223000,28.89338000);Gemlik|(40.43510000,29.14943000);Gürsu|(40.25498000,29.21183000)"
+Turkey,TR,Çanakkale,Ayvacık,Ankara,,,39.60111000,26.40472000,Ayvacık;Bayramiç;Biga,"Ayvacık|(39.60111000,26.40472000);Bayramiç|(39.81951000,26.62490000);Biga|(40.26921000,27.20841000)"
+Turkey,TR,Çankırı,Atkaracalar,Ankara,,,40.81593000,33.07556000,Atkaracalar;Bayramören;Çerkeş,"Atkaracalar|(40.81593000,33.07556000);Bayramören|(40.94329000,33.20300000);Çerkeş|(40.81164000,32.89358000)"
+Turkey,TR,Çorum,Alaca,Ankara,,,40.16833000,34.84250000,Alaca;Bayat;Boğazkale,"Alaca|(40.16833000,34.84250000);Bayat|(40.64583000,34.26139000);Boğazkale|(40.03031000,34.61745000)"
+Turkey,TR,Denizli,Acıpayam,Ankara,,,37.42385000,29.34941000,Acıpayam;Babadağ;Baklan,"Acıpayam|(37.42385000,29.34941000);Babadağ|(37.80764000,28.85665000);Baklan|(37.97694000,29.60861000)"
+Turkey,TR,Diyarbakır,Bağlar,Ankara,,,37.91068000,40.22627000,Bağlar;Bismil;Çermik,"Bağlar|(37.91068000,40.22627000);Bismil|(37.84514000,40.65931000);Çermik|(38.13538000,39.44500000)"
+Turkey,TR,Düzce,Akçakoca,Ankara,,,41.08663000,31.11623000,Akçakoca;Çilimli;Cumayeri,"Akçakoca|(41.08663000,31.11623000);Çilimli|(40.90267000,31.05913000);Cumayeri|(40.88176000,30.94094000)"
+Turkey,TR,Edirne,Enez,Ankara,,,40.72472000,26.08250000,Enez;Havsa;İpsala,"Enez|(40.72472000,26.08250000);Havsa|(41.54898000,26.82207000);İpsala|(40.92115000,26.38273000)"
+Turkey,TR,Elazığ,Ağın,Ankara,,,38.93792000,38.71155000,Ağın;Alacakaya;Arıcak,"Ağın|(38.93792000,38.71155000);Alacakaya|(38.46269800,39.86275800);Arıcak|(38.56340000,40.12480000)"
+Turkey,TR,Erzincan,Çayırlı,Ankara,,,39.80454000,40.03724000,Çayırlı;İliç;Kemah,"Çayırlı|(39.80454000,40.03724000);İliç|(39.45587000,38.56409000);Kemah|(39.59606000,39.02329000)"
+Turkey,TR,Erzurum,Aşkale,Ankara,,,39.92083000,40.69500000,Aşkale;Aziziye;Çat,"Aşkale|(39.92083000,40.69500000);Aziziye|(39.94028000,41.11153000);Çat|(39.61055000,40.97851000)"
+Turkey,TR,Eskişehir,Alpu,Ankara,,,39.76903000,30.96060000,Alpu;Beylikova;Çifteler,"Alpu|(39.76903000,30.96060000);Beylikova|(39.68694000,31.20556000);Çifteler|(39.38306000,31.03917000)"
+Turkey,TR,Gaziantep,Araban,Ankara,,,37.42559000,37.78175000,Araban;İslahiye;Karkamış,"Araban|(37.42559000,37.78175000);İslahiye|(36.96528000,36.70972000);Karkamış|(36.83452000,37.99830000)"
+Turkey,TR,Giresun,Alucra,Ankara,,,40.31924000,38.76528000,Alucra;Bulancak;Çamoluk,"Alucra|(40.31924000,38.76528000);Bulancak|(40.93805000,38.23148000);Çamoluk|(40.13418000,38.73389000)"
+Turkey,TR,Gümüşhane,Kelkit,Ankara,,,40.12682000,39.43424000,Kelkit;Köse;Kürtün,"Kelkit|(40.12682000,39.43424000);Köse|(40.20692000,39.64626000);Kürtün|(40.69516000,39.09468000)"
+Turkey,TR,Hakkâri,Çukurca,Ankara,,,37.24806000,43.61361000,Çukurca;Derecik;Merkez,"Çukurca|(37.24806000,43.61361000);Derecik|(37.07242300,44.32434800);Merkez|(37.57444000,43.74083000)"
+Turkey,TR,Hatay,Altınözü,Ankara,,,36.11244000,36.24488000,Altınözü;Antakya;Arsuz,"Altınözü|(36.11244000,36.24488000);Antakya|(36.20655000,36.15722000);Arsuz|(36.41305000,35.89033000)"
+Turkey,TR,Iğdır,Aralık,Ankara,,,39.87277800,44.51916700,Aralık;Karakoyunlu;Merkez,"Aralık|(39.87277800,44.51916700);Karakoyunlu|(39.87036000,43.63014000);Merkez|(39.92371000,44.04500000)"
+Turkey,TR,Isparta,Aksu,Ankara,,,37.79889000,31.07111000,Aksu;Atabey;Eğirdir,"Aksu|(37.79889000,31.07111000);Atabey|(37.95083000,30.63861000);Eğirdir|(37.87462000,30.85042000)"
+Turkey,TR,İstanbul,Adalar,Ankara,,,40.86913000,29.12064000,Adalar;Arnavutköy;Ataşehir,"Adalar|(40.86913000,29.12064000);Arnavutköy|(41.19674000,28.73405000);Ataşehir|(40.99104000,29.13471000)"
+Turkey,TR,İzmir,İzmir,Ankara,,,38.41782870,26.91490300,Aliağa;Balçova;Bayındır,"Aliağa|(38.80078000,27.04375000);Balçova|(38.37302000,27.08714000);Bayındır|(38.21741000,27.64744000)"
+Turkey,TR,Kahramanmaraş,Afşin,Ankara,,,38.24769000,36.91399000,Afşin;Andırın;Çağlayancerit,"Afşin|(38.24769000,36.91399000);Andırın|(37.57757000,36.35492000);Çağlayancerit|(37.74523000,37.28618000)"
+Turkey,TR,Karabük,Eflani,Ankara,,,41.42289000,32.95761000,Eflani;Eskipazar;Merkez,"Eflani|(41.42289000,32.95761000);Eskipazar|(40.95207000,32.54604000);Merkez|(41.20488000,32.62768000)"
+Turkey,TR,Karaman,Ayrancı,Ankara,,,37.37111000,33.69291000,Ayrancı;Başyayla;Ermenek,"Ayrancı|(37.37111000,33.69291000);Başyayla|(36.75337000,32.68018000);Ermenek|(36.64043000,32.89179000)"
+Turkey,TR,Kars,Akyaka,Ankara,,,40.74093000,43.61432000,Akyaka;Arpaçay;Digor,"Akyaka|(40.74093000,43.61432000);Arpaçay|(40.84522000,43.32747000);Digor|(40.37515000,43.41361000)"
+Turkey,TR,Kastamonu,Abana,Ankara,,,41.97858000,34.01100000,Abana;Ağlı;Araç,"Abana|(41.97858000,34.01100000);Ağlı|(41.69283000,33.54487000);Araç|(41.24222000,33.32767000)"
+Turkey,TR,Kayseri,Kayseri,Ankara,,,38.72355320,35.30537320,Akkışla;Bünyan;Develi,"Akkışla|(39.00222000,36.17381000);Bünyan|(38.84630000,35.86033000);Develi|(38.26789000,35.59161000)"
+Turkey,TR,Kilis,Elbeyli,Ankara,,,36.67417000,37.46667000,Elbeyli;Merkez;Musabeyli,"Elbeyli|(36.67417000,37.46667000);Merkez|(36.71611000,37.11500000);Musabeyli|(36.88639000,36.91861000)"
+Turkey,TR,Kırıkkale,Bahşılı,Ankara,,,39.80979000,33.44080000,Bahşılı;Balışeyh;Çelebi,"Bahşılı|(39.80979000,33.44080000);Balışeyh|(39.91411000,33.72333000);Çelebi|(39.47470000,33.52895000)"
+Turkey,TR,Kırklareli,Babaeski,Ankara,,,41.43250000,27.09306000,Babaeski;Demirköy;Kofçaz,"Babaeski|(41.43250000,27.09306000);Demirköy|(41.83567000,27.77137000);Kofçaz|(41.94481000,27.15829000)"
+Turkey,TR,Kırşehir,Akçakent,Ankara,,,39.63184000,34.08468000,Akçakent;Akpınar;Boztepe,"Akçakent|(39.63184000,34.08468000);Akpınar|(39.45005000,33.96484000);Boztepe|(39.27979000,34.26657000)"
+Turkey,TR,Kocaeli,Başiskele,Ankara,,,40.64574000,29.90015000,Başiskele;Çayırova;Darıca,"Başiskele|(40.64574000,29.90015000);Çayırova|(40.82784000,29.39014000);Darıca|(40.76780000,29.37126000)"
+Turkey,TR,Konya,Ahırlı,Ankara,,,37.24828000,32.12419000,Ahırlı;Akören;Akşehir,"Ahırlı|(37.24828000,32.12419000);Akören|(37.46265000,32.37489000);Akşehir|(38.35750000,31.41639000)"
+Turkey,TR,Kütahya,Altıntaş,Ankara,,,39.06932000,30.12048000,Altıntaş;Aslanapa;Çavdarhisar,"Altıntaş|(39.06932000,30.12048000);Aslanapa|(39.21581000,29.86990000);Çavdarhisar|(39.20333000,29.63094000)"
+Turkey,TR,Malatya,Akçadağ,Ankara,,,38.33899000,37.97021000,Akçadağ;Arapgir;Arguvan,"Akçadağ|(38.33899000,37.97021000);Arapgir|(39.04117000,38.49516000);Arguvan|(38.78172000,38.26349000)"
+Turkey,TR,Manisa,Ahmetli,Ankara,,,38.51960000,27.93865000,Ahmetli;Akhisar;Alaşehir,"Ahmetli|(38.51960000,27.93865000);Akhisar|(38.91852000,27.84006000);Alaşehir|(38.35083000,28.51718000)"
+Turkey,TR,Mardin,Artuklu,Ankara,,,37.31714000,40.72473000,Artuklu;Dargeçit;Derik,"Artuklu|(37.31714000,40.72473000);Dargeçit|(37.54616000,41.71652000);Derik|(37.36431000,40.26883000)"
+Turkey,TR,Mersin,Mersin,Ankara,,,36.74287670,34.36409150,Akdeniz;Anamur;Aydıncık,"Akdeniz|(36.86424000,34.67731000);Anamur|(36.07508000,32.83691000);Aydıncık|(36.14370000,33.32016000)"
+Turkey,TR,Muğla,Bodrum,Ankara,,,37.06500000,27.49819000,Bodrum;Dalaman;Datça,"Bodrum|(37.06500000,27.49819000);Dalaman|(36.81691000,28.87815000);Datça|(36.73778000,27.68417000)"
+Turkey,TR,Muş,Bulanık,Ankara,,,39.08656000,42.27158000,Bulanık;Hasköy;Korkut,"Bulanık|(39.08656000,42.27158000);Hasköy|(38.68231000,41.67851000);Korkut|(38.73390000,41.78396000)"
+Turkey,TR,Nevşehir,Acıgöl,Ankara,,,38.55028000,34.50917000,Acıgöl;Avanos;Derinkuyu,"Acıgöl|(38.55028000,34.50917000);Avanos|(38.71500000,34.84667000);Derinkuyu|(38.37510000,34.73419000)"
+Turkey,TR,Niğde,Altunhisar,Ankara,,,37.99159000,34.37334000,Altunhisar;Bor;Çamardı,"Altunhisar|(37.99159000,34.37334000);Bor|(37.89056000,34.55889000);Çamardı|(37.84157000,34.99005000)"
+Turkey,TR,Ordu,Akkuş,Ankara,,,40.81000000,36.96000000,Akkuş;Altınordu;Aybastı,"Akkuş|(40.81000000,36.96000000);Altınordu|(40.94879000,37.79572000);Aybastı|(40.69690000,37.40794000)"
+Turkey,TR,Osmaniye,Bahçe,Ankara,,,37.20105000,36.57687000,Bahçe;Düziçi;Hasanbeyli,"Bahçe|(37.20105000,36.57687000);Düziçi|(37.25062000,36.47051000);Hasanbeyli|(37.12838000,36.54608000)"
+Turkey,TR,Rize,Ardeşen,Ankara,,,41.19111000,40.98750000,Ardeşen;Çamlıhemşin;Çayeli,"Ardeşen|(41.19111000,40.98750000);Çamlıhemşin|(41.04593800,41.00527500);Çayeli|(41.08941000,40.73696000)"
+Turkey,TR,Sakarya,Adapazarı,Ankara,,,40.78056000,30.40333000,Adapazarı;Akyazı;Arifiye,"Adapazarı|(40.78056000,30.40333000);Akyazı|(40.68500000,30.62222000);Arifiye|(40.71327000,30.36128000)"
+Turkey,TR,Samsun,Alaçam,Ankara,,,41.61563000,35.60632000,Alaçam;Asarcık;Atakum,"Alaçam|(41.61563000,35.60632000);Asarcık|(41.03556000,36.23556000);Atakum|(41.34730000,36.23051000)"
+Turkey,TR,Şanlıurfa,Akçakale,Ankara,,,36.71111000,38.94750000,Akçakale;Birecik;Bozova,"Akçakale|(36.71111000,38.94750000);Birecik|(37.02577000,37.97841000);Bozova|(37.36250000,38.52667000)"
+Turkey,TR,Siirt,Baykan,Ankara,,,38.15754000,41.77330000,Baykan;Eruh;Kurtalan,"Baykan|(38.15754000,41.77330000);Eruh|(37.74183000,42.17422000);Kurtalan|(37.92533000,41.68493000)"
+Turkey,TR,Sinop,Ayancık,Ankara,,,41.95000000,34.58333300,Ayancık;Boyabat;Dikmen,"Ayancık|(41.95000000,34.58333300);Boyabat|(41.46889000,34.76667000);Dikmen|(41.66000000,35.27055556)"
+Turkey,TR,Sivas,Akıncılar,Ankara,,,40.07172000,38.34330000,Akıncılar;Altınyayla;Divriği,"Akıncılar|(40.07172000,38.34330000);Altınyayla|(39.27249000,36.75098000);Divriği|(39.37100000,38.11370000)"
+Turkey,TR,Şırnak,Beytüşşebap,Ankara,,,37.57144000,43.16515000,Beytüşşebap;Cizre;Güçlükonak,"Beytüşşebap|(37.57144000,43.16515000);Cizre|(37.33024000,42.18484000);Güçlükonak|(37.47133000,41.91298000)"
+Turkey,TR,Tekirdağ,Çerkezköy,Ankara,,,41.28616000,27.99969000,Çerkezköy;Çorlu;Ergene,"Çerkezköy|(41.28616000,27.99969000);Çorlu|(41.15917000,27.80000000);Ergene|(40.85953000,27.27081000)"
+Turkey,TR,Tokat,Almus,Ankara,,,40.37583000,36.90444000,Almus;Artova;Başçiftlik,"Almus|(40.37583000,36.90444000);Artova|(40.11578000,36.30010000);Başçiftlik|(40.54694000,37.16917000)"
+Turkey,TR,Trabzon,Akçaabat,Ankara,,,41.01970000,39.56293000,Akçaabat;Araklı;Arsin,"Akçaabat|(41.01970000,39.56293000);Araklı|(40.74000000,39.96000000);Arsin|(40.86743000,39.92938000)"
+Turkey,TR,Tunceli,Çemişgezek,Ankara,,,39.06234000,38.91400000,Çemişgezek;Hozat;Mazgirt,"Çemişgezek|(39.06234000,38.91400000);Hozat|(39.10029000,39.20816000);Mazgirt|(39.01783000,39.60064000)"
+Turkey,TR,Uşak,Banaz,Ankara,,,38.73707000,29.75194000,Banaz;Eşme;Karahallı,"Banaz|(38.73707000,29.75194000);Eşme|(38.39976000,28.96905000);Karahallı|(38.32083000,29.53028000)"
+Turkey,TR,Van,Bahçesaray,Ankara,,,38.12460000,42.79825000,Bahçesaray;Başkale;Çaldıran,"Bahçesaray|(38.12460000,42.79825000);Başkale|(38.04526000,44.01718000);Çaldıran|(39.14317000,43.91068000)"
+Turkey,TR,Yalova,Altınova,Ankara,,,40.69495000,29.50986000,Altınova;Armutlu;Çiftlikköy,"Altınova|(40.69495000,29.50986000);Armutlu|(40.52919000,28.83871000);Çiftlikköy|(40.66028000,29.32361000)"
+Turkey,TR,Yozgat,Akdağmadeni,Ankara,,,39.66028000,35.88361000,Akdağmadeni;Aydıncık;Boğazlıyan,"Akdağmadeni|(39.66028000,35.88361000);Aydıncık|(40.12727000,35.28765000);Boğazlıyan|(39.19627000,35.25420000)"
+Turkey,TR,Zonguldak,Alaplı,Ankara,,,41.18140000,31.38514000,Alaplı;Çaycuma;Devrek,"Alaplı|(41.18140000,31.38514000);Çaycuma|(41.42639000,32.07556000);Devrek|(41.21917000,31.95583000)"
+Turkmenistan,TM,Ahal,Abadan,Ashgabat,,,38.05415000,58.19721000,Abadan;Annau;Arçabil,"Abadan|(38.05415000,58.19721000);Annau|(37.88754000,58.51596000);Arçabil|(37.91500000,58.08987000)"
+Turkmenistan,TM,Ashgabat,Ashgabat,Ashgabat,,,37.95000000,58.38333000,Ashgabat,"Ashgabat|(37.95000000,58.38333000)"
+Turkmenistan,TM,Balkan,Balkanabat,Ashgabat,,,39.51075000,54.36713000,Balkanabat;Bereket;Gumdag,"Balkanabat|(39.51075000,54.36713000);Bereket|(39.24463000,55.51536000);Gumdag|(39.20611000,54.59056000)"
+Turkmenistan,TM,Daşoguz,Daşoguz,Ashgabat,,,41.83625000,59.96661000,Akdepe;Boldumsaz;Daşoguz,"Akdepe|(42.05513000,59.37877000);Boldumsaz|(42.12824000,59.67101000);Daşoguz|(41.83625000,59.96661000)"
+Turkmenistan,TM,Lebap,Atamyrat,Ashgabat,,,37.83573000,65.21058000,Atamyrat;Farap;Gazojak,"Atamyrat|(37.83573000,65.21058000);Farap|(39.17037000,63.61165000);Gazojak|(41.18746000,61.40360000)"
+Turkmenistan,TM,Mary,Mary,Ashgabat,,,37.59378000,61.83031000,Bayramaly;Mary;Serhetabat,"Bayramaly|(37.61852000,62.16715000);Mary|(37.59378000,61.83031000);Serhetabat|(35.27992000,62.34383000)"
+Turks and Caicos Islands,TC,Grand Turk,,Cockburn Town,,,,,,
+Turks and Caicos Islands,TC,Middle Caicos,,Cockburn Town,,,,,,
+Turks and Caicos Islands,TC,North Caicos,,Cockburn Town,,,,,,
+Turks and Caicos Islands,TC,Providenciales,,Cockburn Town,,,,,,
+Turks and Caicos Islands,TC,Salt Cay,,Cockburn Town,,,,,,
+Turks and Caicos Islands,TC,South Caicos,,Cockburn Town,,,,,,
+Tuvalu,TV,Funafuti,Funafuti,Funafuti,,,-8.52425000,179.19417000,Alapi Village;Fakaifou Village;Funafuti,"Alapi Village|(-8.52074000,179.19680000);Fakaifou Village|(-8.51758000,179.20094000);Funafuti|(-8.52425000,179.19417000)"
+Tuvalu,TV,Nanumanga,Toga Village,Funafuti,,,-6.28764000,176.31472000,Toga Village,"Toga Village|(-6.28764000,176.31472000)"
+Tuvalu,TV,Nanumea,,Funafuti,,,,,,
+Tuvalu,TV,Niutao Island Council,Kulia Village,Funafuti,,,-6.10819000,177.33393000,Kulia Village;Niulakita,"Kulia Village|(-6.10819000,177.33393000);Niulakita|(-10.78800000,179.46600000)"
+Tuvalu,TV,Nui,Tanrake Village,Funafuti,,,-7.24562000,177.14511000,Tanrake Village,"Tanrake Village|(-7.24562000,177.14511000)"
+Tuvalu,TV,Nukufetau,Savave Village,Funafuti,,,-8.02731000,178.31351000,Savave Village,"Savave Village|(-8.02731000,178.31351000)"
+Tuvalu,TV,Nukulaelae,,Funafuti,,,,,,
+Tuvalu,TV,Vaitupu,Asau Village,Funafuti,,,-7.49026000,178.68016000,Asau Village,"Asau Village|(-7.49026000,178.68016000)"
+Uganda,UG,Abim,,Kampala,,,,,,
+Uganda,UG,Adjumani,,Kampala,,,,,,
+Uganda,UG,Agago,,Kampala,,,,,,
+Uganda,UG,Alebtong,,Kampala,,,,,,
+Uganda,UG,Amolatar,,Kampala,,,,,,
+Uganda,UG,Amudat,,Kampala,,,,,,
+Uganda,UG,Amuria,,Kampala,,,,,,
+Uganda,UG,Amuru,,Kampala,,,,,,
+Uganda,UG,Apac,,Kampala,,,,,,
+Uganda,UG,Arua,,Kampala,,,,,,
+Uganda,UG,Budaka,,Kampala,,,,,,
+Uganda,UG,Bududa,,Kampala,,,,,,
+Uganda,UG,Bugiri,,Kampala,,,,,,
+Uganda,UG,Bugweri,,Kampala,,,,,,
+Uganda,UG,Buhweju,,Kampala,,,,,,
+Uganda,UG,Buikwe,,Kampala,,,,,,
+Uganda,UG,Bukedea,,Kampala,,,,,,
+Uganda,UG,Bukomansimbi,,Kampala,,,,,,
+Uganda,UG,Bukwo,,Kampala,,,,,,
+Uganda,UG,Bulambuli,,Kampala,,,,,,
+Uganda,UG,Buliisa,,Kampala,,,,,,
+Uganda,UG,Bundibugyo,,Kampala,,,,,,
+Uganda,UG,Bunyangabu,,Kampala,,,,,,
+Uganda,UG,Bushenyi,,Kampala,,,,,,
+Uganda,UG,Busia,,Kampala,,,,,,
+Uganda,UG,Butaleja,,Kampala,,,,,,
+Uganda,UG,Butambala,,Kampala,,,,,,
+Uganda,UG,Butebo,,Kampala,,,,,,
+Uganda,UG,Buvuma,,Kampala,,,,,,
+Uganda,UG,Buyende,,Kampala,,,,,,
+Uganda,UG,Central,Bukomansimbi District,Kampala,,,-0.12855000,31.62527000,Bukomansimbi District;Buvuma District;Bweyogerere,"Bukomansimbi District|(-0.12855000,31.62527000);Buvuma District|(-0.36744000,33.20071000);Bweyogerere|(0.35773000,32.66332000)"
+Uganda,UG,Dokolo,,Kampala,,,,,,
+Uganda,UG,Eastern,Bugembe,Kampala,,,0.48213000,33.24065000,Bugembe;Bugiri;Bukwa District,"Bugembe|(0.48213000,33.24065000);Bugiri|(0.57139000,33.74167000);Bukwa District|(1.27115000,34.66778000)"
+Uganda,UG,Gomba,,Kampala,,,,,,
+Uganda,UG,Gulu,,Kampala,,,,,,
+Uganda,UG,Hoima,,Kampala,,,,,,
+Uganda,UG,Ibanda,,Kampala,,,,,,
+Uganda,UG,Iganga,,Kampala,,,,,,
+Uganda,UG,Isingiro,,Kampala,,,,,,
+Uganda,UG,Jinja,,Kampala,,,,,,
+Uganda,UG,Kaabong,,Kampala,,,,,,
+Uganda,UG,Kabale,,Kampala,,,,,,
+Uganda,UG,Kabarole,,Kampala,,,,,,
+Uganda,UG,Kaberamaido,,Kampala,,,,,,
+Uganda,UG,Kagadi,,Kampala,,,,,,
+Uganda,UG,Kakumiro,,Kampala,,,,,,
+Uganda,UG,Kalaki,,Kampala,,,,,,
+Uganda,UG,Kalangala,,Kampala,,,,,,
+Uganda,UG,Kaliro,,Kampala,,,,,,
+Uganda,UG,Kalungu,,Kampala,,,,,,
+Uganda,UG,Kampala,,Kampala,,,,,,
+Uganda,UG,Kamuli,,Kampala,,,,,,
+Uganda,UG,Kamwenge,,Kampala,,,,,,
+Uganda,UG,Kanungu,,Kampala,,,,,,
+Uganda,UG,Kapchorwa,,Kampala,,,,,,
+Uganda,UG,Kapelebyong,,Kampala,,,,,,
+Uganda,UG,Karenga,,Kampala,,,,,,
+Uganda,UG,Kasanda,,Kampala,,,,,,
+Uganda,UG,Kasese,,Kampala,,,,,,
+Uganda,UG,Katakwi,,Kampala,,,,,,
+Uganda,UG,Kayunga,,Kampala,,,,,,
+Uganda,UG,Kazo,,Kampala,,,,,,
+Uganda,UG,Kibaale,,Kampala,,,,,,
+Uganda,UG,Kiboga,,Kampala,,,,,,
+Uganda,UG,Kibuku,,Kampala,,,,,,
+Uganda,UG,Kikuube,,Kampala,,,,,,
+Uganda,UG,Kiruhura,,Kampala,,,,,,
+Uganda,UG,Kiryandongo,,Kampala,,,,,,
+Uganda,UG,Kisoro,,Kampala,,,,,,
+Uganda,UG,Kitagwenda,,Kampala,,,,,,
+Uganda,UG,Kitgum,,Kampala,,,,,,
+Uganda,UG,Koboko,,Kampala,,,,,,
+Uganda,UG,Kole,,Kampala,,,,,,
+Uganda,UG,Kotido,,Kampala,,,,,,
+Uganda,UG,Kumi,,Kampala,,,,,,
+Uganda,UG,Kwania,,Kampala,,,,,,
+Uganda,UG,Kween,,Kampala,,,,,,
+Uganda,UG,Kyankwanzi,,Kampala,,,,,,
+Uganda,UG,Kyegegwa,,Kampala,,,,,,
+Uganda,UG,Kyenjojo,,Kampala,,,,,,
+Uganda,UG,Kyotera,,Kampala,,,,,,
+Uganda,UG,Lamwo,,Kampala,,,,,,
+Uganda,UG,Lira,,Kampala,,,,,,
+Uganda,UG,Luuka,,Kampala,,,,,,
+Uganda,UG,Luwero,,Kampala,,,,,,
+Uganda,UG,Lwengo,,Kampala,,,,,,
+Uganda,UG,Lyantonde,,Kampala,,,,,,
+Uganda,UG,Madi-Okollo,,Kampala,,,,,,
+Uganda,UG,Manafwa,,Kampala,,,,,,
+Uganda,UG,Maracha,,Kampala,,,,,,
+Uganda,UG,Masaka,,Kampala,,,,,,
+Uganda,UG,Masindi,,Kampala,,,,,,
+Uganda,UG,Mayuge,,Kampala,,,,,,
+Uganda,UG,Mbale,,Kampala,,,,,,
+Uganda,UG,Mbarara,,Kampala,,,,,,
+Uganda,UG,Mitooma,,Kampala,,,,,,
+Uganda,UG,Mityana,,Kampala,,,,,,
+Uganda,UG,Moroto,,Kampala,,,,,,
+Uganda,UG,Moyo,,Kampala,,,,,,
+Uganda,UG,Mpigi,,Kampala,,,,,,
+Uganda,UG,Mubende,,Kampala,,,,,,
+Uganda,UG,Mukono,,Kampala,,,,,,
+Uganda,UG,Nabilatuk,,Kampala,,,,,,
+Uganda,UG,Nakapiripirit,,Kampala,,,,,,
+Uganda,UG,Nakaseke,,Kampala,,,,,,
+Uganda,UG,Nakasongola,,Kampala,,,,,,
+Uganda,UG,Namayingo,,Kampala,,,,,,
+Uganda,UG,Namisindwa,,Kampala,,,,,,
+Uganda,UG,Namutumba,,Kampala,,,,,,
+Uganda,UG,Napak,,Kampala,,,,,,
+Uganda,UG,Nebbi,,Kampala,,,,,,
+Uganda,UG,Ngora,,Kampala,,,,,,
+Uganda,UG,Northern,Adjumani,Kampala,,,3.37786000,31.79090000,Adjumani;Amudat;Apac,"Adjumani|(3.37786000,31.79090000);Amudat|(1.95000000,34.95000000);Apac|(1.97556000,32.53861000)"
+Uganda,UG,Ntoroko,,Kampala,,,,,,
+Uganda,UG,Ntungamo,,Kampala,,,,,,
+Uganda,UG,Nwoya,,Kampala,,,,,,
+Uganda,UG,Obongi,,Kampala,,,,,,
+Uganda,UG,Omoro,,Kampala,,,,,,
+Uganda,UG,Otuke,,Kampala,,,,,,
+Uganda,UG,Oyam,,Kampala,,,,,,
+Uganda,UG,Pader,,Kampala,,,,,,
+Uganda,UG,Pakwach,,Kampala,,,,,,
+Uganda,UG,Pallisa,,Kampala,,,,,,
+Uganda,UG,Rakai,,Kampala,,,,,,
+Uganda,UG,Rubanda,,Kampala,,,,,,
+Uganda,UG,Rubirizi,,Kampala,,,,,,
+Uganda,UG,Rukiga,,Kampala,,,,,,
+Uganda,UG,Rukungiri,,Kampala,,,,,,
+Uganda,UG,Rwampara,,Kampala,,,,,,
+Uganda,UG,Sembabule,,Kampala,,,,,,
+Uganda,UG,Serere,,Kampala,,,,,,
+Uganda,UG,Sheema,,Kampala,,,,,,
+Uganda,UG,Sironko,,Kampala,,,,,,
+Uganda,UG,Soroti,,Kampala,,,,,,
+Uganda,UG,Tororo,,Kampala,,,,,,
+Uganda,UG,Wakiso,,Kampala,,,,,,
+Uganda,UG,Western,Bundibugyo,Kampala,,,0.71117000,30.06469000,Bundibugyo;Bwizibwera;Fort Portal,"Bundibugyo|(0.71117000,30.06469000);Bwizibwera|(-0.59167000,30.62861000);Fort Portal|(0.66174000,30.27480000)"
+Uganda,UG,Yumbe,,Kampala,,,,,,
+Uganda,UG,Zombo,,Kampala,,,,,,
+Ukraine,UA,Autonomous Republic of Crimea,Abrikosovka,Kyiv,,,45.10759000,35.10139000,Abrikosovka;Abrikosovo;Aeroflotskiy,"Abrikosovka|(45.10759000,35.10139000);Abrikosovo|(45.69236000,34.10156000);Aeroflotskiy|(45.01816000,33.99961000)"
+Ukraine,UA,Cherkaska,Babanka,Kyiv,,,48.70971000,30.44827000,Babanka;Buky;Cherkasy,"Babanka|(48.70971000,30.44827000);Buky|(49.09252000,30.40355000);Cherkasy|(49.42854000,32.06207000)"
+Ukraine,UA,Chernihivska,Avdiyivka,Kyiv,,,51.77660000,32.79988000,Avdiyivka;Bakhmach;Baturyn,"Avdiyivka|(51.77660000,32.79988000);Bakhmach|(51.18144000,32.83463000);Baturyn|(51.34567000,32.87794000)"
+Ukraine,UA,Chernivetska,Banyliv,Kyiv,,,48.36612000,25.34549000,Banyliv;Berehomet;Boyany,"Banyliv|(48.36612000,25.34549000);Berehomet|(48.17882000,25.34855000);Boyany|(48.27077000,26.12624000)"
+Ukraine,UA,Dnipropetrovska,Apostolove,Kyiv,,,47.66003000,33.71369000,Apostolove;Auly;Aviatorske,"Apostolove|(47.66003000,33.71369000);Auly|(48.56660000,34.46111000);Aviatorske|(48.36714000,35.08132000)"
+Ukraine,UA,Donetska,Amvrosiivka Raion,Kyiv,,,47.75000000,38.50000000,Amvrosiivka Raion;Amvrosiyivka;Avdiyivka,"Amvrosiivka Raion|(47.75000000,38.50000000);Amvrosiyivka|(47.79348000,38.47768000);Avdiyivka|(48.13989000,37.74255000)"
+Ukraine,UA,Ivano-Frankivska,Bili Oslavy,Kyiv,,,48.48722000,24.70078000,Bili Oslavy;Bilshivtsi;Bohorodchans’kyy Rayon,"Bili Oslavy|(48.48722000,24.70078000);Bilshivtsi|(49.18333000,24.75000000);Bohorodchans’kyy Rayon|(48.72278000,24.38042000)"
+Ukraine,UA,Kharkivska,Balakliya,Kyiv,,,49.46270000,36.85951000,Balakliya;Barvinkove;Berezivka,"Balakliya|(49.46270000,36.85951000);Barvinkove|(48.90970000,37.02051000);Berezivka|(49.43935000,35.70736000)"
+Ukraine,UA,Khersonska,Askaniya-Nova,Kyiv,,,46.45135000,33.86889000,Askaniya-Nova;Bekhtery;Beryslav,"Askaniya-Nova|(46.45135000,33.86889000);Bekhtery|(46.24790000,32.29123000);Beryslav|(46.84152000,33.42838000)"
+Ukraine,UA,Khmelnytska,Antoniny,Kyiv,,,49.80974000,26.87714000,Antoniny;Bazaliya;Derazhnya,"Antoniny|(49.80974000,26.87714000);Bazaliya|(49.71267000,26.47331000);Derazhnya|(49.26920000,27.43382000)"
+Ukraine,UA,Kirovohradska,Adzhamka,Kyiv,,,48.54245000,32.53542000,Adzhamka;Blahovishchenske Raion;Bobrynets,"Adzhamka|(48.54245000,32.53542000);Blahovishchenske Raion|(48.25000000,30.25000000);Bobrynets|(48.05896000,32.16641000)"
+Ukraine,UA,Kyiv,Kyiv,Kyiv,,,50.45466000,30.52380000,Darnytsia Raion;Desnyans’kyy Rayon;Dnipro Raion,"Darnytsia Raion|(50.41333000,30.69305000);Desnyans’kyy Rayon|(50.53550000,30.60875000);Dnipro Raion|(50.46756000,30.63194000)"
+Ukraine,UA,Kyivska,Baryshivka,Kyiv,,,50.36098000,31.32173000,Baryshivka;Baryshivs’kyy Rayon;Bila Tserkva,"Baryshivka|(50.36098000,31.32173000);Baryshivs’kyy Rayon|(50.36919000,31.34896000);Bila Tserkva|(49.80939000,30.11209000)"
+Ukraine,UA,Luhanska,Alchevs’k,Kyiv,,,48.46893000,38.81669000,Alchevs’k;Alchevs’ka Mis’krada;Antratsyt,"Alchevs’k|(48.46893000,38.81669000);Alchevs’ka Mis’krada|(48.48029000,38.79690000);Antratsyt|(48.11503000,39.09128000)"
+Ukraine,UA,Lvivska,Belz,Kyiv,,,50.38226000,24.00642000,Belz;Bibrka;Boryslav,"Belz|(50.38226000,24.00642000);Bibrka|(49.64093000,24.28874000);Boryslav|(49.28672000,23.43238000)"
+Ukraine,UA,Mykolaivska,Arbuzynka,Kyiv,,,47.90972000,31.31963000,Arbuzynka;Bashtanka;Berezanka,"Arbuzynka|(47.90972000,31.31963000);Bashtanka|(47.40719000,32.43868000);Berezanka|(46.85262000,31.38802000)"
+Ukraine,UA,Odeska,Artsyz,Kyiv,,,45.99194000,29.41824000,Artsyz;Balta;Balts’kyy Rayon,"Artsyz|(45.99194000,29.41824000);Balta|(47.93548000,29.61982000);Balts’kyy Rayon|(47.99828000,29.64835000)"
+Ukraine,UA,Poltavska,Abramok,Kyiv,,,50.63694444,27.90750000,Abramok;Adamivka;Adamove,"Abramok|(50.63694444,27.90750000);Adamivka|(50.37694444,27.91527778);Adamove|(50.83111111,27.48305556)"
+Ukraine,UA,Rivnenska,Demydivs’kyy Rayon,Kyiv,,,50.44302000,25.29061000,Demydivs’kyy Rayon;Dubno;Dubrovytsya,"Demydivs’kyy Rayon|(50.44302000,25.29061000);Dubno|(50.41694000,25.73432000);Dubrovytsya|(51.57438000,26.56503000)"
+Ukraine,UA,Sevastopol,Sevastopol,Kyiv,,,44.58883000,33.52240000,Afanas’yeva;Alarskiy Rayon;Alekseyevskaya,"Afanas’yeva|(54.63958000,100.61755000);Alarskiy Rayon|(53.33333000,103.00000000);Alekseyevskaya|(57.85000000,108.40000000)"
+Ukraine,UA,Sumska,Bilopillya,Kyiv,,,51.15016000,34.31287000,Bilopillya;Boromlya;Buryn’,"Bilopillya|(51.15016000,34.31287000);Boromlya|(50.61839000,34.97042000);Buryn’|(51.19912000,33.83523000)"
+Ukraine,UA,Ternopilska,Belaya,Kyiv,,,49.02900000,25.77059000,Belaya;Borshchiv;Buchach,"Belaya|(49.02900000,25.77059000);Borshchiv|(48.80332000,26.04347000);Buchach|(49.06254000,25.38798000)"
+Ukraine,UA,Vinnytska,Bar,Kyiv,,,49.07717000,27.68256000,Bar;Barskiy Rayon;Bershad,"Bar|(49.07717000,27.68256000);Barskiy Rayon|(49.06667000,27.68333000);Bershad|(48.36782000,29.51726000)"
+Ukraine,UA,Volynska,Berestechko,Kyiv,,,50.36047000,25.11071000,Berestechko;Blahodatne;Hołoby,"Berestechko|(50.36047000,25.11071000);Blahodatne|(50.66365000,24.24918000);Hołoby|(51.08651000,25.00767000)"
+Ukraine,UA,Zakarpatska,Batiovo,Kyiv,,,48.36166000,22.39970000,Batiovo;Berehivs’ka Mis’krada;Berehove,"Batiovo|(48.36166000,22.39970000);Berehivs’ka Mis’krada|(48.21255000,22.65536000);Berehove|(48.20555000,22.64418000)"
+Ukraine,UA,Zaporizka,Balky,Kyiv,,,47.38336000,34.94396000,Balky;Berdiansk Raion;Berdyans’ka Mis’krada,"Balky|(47.38336000,34.94396000);Berdiansk Raion|(46.83333000,36.75000000);Berdyans’ka Mis’krada|(46.81565000,36.77049000)"
+Ukraine,UA,Zhytomyrska,Andrushivka,Kyiv,,,50.02288000,29.02023000,Andrushivka;Andrushivs’kyy Rayon;Baranivka,"Andrushivka|(50.02288000,29.02023000);Andrushivs’kyy Rayon|(50.01709000,29.03215000);Baranivka|(50.29691000,27.66220000)"
+United Arab Emirates,AE,Abu Dhabi,Abu Dhabi,Abu Dhabi,,,24.41361000,54.43295000,Abu Dhabi;Al Ain City;Al Dhafra,"Abu Dhabi|(24.41361000,54.43295000);Al Ain City|(24.19167000,55.76056000);Al Dhafra|(23.65745000,53.72225000)"
+United Arab Emirates,AE,Ajman,Ajman,Abu Dhabi,,,25.40328000,55.52341000,Ajman;Manama;Masfut,"Ajman|(25.40328000,55.52341000);Manama|(25.32568000,56.00259000);Masfut|(24.83982000,56.05158000)"
+United Arab Emirates,AE,Dubai,Dubai,Abu Dhabi,,,25.06570000,55.17128000,Dubai,"Dubai|(25.06570000,55.17128000)"
+United Arab Emirates,AE,Fujairah,Fujairah,Abu Dhabi,,,25.11641000,56.34141000,Dibba Al Fujairah Municipality;Dibba Al-Fujairah;Dibba Al-Hisn,"Dibba Al Fujairah Municipality|(25.58580000,56.24792000);Dibba Al-Fujairah|(25.59246000,56.26176000);Dibba Al-Hisn|(25.61955000,56.27291000)"
+United Arab Emirates,AE,Ras Al Khaimah,Ras Al Khaimah,Abu Dhabi,,,25.46116000,56.04058000,Ras Al Khaimah,"Ras Al Khaimah|(25.46116000,56.04058000)"
+United Arab Emirates,AE,Sharjah,Sharjah,Abu Dhabi,,,25.33737000,55.41206000,Al Batayih;Al Dhaid;Al Hamriyah,"Al Batayih|(25.22317000,55.74272000);Al Dhaid|(25.28812000,55.88157000);Al Hamriyah|(25.46121000,55.54813000)"
+United Arab Emirates,AE,Umm Al Quwain,Umm AL Quwain,Abu Dhabi,,,25.49326000,55.73520000,Umm AL Quwain,"Umm AL Quwain|(25.49326000,55.73520000)"
+United Kingdom,GB,Aberdeen,,London,,,,,,
+United Kingdom,GB,Aberdeenshire,,London,,,,,,
+United Kingdom,GB,Angus,,London,,,,,,
+United Kingdom,GB,Antrim,,London,,,,,,
+United Kingdom,GB,Antrim and Newtownabbey,,London,,,,,,
+United Kingdom,GB,Ards,,London,,,,,,
+United Kingdom,GB,Ards and North Down,,London,,,,,,
+United Kingdom,GB,Argyll and Bute,,London,,,,,,
+United Kingdom,GB,Armagh,,London,,,,,,
+United Kingdom,GB,"Armagh, Banbridge and Craigavon",,London,,,,,,
+United Kingdom,GB,Ascension Island,,London,,,,,,
+United Kingdom,GB,Ballymena,,London,,,,,,
+United Kingdom,GB,Ballymoney,,London,,,,,,
+United Kingdom,GB,Banbridge,,London,,,,,,
+United Kingdom,GB,Barking and Dagenham,,London,,,,,,
+United Kingdom,GB,Barnet,,London,,,,,,
+United Kingdom,GB,Barnsley,,London,,,,,,
+United Kingdom,GB,Bath and North East Somerset,,London,,,,,,
+United Kingdom,GB,Bedford,,London,,,,,,
+United Kingdom,GB,Belfast,,London,,,,,,
+United Kingdom,GB,Bexley,,London,,,,,,
+United Kingdom,GB,Birmingham,,London,,,,,,
+United Kingdom,GB,Blackburn with Darwen,,London,,,,,,
+United Kingdom,GB,Blackpool,,London,,,,,,
+United Kingdom,GB,Blaenau Gwent,,London,,,,,,
+United Kingdom,GB,Bolton,,London,,,,,,
+United Kingdom,GB,Bournemouth,,London,,,,,,
+United Kingdom,GB,Bracknell Forest,,London,,,,,,
+United Kingdom,GB,Bradford,,London,,,,,,
+United Kingdom,GB,Brent,,London,,,,,,
+United Kingdom,GB,Bridgend,,London,,,,,,
+United Kingdom,GB,Brighton and Hove,,London,,,,,,
+United Kingdom,GB,Bristol,,London,,,,,,
+United Kingdom,GB,Bromley,,London,,,,,,
+United Kingdom,GB,Buckinghamshire,,London,,,,,,
+United Kingdom,GB,Bury,,London,,,,,,
+United Kingdom,GB,Caerphilly,,London,,,,,,
+United Kingdom,GB,Calderdale,,London,,,,,,
+United Kingdom,GB,Cambridgeshire,,London,,,,,,
+United Kingdom,GB,Camden,,London,,,,,,
+United Kingdom,GB,Cardiff,,London,,,,,,
+United Kingdom,GB,Carmarthenshire,,London,,,,,,
+United Kingdom,GB,Carrickfergus,,London,,,,,,
+United Kingdom,GB,Castlereagh,,London,,,,,,
+United Kingdom,GB,Causeway Coast and Glens,,London,,,,,,
+United Kingdom,GB,Central Bedfordshire,,London,,,,,,
+United Kingdom,GB,Ceredigion,,London,,,,,,
+United Kingdom,GB,Cheshire East,,London,,,,,,
+United Kingdom,GB,Cheshire West and Chester,,London,,,,,,
+United Kingdom,GB,City of Kingston upon Hull,,London,,,,,,
+United Kingdom,GB,City of Southampton,,London,,,,,,
+United Kingdom,GB,Clackmannanshire,,London,,,,,,
+United Kingdom,GB,Coleraine,,London,,,,,,
+United Kingdom,GB,Conwy,,London,,,,,,
+United Kingdom,GB,Cookstown,,London,,,,,,
+United Kingdom,GB,Cornwall,,London,,,,,,
+United Kingdom,GB,Coventry,,London,,,,,,
+United Kingdom,GB,Craigavon,,London,,,,,,
+United Kingdom,GB,Croydon,,London,,,,,,
+United Kingdom,GB,Cumbria,,London,,,,,,
+United Kingdom,GB,Darlington,,London,,,,,,
+United Kingdom,GB,Denbighshire,,London,,,,,,
+United Kingdom,GB,Derby,,London,,,,,,
+United Kingdom,GB,Derbyshire,,London,,,,,,
+United Kingdom,GB,Derry,,London,,,,,,
+United Kingdom,GB,Derry City and Strabane,,London,,,,,,
+United Kingdom,GB,Devon,,London,,,,,,
+United Kingdom,GB,Doncaster,,London,,,,,,
+United Kingdom,GB,Dorset,,London,,,,,,
+United Kingdom,GB,Down District Council,,London,,,,,,
+United Kingdom,GB,Dudley,,London,,,,,,
+United Kingdom,GB,Dumfries and Galloway,,London,,,,,,
+United Kingdom,GB,Dundee,,London,,,,,,
+United Kingdom,GB,Dungannon and South Tyrone,,London,,,,,,
+United Kingdom,GB,Durham,,London,,,,,,
+United Kingdom,GB,Ealing,,London,,,,,,
+United Kingdom,GB,East Ayrshire,,London,,,,,,
+United Kingdom,GB,East Dunbartonshire,,London,,,,,,
+United Kingdom,GB,East Lothian,,London,,,,,,
+United Kingdom,GB,East Renfrewshire,,London,,,,,,
+United Kingdom,GB,East Riding of Yorkshire,,London,,,,,,
+United Kingdom,GB,East Sussex,,London,,,,,,
+United Kingdom,GB,Edinburgh,,London,,,,,,
+United Kingdom,GB,Enfield,,London,,,,,,
+United Kingdom,GB,England,Abbey Wood,London,,,51.48688000,0.10747000,Abbey Wood;Abbots Bromley;Abbots Langley,"Abbey Wood|(51.48688000,0.10747000);Abbots Bromley|(52.81705000,-1.87694000);Abbots Langley|(51.70573000,-0.41757000)"
+United Kingdom,GB,Essex,,London,,,,,,
+United Kingdom,GB,Falkirk,,London,,,,,,
+United Kingdom,GB,Fermanagh,,London,,,,,,
+United Kingdom,GB,Fermanagh and Omagh,,London,,,,,,
+United Kingdom,GB,Fife,,London,,,,,,
+United Kingdom,GB,Flintshire,,London,,,,,,
+United Kingdom,GB,Gateshead,,London,,,,,,
+United Kingdom,GB,Glasgow,,London,,,,,,
+United Kingdom,GB,Gloucestershire,,London,,,,,,
+United Kingdom,GB,Greenwich,,London,,,,,,
+United Kingdom,GB,Gwynedd,,London,,,,,,
+United Kingdom,GB,Hackney,,London,,,,,,
+United Kingdom,GB,Halton,,London,,,,,,
+United Kingdom,GB,Hammersmith and Fulham,,London,,,,,,
+United Kingdom,GB,Hampshire,Basingstoke and Deane,London,,,51.25869640,-1.54714010,Basingstoke and Deane;Borough of Eastleigh;Borough of Fareham,"Basingstoke and Deane|(51.25869640,-1.54714010);Borough of Eastleigh|(50.92329300,-1.49372050);Borough of Fareham|(50.85415160,-1.29500360)"
+United Kingdom,GB,Haringey,,London,,,,,,
+United Kingdom,GB,Harrow,,London,,,,,,
+United Kingdom,GB,Hartlepool,,London,,,,,,
+United Kingdom,GB,Havering,,London,,,,,,
+United Kingdom,GB,Herefordshire,,London,,,,,,
+United Kingdom,GB,Hertfordshire,,London,,,,,,
+United Kingdom,GB,Highland,,London,,,,,,
+United Kingdom,GB,Hillingdon,,London,,,,,,
+United Kingdom,GB,Hounslow,,London,,,,,,
+United Kingdom,GB,Inverclyde,,London,,,,,,
+United Kingdom,GB,Isle of Wight,,London,,,,,,
+United Kingdom,GB,Isles of Scilly,,London,,,,,,
+United Kingdom,GB,Islington,,London,,,,,,
+United Kingdom,GB,Kensington and Chelsea,,London,,,,,,
+United Kingdom,GB,Kent,,London,,,,,,
+United Kingdom,GB,Kingston upon Thames,,London,,,,,,
+United Kingdom,GB,Kirklees,,London,,,,,,
+United Kingdom,GB,Knowsley,,London,,,,,,
+United Kingdom,GB,Lambeth,,London,,,,,,
+United Kingdom,GB,Lancashire,,London,,,,,,
+United Kingdom,GB,Larne,,London,,,,,,
+United Kingdom,GB,Leeds,,London,,,,,,
+United Kingdom,GB,Leicester,,London,,,,,,
+United Kingdom,GB,Leicestershire,,London,,,,,,
+United Kingdom,GB,Lewisham,,London,,,,,,
+United Kingdom,GB,Limavady,,London,,,,,,
+United Kingdom,GB,Lincolnshire,,London,,,,,,
+United Kingdom,GB,Lisburn,,London,,,,,,
+United Kingdom,GB,Lisburn and Castlereagh,,London,,,,,,
+United Kingdom,GB,Liverpool,,London,,,,,,
+United Kingdom,GB,London,,London,,,,,,
+United Kingdom,GB,Magherafelt,,London,,,,,,
+United Kingdom,GB,Manchester,,London,,,,,,
+United Kingdom,GB,Medway,,London,,,,,,
+United Kingdom,GB,Merthyr Tydfil,,London,,,,,,
+United Kingdom,GB,Merton,,London,,,,,,
+United Kingdom,GB,Mid and East Antrim,,London,,,,,,
+United Kingdom,GB,Mid Ulster,,London,,,,,,
+United Kingdom,GB,Middlesbrough,,London,,,,,,
+United Kingdom,GB,Midlothian,,London,,,,,,
+United Kingdom,GB,Milton Keynes,,London,,,,,,
+United Kingdom,GB,Monmouthshire,,London,,,,,,
+United Kingdom,GB,Moray,,London,,,,,,
+United Kingdom,GB,Moyle,,London,,,,,,
+United Kingdom,GB,Neath Port Talbot,,London,,,,,,
+United Kingdom,GB,Newcastle upon Tyne,,London,,,,,,
+United Kingdom,GB,Newham,,London,,,,,,
+United Kingdom,GB,Newport,,London,,,,,,
+United Kingdom,GB,Newry and Mourne,,London,,,,,,
+United Kingdom,GB,"Newry, Mourne and Down",,London,,,,,,
+United Kingdom,GB,Newtownabbey,,London,,,,,,
+United Kingdom,GB,Norfolk,,London,,,,,,
+United Kingdom,GB,North Ayrshire,,London,,,,,,
+United Kingdom,GB,North Down,,London,,,,,,
+United Kingdom,GB,North East Lincolnshire,,London,,,,,,
+United Kingdom,GB,North Lanarkshire,,London,,,,,,
+United Kingdom,GB,North Lincolnshire,,London,,,,,,
+United Kingdom,GB,North Somerset,,London,,,,,,
+United Kingdom,GB,North Tyneside,,London,,,,,,
+United Kingdom,GB,North Yorkshire,,London,,,,,,
+United Kingdom,GB,Northamptonshire,,London,,,,,,
+United Kingdom,GB,Northern Ireland,Ahoghill,London,,,54.86667000,-6.36667000,Ahoghill;Annahilt;Annalong,"Ahoghill|(54.86667000,-6.36667000);Annahilt|(54.43333000,-6.00000000);Annalong|(54.10823000,-5.89966000)"
+United Kingdom,GB,Northumberland,,London,,,,,,
+United Kingdom,GB,Nottingham,,London,,,,,,
+United Kingdom,GB,Nottinghamshire,,London,,,,,,
+United Kingdom,GB,Oldham,,London,,,,,,
+United Kingdom,GB,Omagh,,London,,,,,,
+United Kingdom,GB,Orkney Islands,,London,,,,,,
+United Kingdom,GB,Outer Hebrides,,London,,,,,,
+United Kingdom,GB,Oxfordshire,,London,,,,,,
+United Kingdom,GB,Pembrokeshire,,London,,,,,,
+United Kingdom,GB,Perth and Kinross,,London,,,,,,
+United Kingdom,GB,Peterborough,,London,,,,,,
+United Kingdom,GB,Plymouth,,London,,,,,,
+United Kingdom,GB,Poole,,London,,,,,,
+United Kingdom,GB,Portsmouth,,London,,,,,,
+United Kingdom,GB,Powys,,London,,,,,,
+United Kingdom,GB,Reading,,London,,,,,,
+United Kingdom,GB,Redbridge,,London,,,,,,
+United Kingdom,GB,Redcar and Cleveland,,London,,,,,,
+United Kingdom,GB,Renfrewshire,,London,,,,,,
+United Kingdom,GB,Rhondda Cynon Taf,,London,,,,,,
+United Kingdom,GB,Richmond upon Thames,,London,,,,,,
+United Kingdom,GB,Rochdale,,London,,,,,,
+United Kingdom,GB,Rotherham,,London,,,,,,
+United Kingdom,GB,Rutland,,London,,,,,,
+United Kingdom,GB,Saint Helena,,London,,,,,,
+United Kingdom,GB,Salford,,London,,,,,,
+United Kingdom,GB,Sandwell,,London,,,,,,
+United Kingdom,GB,Scotland,Aberchirder,London,,,57.56012000,-2.62856000,Aberchirder;Aberdeen;Aberdeenshire,"Aberchirder|(57.56012000,-2.62856000);Aberdeen|(57.14369000,-2.09814000);Aberdeenshire|(57.16667000,-2.66667000)"
+United Kingdom,GB,Scottish Borders,,London,,,,,,
+United Kingdom,GB,Sefton,,London,,,,,,
+United Kingdom,GB,Sheffield,,London,,,,,,
+United Kingdom,GB,Shetland Islands,,London,,,,,,
+United Kingdom,GB,Shropshire,,London,,,,,,
+United Kingdom,GB,Slough,,London,,,,,,
+United Kingdom,GB,Solihull,,London,,,,,,
+United Kingdom,GB,Somerset,,London,,,,,,
+United Kingdom,GB,South Ayrshire,,London,,,,,,
+United Kingdom,GB,South Gloucestershire,,London,,,,,,
+United Kingdom,GB,South Lanarkshire,,London,,,,,,
+United Kingdom,GB,South Tyneside,,London,,,,,,
+United Kingdom,GB,Southend-on-Sea,,London,,,,,,
+United Kingdom,GB,Southwark,,London,,,,,,
+United Kingdom,GB,St Helens,,London,,,,,,
+United Kingdom,GB,Staffordshire,,London,,,,,,
+United Kingdom,GB,Stirling,,London,,,,,,
+United Kingdom,GB,Stockport,,London,,,,,,
+United Kingdom,GB,Stockton-on-Tees,,London,,,,,,
+United Kingdom,GB,Stoke-on-Trent,,London,,,,,,
+United Kingdom,GB,Strabane,,London,,,,,,
+United Kingdom,GB,Suffolk,,London,,,,,,
+United Kingdom,GB,Sunderland,,London,,,,,,
+United Kingdom,GB,Surrey,,London,,,,,,
+United Kingdom,GB,Sutton,,London,,,,,,
+United Kingdom,GB,Swansea,,London,,,,,,
+United Kingdom,GB,Swindon,,London,,,,,,
+United Kingdom,GB,Tameside,,London,,,,,,
+United Kingdom,GB,Telford and Wrekin,,London,,,,,,
+United Kingdom,GB,Thurrock,,London,,,,,,
+United Kingdom,GB,Torbay,,London,,,,,,
+United Kingdom,GB,Torfaen,,London,,,,,,
+United Kingdom,GB,Tower Hamlets,,London,,,,,,
+United Kingdom,GB,Trafford,,London,,,,,,
+United Kingdom,GB,United Kingdom,,London,,,,,,
+United Kingdom,GB,Vale of Glamorgan,,London,,,,,,
+United Kingdom,GB,Wakefield,,London,,,,,,
+United Kingdom,GB,Wales,Aberaeron,London,,,52.24247000,-4.25871000,Aberaeron;Abercanaid;Abercarn,"Aberaeron|(52.24247000,-4.25871000);Abercanaid|(51.72361000,-3.36611000);Abercarn|(51.64733000,-3.13476000)"
+United Kingdom,GB,Walsall,,London,,,,,,
+United Kingdom,GB,Waltham Forest,,London,,,,,,
+United Kingdom,GB,Wandsworth,,London,,,,,,
+United Kingdom,GB,Warrington,,London,,,,,,
+United Kingdom,GB,Warwickshire,,London,,,,,,
+United Kingdom,GB,West Berkshire,,London,,,,,,
+United Kingdom,GB,West Dunbartonshire,,London,,,,,,
+United Kingdom,GB,West Lothian,,London,,,,,,
+United Kingdom,GB,West Sussex,,London,,,,,,
+United Kingdom,GB,Westminster,,London,,,,,,
+United Kingdom,GB,Wigan,,London,,,,,,
+United Kingdom,GB,Wiltshire,,London,,,,,,
+United Kingdom,GB,Windsor and Maidenhead,,London,,,,,,
+United Kingdom,GB,Wirral,,London,,,,,,
+United Kingdom,GB,Wokingham,,London,,,,,,
+United Kingdom,GB,Wolverhampton,,London,,,,,,
+United Kingdom,GB,Worcestershire,,London,,,,,,
+United Kingdom,GB,Wrexham,,London,,,,,,
+United Kingdom,GB,York,,London,,,,,,
+United States,US,Alabama,Abbeville,Washington,,,31.57184000,-85.25049000,Abbeville;Adamsville;Alabaster,"Abbeville|(31.57184000,-85.25049000);Adamsville|(33.60094000,-86.95611000);Alabaster|(33.24428000,-86.81638000)"
+United States,US,Alaska,Akutan,Washington,,,54.13350000,-165.77686000,Akutan;Aleutians East Borough;Aleutians West Census Area,"Akutan|(54.13350000,-165.77686000);Aleutians East Borough|(54.85000000,-163.41667000);Aleutians West Census Area|(52.16298000,-174.28505000)"
+United States,US,American Samoa,,Washington,,,,,,
+United States,US,Arizona,Ahwatukee Foothills,Washington,,,33.34171000,-111.98403000,Ahwatukee Foothills;Ajo;Alhambra,"Ahwatukee Foothills|(33.34171000,-111.98403000);Ajo|(32.37172000,-112.86071000);Alhambra|(33.49838000,-112.13432000)"
+United States,US,Arkansas,Alexander,Washington,,,34.62954000,-92.44127000,Alexander;Alma;Arkadelphia,"Alexander|(34.62954000,-92.44127000);Alma|(35.47787000,-94.22188000);Arkadelphia|(34.12093000,-93.05378000)"
+United States,US,California,Acalanes Ridge,Washington,,,37.90472000,-122.07857000,Acalanes Ridge;Acton;Adelanto,"Acalanes Ridge|(37.90472000,-122.07857000);Acton|(34.46999000,-118.19674000);Adelanto|(34.58277000,-117.40922000)"
+United States,US,Colorado,Acres Green,Washington,,,39.55666000,-104.89609000,Acres Green;Adams County;Air Force Academy,"Acres Green|(39.55666000,-104.89609000);Adams County|(39.87363000,-104.33791000);Air Force Academy|(38.99425000,-104.86375000)"
+United States,US,Connecticut,Ansonia,Washington,,,41.34621000,-73.07900000,Ansonia;Baltic;Berlin,"Ansonia|(41.34621000,-73.07900000);Baltic|(41.61704000,-72.08452000);Berlin|(41.62223400,-72.77362800)"
+United States,US,Delaware,Bear,Washington,,,39.62928000,-75.65826000,Bear;Bellefonte;Bethany Beach,"Bear|(39.62928000,-75.65826000);Bellefonte|(39.76622000,-75.50936000);Bethany Beach|(38.53956000,-75.05518000)"
+United States,US,District of Columbia,Adams Morgan,Washington,,,38.92150000,-77.04220000,Adams Morgan;Bloomingdale;Chevy Chase,"Adams Morgan|(38.92150000,-77.04220000);Bloomingdale|(38.91678000,-77.01137000);Chevy Chase|(38.96400000,-77.06776000)"
+United States,US,Florida,Aberdeen,Washington,,,26.55063000,-80.14866000,Aberdeen;Alachua;Alachua County,"Aberdeen|(26.55063000,-80.14866000);Alachua|(29.75163000,-82.42483000);Alachua County|(29.67476000,-82.35770000)"
+United States,US,Georgia,Abbeville,Washington,,,31.99212000,-83.30682000,Abbeville;Acworth;Adairsville,"Abbeville|(31.99212000,-83.30682000);Acworth|(34.06635000,-84.67837000);Adairsville|(34.36870000,-84.93411000)"
+United States,US,Guam,,Washington,,,,,,
+United States,US,Hawaii,‘Āhuimanu,Washington,,,21.44472000,-157.83778000,‘Āhuimanu;‘Aiea;‘Ele‘ele,"‘Āhuimanu|(21.44472000,-157.83778000);‘Aiea|(21.38222000,-157.93361000);‘Ele‘ele|(21.90738000,-159.58322000)"
+United States,US,Idaho,Aberdeen,Washington,,,42.94408000,-112.83833000,Aberdeen;Ada County;Adams County,"Aberdeen|(42.94408000,-112.83833000);Ada County|(43.45112000,-116.24109000);Adams County|(44.88965000,-116.45387000)"
+United States,US,Illinois,Abingdon,Washington,,,40.80448000,-90.40180000,Abingdon;Adams County;Addison,"Abingdon|(40.80448000,-90.40180000);Adams County|(39.98789000,-91.18849000);Addison|(41.93170000,-87.98896000)"
+United States,US,Indiana,Aberdeen,Washington,,,41.43893000,-87.11142000,Aberdeen;Adams County;Akron,"Aberdeen|(41.43893000,-87.11142000);Adams County|(40.74566000,-84.93665000);Akron|(41.03838000,-86.02805000)"
+United States,US,Iowa,Ackley,Washington,,,42.55415000,-93.05326000,Ackley;Adair County;Adams County,"Ackley|(42.55415000,-93.05326000);Adair County|(41.33075000,-94.47094000);Adams County|(41.02898000,-94.69918000)"
+United States,US,Kansas,Abilene,Washington,,,38.91722000,-97.21391000,Abilene;Allen County;Alma,"Abilene|(38.91722000,-97.21391000);Allen County|(37.88573000,-95.30139000);Alma|(39.01667000,-96.28916000)"
+United States,US,Kentucky,Adair County,Washington,,,37.10416000,-85.28065000,Adair County;Albany;Alexandria,"Adair County|(37.10416000,-85.28065000);Albany|(36.69090000,-85.13468000);Alexandria|(38.95951000,-84.38799000)"
+United States,US,Louisiana,Abbeville,Washington,,,29.97465000,-92.13429000,Abbeville;Abita Springs;Acadia Parish,"Abbeville|(29.97465000,-92.13429000);Abita Springs|(30.47864000,-90.04008000);Acadia Parish|(30.29053000,-92.41198000)"
+United States,US,Maine,Acton,Washington,,,43.53425000,-70.90978000,Acton;Addison;Albion,"Acton|(43.53425000,-70.90978000);Addison|(44.61841000,-67.74416000);Albion|(44.53229000,-69.44254000)"
+United States,US,Maryland,Aberdeen,Washington,,,39.50956000,-76.16412000,Aberdeen;Aberdeen Proving Ground;Accokeek,"Aberdeen|(39.50956000,-76.16412000);Aberdeen Proving Ground|(39.46686000,-76.13066000);Accokeek|(38.66762000,-77.02831000)"
+United States,US,Massachusetts,Abington,Washington,,,42.10482000,-70.94532000,Abington;Acton;Acushnet,"Abington|(42.10482000,-70.94532000);Acton|(42.48509000,-71.43284000);Acushnet|(41.68066000,-70.90782000)"
+United States,US,Michigan,Adrian,Washington,,,41.89755000,-84.03717000,Adrian;Albion;Alcona County,"Adrian|(41.89755000,-84.03717000);Albion|(42.24310000,-84.75303000);Alcona County|(44.71161000,-83.34366000)"
+United States,US,Minnesota,Ada,Washington,,,47.29969000,-96.51535000,Ada;Adrian;Afton,"Ada|(47.29969000,-96.51535000);Adrian|(43.63497000,-95.93280000);Afton|(44.90275000,-92.78354000)"
+United States,US,Mississippi,Aberdeen,Washington,,,33.82511000,-88.54366000,Aberdeen;Ackerman;Adams County,"Aberdeen|(33.82511000,-88.54366000);Ackerman|(33.31012000,-89.17284000);Adams County|(31.48294000,-91.35350000)"
+United States,US,Missouri,Adair County,Washington,,,40.19056000,-92.60072000,Adair County;Adrian;Advance,"Adair County|(40.19056000,-92.60072000);Adrian|(38.39752000,-94.35162000);Advance|(37.10455000,-89.90953000)"
+United States,US,Montana,Absarokee,Washington,,,45.52050000,-109.44294000,Absarokee;Anaconda;Baker,"Absarokee|(45.52050000,-109.44294000);Anaconda|(46.12854000,-112.94226000);Baker|(46.36695000,-104.28466000)"
+United States,US,Nebraska,Adams County,Washington,,,40.52447000,-98.50121000,Adams County;Ainsworth;Albion,"Adams County|(40.52447000,-98.50121000);Ainsworth|(42.55000000,-99.86262000);Albion|(41.69084000,-98.00367000)"
+United States,US,Nevada,Alamo,Washington,,,37.36496000,-115.16446000,Alamo;Battle Mountain;Beatty,"Alamo|(37.36496000,-115.16446000);Battle Mountain|(40.64213000,-116.93427000);Beatty|(36.90856000,-116.75923000)"
+United States,US,New Hampshire,Alexandria,Washington,,,43.61146000,-71.79286000,Alexandria;Alstead;Andover,"Alexandria|(43.61146000,-71.79286000);Alstead|(43.14897000,-72.36064000);Andover|(43.43702000,-71.82341000)"
+United States,US,New Jersey,Absecon,Washington,,,39.42845000,-74.49571000,Absecon;Allendale;Allentown,"Absecon|(39.42845000,-74.49571000);Allendale|(41.04149000,-74.12903000);Allentown|(40.17789000,-74.58349000)"
+United States,US,New Mexico,Agua Fria,Washington,,,35.65448000,-106.02224000,Agua Fria;Alamo;Alamogordo,"Agua Fria|(35.65448000,-106.02224000);Alamo|(34.42089000,-107.51088000);Alamogordo|(32.89953000,-105.96027000)"
+United States,US,New York,Adams,Washington,,,43.80923000,-76.02409000,Adams;Adams Center;Addison,"Adams|(43.80923000,-76.02409000);Adams Center|(43.86006000,-76.00548000);Addison|(42.10285000,-77.23359000)"
+United States,US,North Carolina,Aberdeen,Washington,,,35.13155000,-79.42948000,Aberdeen;Advance;Ahoskie,"Aberdeen|(35.13155000,-79.42948000);Advance|(35.94125000,-80.40922000);Ahoskie|(36.28682000,-76.98468000)"
+United States,US,North Dakota,Adams County,Washington,,,46.09684000,-102.52853000,Adams County;Amidon;Ashley,"Adams County|(46.09684000,-102.52853000);Amidon|(46.48223000,-103.32185000);Ashley|(46.03414000,-99.37150000)"
+United States,US,Northern Mariana Islands,,Washington,,,,,,
+United States,US,Ohio,Ada,Washington,,,40.76950000,-83.82271000,Ada;Adams County;Akron,"Ada|(40.76950000,-83.82271000);Adams County|(38.84551000,-83.47215000);Akron|(41.08144000,-81.51901000)"
+United States,US,Oklahoma,Ada,Washington,,,34.77453000,-96.67834000,Ada;Adair County;Afton,"Ada|(34.77453000,-96.67834000);Adair County|(35.88393000,-94.65868000);Afton|(36.69369000,-94.96302000)"
+United States,US,Oregon,Albany,Washington,,,44.63651000,-123.10593000,Albany;Aloha;Altamont,"Albany|(44.63651000,-123.10593000);Aloha|(45.49428000,-122.86705000);Altamont|(42.20681000,-121.73722000)"
+United States,US,Pennsylvania,Abbottstown,Washington,,,39.88649000,-76.98470000,Abbottstown;Adams County;Adamstown,"Abbottstown|(39.88649000,-76.98470000);Adams County|(39.87145000,-77.21789000);Adamstown|(40.24120000,-76.05633000)"
+United States,US,Puerto Rico,Adjuntas,Washington,,,18.16277778,-66.72222222,Adjuntas;Aguada;Aguadilla,"Adjuntas|(18.16277778,-66.72222222);Aguada|(18.37944444,-67.18833333);Aguadilla|(18.42745000,-67.15407000)"
+United States,US,Rhode Island,Ashaway,Washington,,,41.42343000,-71.78562000,Ashaway;Barrington;Bradford,"Ashaway|(41.42343000,-71.78562000);Barrington|(41.74066000,-71.30866000);Bradford|(41.39899000,-71.73701000)"
+United States,US,South Carolina,Abbeville,Washington,,,34.17817000,-82.37901000,Abbeville;Abbeville County;Aiken,"Abbeville|(34.17817000,-82.37901000);Abbeville County|(34.22257000,-82.45871000);Aiken|(33.56042000,-81.71955000)"
+United States,US,South Dakota,Aberdeen,Washington,,,45.46470000,-98.48648000,Aberdeen;Alexandria;Armour,"Aberdeen|(45.46470000,-98.48648000);Alexandria|(43.65359000,-97.78285000);Armour|(43.31860000,-98.34675000)"
+United States,US,Tennessee,Adamsville,Washington,,,35.23591000,-88.39060000,Adamsville;Alamo;Alcoa,"Adamsville|(35.23591000,-88.39060000);Alamo|(35.78479000,-89.11729000);Alcoa|(35.78953000,-83.97379000)"
+United States,US,Texas,Abernathy,Washington,,,33.83230000,-101.84295000,Abernathy;Abilene;Abram,"Abernathy|(33.83230000,-101.84295000);Abilene|(32.44874000,-99.73314000);Abram|(26.19980000,-98.41113000)"
+United States,US,United States Minor Outlying Islands,,Washington,,,,,,
+United States,US,United States Virgin Islands,,Washington,,,,,,
+United States,US,Utah,Alpine,Washington,,,40.45328000,-111.77799000,Alpine;American Fork;Aurora,"Alpine|(40.45328000,-111.77799000);American Fork|(40.37690000,-111.79576000);Aurora|(38.92219000,-111.93409000)"
+United States,US,Vermont,Addison,Washington,,,44.08867000,-73.30262000,Addison;Addison County;Arlington,"Addison|(44.08867000,-73.30262000);Addison County|(44.03091000,-73.14094000);Arlington|(43.07480000,-73.15400000)"
+United States,US,Virginia,Abingdon,Washington,,,36.70983000,-81.97735000,Abingdon;Accomac;Accomack County,"Abingdon|(36.70983000,-81.97735000);Accomac|(37.71957000,-75.66548000);Accomack County|(37.76494000,-75.75656000)"
+United States,US,Washington,Aberdeen,Washington,,,46.97537000,-123.81572000,Aberdeen;Adams County;Ahtanum,"Aberdeen|(46.97537000,-123.81572000);Adams County|(46.98338000,-118.56050000);Ahtanum|(46.55957000,-120.62201000)"
+United States,US,West Virginia,Alderson,Washington,,,37.72595000,-80.64202000,Alderson;Alum Creek;Ansted,"Alderson|(37.72595000,-80.64202000);Alum Creek|(38.28676000,-81.80513000);Ansted|(38.13622000,-81.09955000)"
+United States,US,Wisconsin,Abbotsford,Washington,,,44.94636000,-90.31597000,Abbotsford;Adams;Adams County,"Abbotsford|(44.94636000,-90.31597000);Adams|(43.95608000,-89.81818000);Adams County|(43.96963000,-89.77064000)"
+United States,US,Wyoming,Afton,Washington,,,42.72493000,-110.93187000,Afton;Albany County;Antelope Valley-Crestview,"Afton|(42.72493000,-110.93187000);Albany County|(41.65447000,-105.72391000);Antelope Valley-Crestview|(44.22488000,-105.47409000)"
+United States Minor Outlying Islands,UM,Baker Island,,nan,,,,,,
+United States Minor Outlying Islands,UM,Howland Island,,nan,,,,,,
+United States Minor Outlying Islands,UM,Jarvis Island,,nan,,,,,,
+United States Minor Outlying Islands,UM,Johnston Atoll,,nan,,,,,,
+United States Minor Outlying Islands,UM,Kingman Reef,,nan,,,,,,
+United States Minor Outlying Islands,UM,Midway Islands,,nan,,,,,,
+United States Minor Outlying Islands,UM,Navassa Island,,nan,,,,,,
+United States Minor Outlying Islands,UM,Palmyra Atoll,,nan,,,,,,
+United States Minor Outlying Islands,UM,Wake Island,,nan,,,,,,
+Uruguay,UY,Artigas,Artigas,Montevideo,EMEA,5,-30.40000000,-56.46667000,Artigas;Baltasar Brum;Bella Unión,"Artigas|(-30.40000000,-56.46667000);Baltasar Brum|(-30.71905000,-57.32596000);Bella Unión|(-30.25966000,-57.59919000)"
+Uruguay,UY,Canelones,Canelones,Montevideo,EMEA,5,-34.52278000,-56.27778000,Aguas Corrientes;Atlántida;Barra de Carrasco,"Aguas Corrientes|(-34.52194000,-56.39361000);Atlántida|(-34.77190000,-55.75840000);Barra de Carrasco|(-34.87722000,-56.02972000)"
+Uruguay,UY,Cerro Largo,Aceguá,Montevideo,EMEA,5,-31.87178000,-54.16351000,Aceguá;Isidoro Noblía;Melo,"Aceguá|(-31.87178000,-54.16351000);Isidoro Noblía|(-31.96218000,-54.12309000);Melo|(-32.37028000,-54.16750000)"
+Uruguay,UY,Colonia,Carmelo,Montevideo,EMEA,5,-34.00023000,-58.28402000,Carmelo;Colonia del Sacramento;Florencio Sánchez,"Carmelo|(-34.00023000,-58.28402000);Colonia del Sacramento|(-34.46262000,-57.83976000);Florencio Sánchez|(-33.87785000,-57.37166000)"
+Uruguay,UY,Durazno,Durazno,Montevideo,EMEA,5,-33.38056000,-56.52361000,Blanquillo;Carlos Reyles;Durazno,"Blanquillo|(-32.76667000,-55.63333000);Carlos Reyles|(-33.05658000,-56.47652000);Durazno|(-33.38056000,-56.52361000)"
+Uruguay,UY,Flores,Trinidad,Montevideo,EMEA,5,-33.51650000,-56.89957000,Trinidad,"Trinidad|(-33.51650000,-56.89957000)"
+Uruguay,UY,Florida,Florida,Montevideo,EMEA,5,-34.09556000,-56.21417000,25 de Agosto;25 de Mayo;Alejandro Gallinal,"25 de Agosto|(-34.41167000,-56.40222000);25 de Mayo|(-34.18917000,-56.33944000);Alejandro Gallinal|(-33.86252000,-55.54264000)"
+Uruguay,UY,Lavalleja,José Batlle y Ordóñez,Montevideo,EMEA,5,-33.46667000,-55.11667000,José Batlle y Ordóñez;José Pedro Varela;Mariscala,"José Batlle y Ordóñez|(-33.46667000,-55.11667000);José Pedro Varela|(-33.45451000,-54.53586000);Mariscala|(-34.04085000,-54.77732000)"
+Uruguay,UY,Maldonado,Maldonado,Montevideo,EMEA,5,-34.90000000,-54.95000000,Aiguá;Maldonado;Pan de Azúcar,"Aiguá|(-34.20498000,-54.75665000);Maldonado|(-34.90000000,-54.95000000);Pan de Azúcar|(-34.77870000,-55.23582000)"
+Uruguay,UY,Montevideo,Montevideo,Montevideo,EMEA,5,-34.90328000,-56.18816000,Aires Puros;Arroyo Seco;Atahualpa,"Aires Puros|(-34.85200000,-56.18300000);Arroyo Seco|(-34.80400000,-56.27700000);Atahualpa|(-34.80900000,-56.23000000)"
+Uruguay,UY,Paysandú,Paysandú,Montevideo,EMEA,5,-32.31710000,-58.08072000,Estación Porvenir;Guichón;Paysandú,"Estación Porvenir|(-32.37085000,-57.85371000);Guichón|(-32.35846000,-57.19778000);Paysandú|(-32.31710000,-58.08072000)"
+Uruguay,UY,Río Negro,Fray Bentos,Montevideo,EMEA,5,-33.11651000,-58.31067000,Fray Bentos;Nuevo Berlín;San Javier,"Fray Bentos|(-33.11651000,-58.31067000);Nuevo Berlín|(-32.97974000,-58.05858000);San Javier|(-32.66523000,-58.13320000)"
+Uruguay,UY,Rivera,Rivera,Montevideo,EMEA,5,-30.90534000,-55.55076000,Minas de Corrales;Rivera;Tranqueras,"Minas de Corrales|(-31.57375000,-55.47075000);Rivera|(-30.90534000,-55.55076000);Tranqueras|(-31.20000000,-55.75000000)"
+Uruguay,UY,Rocha,Rocha,Montevideo,EMEA,5,-34.48333000,-54.33333000,Castillos;Cebollatí;Chui,"Castillos|(-34.19871000,-53.85919000);Cebollatí|(-33.26703000,-53.79425000);Chui|(-33.69792000,-53.45926000)"
+Uruguay,UY,Salto,Salto,Montevideo,EMEA,5,-31.38333000,-57.96667000,Belén;Salto;Villa Constitución,"Belén|(-30.78716000,-57.77577000);Salto|(-31.38333000,-57.96667000);Villa Constitución|(-31.06913000,-57.84946000)"
+Uruguay,UY,San José,Delta del Tigre,Montevideo,EMEA,5,-34.76488000,-56.36450000,Delta del Tigre;Ecilda Paullier;Libertad,"Delta del Tigre|(-34.76488000,-56.36450000);Ecilda Paullier|(-34.35778000,-57.04883000);Libertad|(-34.63459000,-56.61739000)"
+Uruguay,UY,Soriano,Cardona,Montevideo,EMEA,5,-33.87049000,-57.36954000,Cardona;Dolores;José Enrique Rodó,"Cardona|(-33.87049000,-57.36954000);Dolores|(-33.53009000,-58.21701000);José Enrique Rodó|(-33.69618000,-57.53153000)"
+Uruguay,UY,Tacuarembó,Tacuarembó,Montevideo,EMEA,5,-31.71694000,-55.98111000,Curtina;Paso de los Toros;Tacuarembó,"Curtina|(-32.15000000,-56.11667000);Paso de los Toros|(-32.81667000,-56.51667000);Tacuarembó|(-31.71694000,-55.98111000)"
+Uruguay,UY,Treinta y Tres,Treinta y Tres,Montevideo,EMEA,5,-33.23333000,-54.38333000,Santa Clara de Olimar;Treinta y Tres;Vergara,"Santa Clara de Olimar|(-32.92254000,-54.94447000);Treinta y Tres|(-33.23333000,-54.38333000);Vergara|(-32.94419000,-53.93810000)"
+Uzbekistan,UZ,Andijan,Andijon,Tashkent,,,40.78206000,72.34424000,Andijon;Andijon Tumani;Asaka,"Andijon|(40.78206000,72.34424000);Andijon Tumani|(40.80000000,72.41667000);Asaka|(40.64153000,72.23868000)"
+Uzbekistan,UZ,Bukhara,Bukhara,Tashkent,,,39.77472000,64.42861000,Bukhara;Galaosiyo;Gazli,"Bukhara|(39.77472000,64.42861000);Galaosiyo|(39.85778000,64.44833000);Gazli|(40.13333000,63.45000000)"
+Uzbekistan,UZ,Fergana,Fergana,Tashkent,,,40.38421000,71.78432000,Beshariq;Fergana;Hamza,"Beshariq|(40.43583000,70.61028000);Fergana|(40.38421000,71.78432000);Hamza|(40.42762000,71.50534000)"
+Uzbekistan,UZ,Jizzakh,Dashtobod,Tashkent,,,40.12694000,68.49444000,Dashtobod;Dŭstlik;Gagarin,"Dashtobod|(40.12694000,68.49444000);Dŭstlik|(40.52472000,68.03583000);Gagarin|(40.66194000,68.17222000)"
+Uzbekistan,UZ,Karakalpakstan,Beruniy,Tashkent,,,41.69111000,60.75250000,Beruniy;Kegeyli Shahar;Khŭjayli,"Beruniy|(41.69111000,60.75250000);Kegeyli Shahar|(42.77667000,59.60778000);Khŭjayli|(42.40043000,59.46005000)"
+Uzbekistan,UZ,Namangan,Namangan,Tashkent,,,40.99830000,71.67257000,Chortoq;Chust;Haqqulobod,"Chortoq|(41.06924000,71.82372000);Chust|(41.00329000,71.23791000);Haqqulobod|(40.91667000,72.11667000)"
+Uzbekistan,UZ,Navoiy,Navoiy,Tashkent,,,40.08444000,65.37917000,Navoiy;Nurota;Qiziltepa,"Navoiy|(40.08444000,65.37917000);Nurota|(40.56139000,65.68861000);Qiziltepa|(40.03306000,64.85000000)"
+Uzbekistan,UZ,Qashqadaryo,Beshkent,Tashkent,,,38.82139000,65.65306000,Beshkent;Chiroqchi;G‘uzor,"Beshkent|(38.82139000,65.65306000);Chiroqchi|(39.03361000,66.57222000);G‘uzor|(38.62083000,66.24806000)"
+Uzbekistan,UZ,Samarqand,Bulung’ur,Tashkent,,,39.76472000,67.27139000,Bulung’ur;Charxin;Chelak,"Bulung’ur|(39.76472000,67.27139000);Charxin|(39.69667000,66.76861000);Chelak|(39.92028000,66.86111000)"
+Uzbekistan,UZ,Sirdaryo,Sirdaryo,Tashkent,,,40.84361000,68.66167000,Guliston;Sirdaryo;Yangiyer,"Guliston|(40.48972000,68.78417000);Sirdaryo|(40.84361000,68.66167000);Yangiyer|(40.27500000,68.82250000)"
+Uzbekistan,UZ,Surxondaryo,Boysun,Tashkent,,,38.20835000,67.20664000,Boysun;Denov;Sho‘rchi,"Boysun|(38.20835000,67.20664000);Denov|(38.26746000,67.89886000);Sho‘rchi|(37.99944000,67.78750000)"
+Uzbekistan,UZ,Tashkent,Tashkent,Tashkent,,,41.26465000,69.21627000,Bektemir;Tashkent,"Bektemir|(41.20972000,69.33417000);Tashkent|(41.26465000,69.21627000)"
+Uzbekistan,UZ,Tashkent,Angren,Tashkent,,,41.01667000,70.14361000,Angren;Bekobod;Bo‘ka,"Angren|(41.01667000,70.14361000);Bekobod|(40.22083000,69.26972000);Bo‘ka|(40.81108000,69.19417000)"
+Uzbekistan,UZ,Xorazm,Boghot Tumani,Tashkent,,,41.31495000,60.85327000,Boghot Tumani;Gurlan;Hazorasp,"Boghot Tumani|(41.31495000,60.85327000);Gurlan|(41.84472000,60.39194000);Hazorasp|(41.31944000,61.07417000)"
+Vanuatu,VU,Malampa,Lakatoro,Port Vila,,,-16.09992000,167.41636000,Lakatoro;Norsup,"Lakatoro|(-16.09992000,167.41636000);Norsup|(-16.06536000,167.39714000)"
+Vanuatu,VU,Penama,,Port Vila,,,,,,
+Vanuatu,VU,Sanma,Luganville,Port Vila,,,-15.51989000,167.16235000,Luganville;Port-Olry,"Luganville|(-15.51989000,167.16235000);Port-Olry|(-15.04175000,167.07265000)"
+Vanuatu,VU,Shefa,Port-Vila,Port Vila,,,-17.73648000,168.31366000,Port-Vila,"Port-Vila|(-17.73648000,168.31366000)"
+Vanuatu,VU,Tafea,Isangel,Port Vila,,,-19.54167000,169.28167000,Isangel,"Isangel|(-19.54167000,169.28167000)"
+Vanuatu,VU,Torba,Sola,Port Vila,,,-13.87611000,167.55167000,Sola,"Sola|(-13.87611000,167.55167000)"
+Venezuela,VE,Amazonas,Maroa,Caracas,,,2.71880000,-67.56046000,Maroa;Municipio Autónomo Alto Orinoco;Puerto Ayacucho,"Maroa|(2.71880000,-67.56046000);Municipio Autónomo Alto Orinoco|(2.73456000,-64.83032000);Puerto Ayacucho|(5.66049000,-67.58343000)"
+Venezuela,VE,Anzoátegui,Anaco,Caracas,,,9.42958000,-64.46428000,Anaco;Aragua de Barcelona;Barcelona,"Anaco|(9.42958000,-64.46428000);Aragua de Barcelona|(9.45588000,-64.82928000);Barcelona|(10.13625000,-64.68618000)"
+Venezuela,VE,Apure,San Fernando de Apure,Caracas,,,7.87266930,-67.48193280,San Fernando de Apure,"San Fernando de Apure|(7.87266930,-67.48193280)"
+Venezuela,VE,Aragua,Cagua,Caracas,,,10.18634000,-67.45935000,Cagua;El Limón;La Victoria,"Cagua|(10.18634000,-67.45935000);El Limón|(10.30589000,-67.63212000);La Victoria|(10.22677000,-67.33122000)"
+Venezuela,VE,Barinas,Barinas,Caracas,,,8.62261000,-70.20749000,Alto Barinas;Barinas;Barinitas,"Alto Barinas|(8.59310000,-70.22610000);Barinas|(8.62261000,-70.20749000);Barinitas|(8.76171000,-70.41199000)"
+Venezuela,VE,Bolívar,Ciudad Bolívar,Caracas,,,8.12923000,-63.54086000,Ciudad Bolívar;Ciudad Guayana;Municipio Padre Pedro Chien,"Ciudad Bolívar|(8.12923000,-63.54086000);Ciudad Guayana|(8.35122000,-62.64102000);Municipio Padre Pedro Chien|(8.02455000,-61.88187000)"
+Venezuela,VE,Carabobo,Guacara,Caracas,,,10.22609000,-67.87700000,Guacara;Güigüe;Los Guayos,"Guacara|(10.22609000,-67.87700000);Güigüe|(10.08344000,-67.77799000);Los Guayos|(10.18932000,-67.93828000)"
+Venezuela,VE,Cojedes,San Carlos,Caracas,,,9.66124000,-68.58268000,San Carlos;Tinaquillo,"San Carlos|(9.66124000,-68.58268000);Tinaquillo|(9.91861000,-68.30472000)"
+Venezuela,VE,Delta Amacuro,Tucupita,Caracas,,,9.05806000,-62.05000000,Tucupita,"Tucupita|(9.05806000,-62.05000000)"
+Venezuela,VE,Distrito Capital,Caracas,Caracas,,,10.50000000,-66.93333333,Caracas,"Caracas|(10.50000000,-66.93333333)"
+Venezuela,VE,Falcón,Chichiriviche,Caracas,,,10.92872000,-68.27283000,Chichiriviche;Coro;Municipio Los Taques,"Chichiriviche|(10.92872000,-68.27283000);Coro|(11.40450000,-69.67344000);Municipio Los Taques|(11.82308000,-70.25353000)"
+Venezuela,VE,Guárico,Altagracia de Orituco,Caracas,,,9.86005000,-66.38139000,Altagracia de Orituco;Calabozo;San Juan de los Morros,"Altagracia de Orituco|(9.86005000,-66.38139000);Calabozo|(8.92416000,-67.42929000);San Juan de los Morros|(9.91152000,-67.35381000)"
+Venezuela,VE,La Guaira,La Guaira,Caracas,,,10.60156000,-66.93293000,Caraballeda;Catia La Mar;La Guaira,"Caraballeda|(10.61216000,-66.85192000);Catia La Mar|(10.60545000,-67.03238000);La Guaira|(10.60156000,-66.93293000)"
+Venezuela,VE,Lara,Barquisimeto,Caracas,,,10.06470000,-69.35703000,Barquisimeto;Cabudare;Carora,"Barquisimeto|(10.06470000,-69.35703000);Cabudare|(10.02658000,-69.26203000);Carora|(10.17283000,-70.08100000)"
+Venezuela,VE,Mérida,Mérida,Caracas,,,8.58972000,-71.15611000,Ejido;El Vigía;Mérida,"Ejido|(8.54665000,-71.24087000);El Vigía|(8.61350000,-71.65702000);Mérida|(8.58972000,-71.15611000)"
+Venezuela,VE,Miranda,Baruta,Caracas,,,10.43424000,-66.87558000,Baruta;Carrizal;Caucaguita,"Baruta|(10.43424000,-66.87558000);Carrizal|(10.34985000,-66.98632000);Caucaguita|(10.35782000,-66.80252000)"
+Venezuela,VE,Monagas,Caripito,Caracas,,,10.11135000,-63.09985000,Caripito;Maturín;Municipio Maturín,"Caripito|(10.11135000,-63.09985000);Maturín|(9.74569000,-63.18323000);Municipio Maturín|(9.40000000,-63.03333000)"
+Venezuela,VE,Nueva Esparta,Juan Griego,Caracas,,,11.08172000,-63.96549000,Juan Griego;La Asunción;Porlamar,"Juan Griego|(11.08172000,-63.96549000);La Asunción|(11.03333000,-63.86278000);Porlamar|(10.95771000,-63.86971000)"
+Venezuela,VE,Portuguesa,Acarigua,Caracas,,,9.55451000,-69.19564000,Acarigua;Araure;Guanare,"Acarigua|(9.55451000,-69.19564000);Araure|(9.58144000,-69.23851000);Guanare|(9.04183000,-69.74206000)"
+Venezuela,VE,Sucre,Carúpano,Caracas,,,10.66516000,-63.25387000,Carúpano;Cumaná;Güiria,"Carúpano|(10.66516000,-63.25387000);Cumaná|(10.45397000,-64.18256000);Güiria|(10.57721000,-62.29841000)"
+Venezuela,VE,Táchira,Colón,Caracas,,,8.03125000,-72.26053000,Colón;La Fría;La Grita,"Colón|(8.03125000,-72.26053000);La Fría|(8.21523000,-72.24888000);La Grita|(8.13316000,-71.98390000)"
+Venezuela,VE,Trujillo,Trujillo,Caracas,,,9.36583000,-70.43694000,Boconó;Municipio Pampanito;Municipio San Rafael de Carvajal,"Boconó|(9.25385000,-70.25105000);Municipio Pampanito|(9.41147000,-70.49592000);Municipio San Rafael de Carvajal|(9.30756000,-70.58965000)"
+Venezuela,VE,Venezuela,,Caracas,,,,,,
+Venezuela,VE,Yaracuy,Chivacoa,Caracas,,,10.15951000,-68.89453000,Chivacoa;Municipio Independencia;Nirgua,"Chivacoa|(10.15951000,-68.89453000);Municipio Independencia|(10.33472000,-68.75555000);Nirgua|(10.15039000,-68.56478000)"
+Venezuela,VE,Zulia,Cabimas,Caracas,,,10.39907000,-71.45206000,Cabimas;Ciudad Ojeda;La Villa del Rosario,"Cabimas|(10.39907000,-71.45206000);Ciudad Ojeda|(10.20161000,-71.31480000);La Villa del Rosario|(10.32580000,-72.31343000)"
+Vietnam,VN,An Giang,Cho Dok,Hanoi,,,10.70000000,105.11667000,Cho Dok;Dương Đông;Hà Tiên,"Cho Dok|(10.70000000,105.11667000);Dương Đông|(10.21716000,103.95929000);Hà Tiên|(10.38310000,104.48753000)"
+Vietnam,VN,Bắc Ninh,Bắc Ninh,Hanoi,,,21.18608000,106.07631000,Bắc Giang;Bắc Ninh;Cung Kiệm,"Bắc Giang|(21.27307000,106.19460000);Bắc Ninh|(21.18608000,106.07631000);Cung Kiệm|(21.18697000,106.16076000)"
+Vietnam,VN,Cà Mau,Cà Mau,Hanoi,,,9.17682000,105.15242000,Bạc Liêu;Cà Mau;Huyện Cái Nước,"Bạc Liêu|(9.29414000,105.72776000);Cà Mau|(9.17682000,105.15242000);Huyện Cái Nước|(9.00094000,105.04201000)"
+Vietnam,VN,Cần Thơ,Cần Thơ,Hanoi,,,10.11667000,105.50000000,Cần Thơ;Cờ Đỏ;Huyện Châu Thành A,"Cần Thơ|(10.11667000,105.50000000);Cờ Đỏ|(10.09472222,105.43194444);Huyện Châu Thành A|(9.93056000,105.64194000)"
+Vietnam,VN,Cao Bằng,Cao Bằng,Hanoi,,,22.66568000,106.25786000,Cao Bằng;Huyện Bảo Lac;Huyện Bảo Lâm,"Cao Bằng|(22.66568000,106.25786000);Huyện Bảo Lac|(22.90085000,105.73332000);Huyện Bảo Lâm|(22.87041000,105.48780000)"
+Vietnam,VN,Đà Nẵng,Da Nang,Hanoi,,,16.06778000,108.22083000,Da Nang;Hội An;Huyện Duy Xuyên,"Da Nang|(16.06778000,108.22083000);Hội An|(15.87944000,108.33500000);Huyện Duy Xuyên|(15.78970000,108.20247000)"
+Vietnam,VN,Đắk Lắk,Buôn Ma Thuột,Hanoi,,,12.66747000,108.03775000,Buôn Ma Thuột;Huyện Buôn Đôn;Huyện Ea H'Leo,"Buôn Ma Thuột|(12.66747000,108.03775000);Huyện Buôn Đôn|(12.90396000,107.73870000);Huyện Ea H'Leo|(13.31814000,108.07148000)"
+Vietnam,VN,Điện Biên,Dien Bien Phu,Hanoi,,,21.38602000,103.02301000,Dien Bien Phu;Huyện Điện Biên Đông;Huyện Mường Nhé,"Dien Bien Phu|(21.38602000,103.02301000);Huyện Điện Biên Đông|(21.25266000,103.26900000);Huyện Mường Nhé|(22.10353000,102.58465000)"
+Vietnam,VN,Đồng Nai,Biên Hòa,Hanoi,,,10.94469000,106.82432000,Biên Hòa;Bình Long;Don Luan,"Biên Hòa|(10.94469000,106.82432000);Bình Long|(11.64711000,106.60586000);Don Luan|(11.53495000,106.88324000)"
+Vietnam,VN,Đồng Tháp,Cao Lãnh,Hanoi,,,10.46017000,105.63294000,Cao Lãnh;Huyện Cái Bè;Huyện Cai Lậy,"Cao Lãnh|(10.46017000,105.63294000);Huyện Cái Bè|(10.38824000,105.94620000);Huyện Cai Lậy|(10.38943000,106.06774000)"
+Vietnam,VN,Gia Lai,Huyện An Lão,Hanoi,,,14.55676000,108.80100000,Huyện An Lão;Huyện Chư Păh;Huyện Chư Prông,"Huyện An Lão|(14.55676000,108.80100000);Huyện Chư Păh|(14.15941000,107.98411000);Huyện Chư Prông|(13.59976000,107.81099000)"
+Vietnam,VN,Hà Nội,Ba Đình,Hanoi,,,21.03482330,105.80854700,Ba Đình;Ba Vì;Bắc Từ Liêm,"Ba Đình|(21.03482330,105.80854700);Ba Vì|(21.15590590,105.21463610);Bắc Từ Liêm|(21.07148680,105.71992260)"
+Vietnam,VN,Hà Tĩnh,Hà Tĩnh,Hanoi,,,18.34282000,105.90569000,Hà Tĩnh;Huyện Cẩm Xuyên;Huyện Can Lộc,"Hà Tĩnh|(18.34282000,105.90569000);Huyện Cẩm Xuyên|(18.19059000,106.00186000);Huyện Can Lộc|(18.44414000,105.76350000)"
+Vietnam,VN,Hải Phòng,Cát Bà,Hanoi,,,20.72779000,107.04819000,Cát Bà;Hải Dương;Haiphong,"Cát Bà|(20.72779000,107.04819000);Hải Dương|(20.94099000,106.33302000);Haiphong|(20.86481000,106.68345000)"
+Vietnam,VN,Hồ Chí Minh,Cần Giờ,Hanoi,,,10.41115000,106.95474000,Cần Giờ;Côn Sơn;Củ Chi,"Cần Giờ|(10.41115000,106.95474000);Côn Sơn|(8.68641000,106.60824000);Củ Chi|(10.97333000,106.49325000)"
+Vietnam,VN,Hưng Yên,Hưng Yên,Hanoi,,,20.64637000,106.05112000,Hưng Yên;Huyện Ân Thi;Huyện Ðông Hưng,"Hưng Yên|(20.64637000,106.05112000);Huyện Ân Thi|(20.81086000,106.09995000);Huyện Ðông Hưng|(20.54388000,106.34090000)"
+Vietnam,VN,Khánh Hòa,Cam Ranh,Hanoi,,,11.92144000,109.15913000,Cam Ranh;Huyện Diên Khánh;Huyện Khánh Sơn,"Cam Ranh|(11.92144000,109.15913000);Huyện Diên Khánh|(12.27341000,109.03890000);Huyện Khánh Sơn|(12.02858000,108.90814000)"
+Vietnam,VN,Lai Châu,Huyện Mưòng Tè,Hanoi,,,22.37443000,102.73835000,Huyện Mưòng Tè;Huyện Tam Đường;Huyện Than Uyên,"Huyện Mưòng Tè|(22.37443000,102.73835000);Huyện Tam Đường|(22.35391000,103.59342000);Huyện Than Uyên|(21.91424000,103.82857000)"
+Vietnam,VN,Lâm Đồng,Bảo Lộc,Hanoi,,,11.54798000,107.80772000,Bảo Lộc;Đam Rong;Đinh Văn,"Bảo Lộc|(11.54798000,107.80772000);Đam Rong|(12.05409000,108.14941000);Đinh Văn|(11.78624000,108.24282000)"
+Vietnam,VN,Lạng Sơn,Lạng Sơn,Hanoi,,,21.85264000,106.76101000,Huyện Bắc Sơn;Huyện Bình Gia;Huyện Cao Lộc,"Huyện Bắc Sơn|(21.83801000,106.27690000);Huyện Bình Gia|(22.07281000,106.30410000);Huyện Cao Lộc|(21.89857000,106.85435000)"
+Vietnam,VN,Lào Cai,Lào Cai,Hanoi,,,22.48556000,103.97066000,Huyện Bắc Hà;Huyện Bảo Yên;Huyện Bát Xát,"Huyện Bắc Hà|(22.50998000,104.30769000);Huyện Bảo Yên|(22.26109000,104.46424000);Huyện Bát Xát|(22.56767000,103.71339000)"
+Vietnam,VN,Nghệ An,Huyện Anh Sơn,Hanoi,,,18.92902000,105.08294000,Huyện Anh Sơn;Huyện Con Cuông;Huyện Diễn Châu,"Huyện Anh Sơn|(18.92902000,105.08294000);Huyện Con Cuông|(19.03898000,104.80353000);Huyện Diễn Châu|(18.98892000,105.57625000)"
+Vietnam,VN,Ninh Bình,Ninh Bình,Hanoi,,,20.25809000,105.97965000,Huyện Bình Lục;Huyện Duy Tiên;Huyện Giao Thủy,"Huyện Bình Lục|(20.50126000,106.02959000);Huyện Duy Tiên|(20.62803000,105.96193000);Huyện Giao Thủy|(20.25706000,106.46245000)"
+Vietnam,VN,Phú Thọ,Hòa Bình,Hanoi,,,20.81717000,105.33759000,Hòa Bình;Huyện Bình Xuyên;Huyện Cẩm Khê,"Hòa Bình|(20.81717000,105.33759000);Huyện Bình Xuyên|(21.30561000,105.66225000);Huyện Cẩm Khê|(21.40683000,105.09845000)"
+Vietnam,VN,Quảng Ngãi,Quảng Ngãi,Hanoi,,,15.12047000,108.79232000,Huyện Ba Tơ;Huyện Bình Sơn;Huyện Đắk Glei,"Huyện Ba Tơ|(14.73973000,108.69326000);Huyện Bình Sơn|(15.31899000,108.76383000);Huyện Đắk Glei|(15.11358000,107.75093000)"
+Vietnam,VN,Quảng Ninh,Cẩm Phả,Hanoi,,,21.01004000,107.27345000,Cẩm Phả;Cẩm Phả Mines;Hạ Long,"Cẩm Phả|(21.01004000,107.27345000);Cẩm Phả Mines|(21.01667000,107.30000000);Hạ Long|(20.95045000,107.07336000)"
+Vietnam,VN,Quảng Trị,Ðông Hà,Hanoi,,,16.81625000,107.10031000,Ðông Hà;Huyện Cam Lộ;Huyện Đa Krông,"Ðông Hà|(16.81625000,107.10031000);Huyện Cam Lộ|(16.79335000,106.96175000);Huyện Đa Krông|(16.55543000,106.97208000)"
+Vietnam,VN,Sơn La,Sơn La,Hanoi,,,21.32560000,103.91882000,Huyện Bắc Yên;Huyện Mai Sơn;Huyện Mộc Châu,"Huyện Bắc Yên|(21.25042000,104.38501000);Huyện Mai Sơn|(21.15884000,104.04821000);Huyện Mộc Châu|(21.83333000,104.75000000)"
+Vietnam,VN,Tây Ninh,Tây Ninh,Hanoi,,,11.31004000,106.09828000,Cần Giuộc;Huyện Bến Cầu;Huyện Bến Lức,"Cần Giuộc|(10.60857000,106.67135000);Huyện Bến Cầu|(11.12889000,106.14296000);Huyện Bến Lức|(10.68858000,106.45484000)"
+Vietnam,VN,Thái Nguyên,Thái Nguyên,Hanoi,,,21.59422000,105.84817000,Bắc Kạn;Huyện Ba Bể;Huyện Bạch Thông,"Bắc Kạn|(22.14701000,105.83481000);Huyện Ba Bể|(22.41667000,105.75000000);Huyện Bạch Thông|(22.25758000,105.83295000)"
+Vietnam,VN,Thanh Hóa,Thanh Hóa,Hanoi,,,19.80000000,105.76667000,Bỉm Sơn;Huyện Bá Thước;Huyện Cẩm Thủy,"Bỉm Sơn|(20.07806000,105.86028000);Huyện Bá Thước|(20.35767000,105.25301000);Huyện Cẩm Thủy|(20.19586000,105.46817000)"
+Vietnam,VN,Thừa Thiên-Huế,Huế,Hanoi,,,16.46190000,107.59546000,Huế;Huyện A Lưới;Huyện Nam Đông,"Huế|(16.46190000,107.59546000);Huyện A Lưới|(16.23422000,107.30650000);Huyện Nam Đông|(16.12396000,107.69270000)"
+Vietnam,VN,Tuyên Quang,Tuyên Quang,Hanoi,,,21.82356000,105.21424000,Hà Giang;Huyện Bắc Mê;Huyện Bắc Quang,"Hà Giang|(22.82333000,104.98357000);Huyện Bắc Mê|(22.75477000,105.29023000);Huyện Bắc Quang|(22.42301000,104.91831000)"
+Vietnam,VN,Vĩnh Long,Vĩnh Long,Hanoi,,,10.25369000,105.97220000,Ấp Tân Ngãi;Bến Tre;Huyện Ba Tri,"Ấp Tân Ngãi|(10.23333000,106.28333000);Bến Tre|(10.24147000,106.37585000);Huyện Ba Tri|(10.06627000,106.60554000)"
+Virgin Islands (US),VI,Saint Croix,Christiansted,Charlotte Amalie,,,17.74403640,-64.71060860,Christiansted;East End;Frederiksted,"Christiansted|(17.74403640,-64.71060860);East End|(17.75238820,-64.67030100);Frederiksted|(17.71246910,-64.88671920)"
+Virgin Islands (US),VI,Saint John,Central,Charlotte Amalie,,,18.33568380,-64.79470780,Central;Coral Bay;Cruz Bay,"Central|(18.33568380,-64.79470780);Coral Bay|(18.34800890,-64.72196820);Cruz Bay|(18.31820370,-64.80242110)"
+Virgin Islands (US),VI,Saint Thomas,Charlotte Amalie,Charlotte Amalie,,,18.34127610,-64.94838690,Charlotte Amalie;East End;Northside,"Charlotte Amalie|(18.34127610,-64.94838690);East End|(18.32901620,-64.87047310);Northside|(18.37380810,-64.95589090)"
+Yemen,YE,'Adan,Aden,Sanaa,,,12.77944000,45.03667000,Aden;Al Buraiqeh;Al Mansura,"Aden|(12.77944000,45.03667000);Al Buraiqeh|(12.80377000,44.77615000);Al Mansura|(12.85320000,44.97240000)"
+Yemen,YE,'Amran,‘Amrān,Sanaa,,,15.65940000,43.94385000,‘Amrān;Al Ashah;Al Madan,"‘Amrān|(15.65940000,43.94385000);Al Ashah|(16.32400000,43.78740000);Al Madan|(16.23280000,43.63900000)"
+Yemen,YE,Abyan,Ahwar,Sanaa,,,13.68530000,46.75560000,Ahwar;Al Mahfad;Al Wade'a,"Ahwar|(13.68530000,46.75560000);Al Mahfad|(13.97050000,46.75600000);Al Wade'a|(13.71360000,46.01220000)"
+Yemen,YE,Al Bayda',Al A'rsh,Sanaa,,,14.36560000,44.77780000,Al A'rsh;Al Bayda;Al Bayḑā’,"Al A'rsh|(14.36560000,44.77780000);Al Bayda|(13.98523000,45.57272000);Al Bayḑā’|(13.93666000,45.54822000)"
+Yemen,YE,Al Hudaydah,Ad Dahi,Sanaa,,,15.22320000,43.19350000,Ad Dahi;Ad Durayhimi;Al Garrahi,"Ad Dahi|(15.22320000,43.19350000);Ad Durayhimi|(14.60460000,43.07180000);Al Garrahi|(14.10580000,43.40940000)"
+Yemen,YE,Al Jawf,Al ‘Inān,Sanaa,,,16.72189000,44.31252000,Al ‘Inān;Al Ghayl;Al Hazm,"Al ‘Inān|(16.72189000,44.31252000);Al Ghayl|(16.09140000,44.68520000);Al Hazm|(16.03780000,44.95850000)"
+Yemen,YE,Al Mahrah,Al Ghaydah,Sanaa,,,16.26180000,52.08160000,Al Ghaydah;Al Ghayz̧ah;Al Masilah,"Al Ghaydah|(16.26180000,52.08160000);Al Ghayz̧ah|(16.20787000,52.17605000);Al Masilah|(15.63990000,50.64450000)"
+Yemen,YE,Al Mahwit,Al Khabt,Sanaa,,,15.48170000,43.36770000,Al Khabt;Al Mahwait;Al Maḩwīt,"Al Khabt|(15.48170000,43.36770000);Al Mahwait|(15.41170000,43.56630000);Al Maḩwīt|(15.47007000,43.54481000)"
+Yemen,YE,Amanat Al Asimah,,Sanaa,,,,,,
+Yemen,YE,Dhamar,‘Ans,Sanaa,,,14.43606000,44.38889000,‘Ans;Al Hada;Al Manar,"‘Ans|(14.43606000,44.38889000);Al Hada|(14.80760000,44.56790000);Al Manar|(14.65300000,44.11640000)"
+Yemen,YE,Hadhramaut,Ad Dis,Sanaa,,,15.09490000,50.01590000,Ad Dis;Ad Dīs ash Sharqīyah;Adh Dhlia'ah,"Ad Dis|(15.09490000,50.01590000);Ad Dīs ash Sharqīyah|(14.90840000,49.94847000);Adh Dhlia'ah|(15.01390000,47.89720000)"
+Yemen,YE,Hajjah,Hajjah,Sanaa,,,15.68160000,43.44996000,Abs;Aflah Al Yaman;Aflah Ash Shawm,"Abs|(16.02150000,43.04850000);Aflah Al Yaman|(15.97890000,43.41110000);Aflah Ash Shawm|(16.05280000,43.41200000)"
+Yemen,YE,Ibb,Ibb,Sanaa,,,13.96667000,44.18333000,Al ‘Udayn;Al Dhihar;Al Makhādir,"Al ‘Udayn|(13.96112000,43.96608000);Al Dhihar|(13.97900000,44.15260000);Al Makhādir|(14.13965000,44.20330000)"
+Yemen,YE,Lahij,Al  Hawtah,Sanaa,,,13.06240000,44.88160000,Al  Hawtah;Al Ḩabīlayn;Al Had,"Al  Hawtah|(13.06240000,44.88160000);Al Ḩabīlayn|(13.52002000,44.85076000);Al Had|(13.97830000,45.25530000)"
+Yemen,YE,Ma'rib,Ma'rib,Sanaa,,,15.46253000,45.32581000,Al Abdiyah;Al Jubah;Bidbadah,"Al Abdiyah|(14.71700000,45.39340000);Al Jubah|(15.12490000,45.28680000);Bidbadah|(15.39810000,44.74730000)"
+Yemen,YE,Raymah,Al Jabin,Sanaa,,,14.68990000,43.61960000,Al Jabin;Al Jafariyah;As Salafiyah,"Al Jabin|(14.68990000,43.61960000);Al Jafariyah|(14.51960000,43.58170000);As Salafiyah|(14.68660000,43.82160000)"
+Yemen,YE,Saada,Al Dhaher,Sanaa,,,16.73140000,43.27530000,Al Dhaher;Al Hashwah;As Safra,"Al Dhaher|(16.73140000,43.27530000);Al Hashwah|(16.88840000,44.27380000);As Safra|(17.01420000,43.85660000)"
+Yemen,YE,Sana'a,Al Haymah Ad Dakhiliyah,Sanaa,,,15.27220000,43.83930000,Al Haymah Ad Dakhiliyah;Al Haymah Al Kharijiyah;Al Husn,"Al Haymah Ad Dakhiliyah|(15.27220000,43.83930000);Al Haymah Al Kharijiyah|(15.02670000,43.85000000);Al Husn|(15.02060000,44.50440000)"
+Yemen,YE,Shabwah,Ain,Sanaa,,,14.95030000,45.60040000,Ain;Al ‘Āqir;Al Talh,"Ain|(14.95030000,45.60040000);Al ‘Āqir|(14.56816000,45.91156000);Al Talh|(15.08260000,47.35140000)"
+Yemen,YE,Socotra,Hadibu,Sanaa,,,12.64881000,54.01895000,Hadibu;Hidaybu;Qalansīyah,"Hadibu|(12.64881000,54.01895000);Hidaybu|(12.50250000,54.00820000);Qalansīyah|(12.68958000,53.48709000)"
+Yemen,YE,Ta'izz,Al Ma'afer,Sanaa,,,13.37420000,43.92620000,Al Ma'afer;Al Mawasit;Al Misrakh,"Al Ma'afer|(13.37420000,43.92620000);Al Mawasit|(13.30420000,44.10050000);Al Misrakh|(13.47020000,44.03770000)"
+Zambia,ZM,Central,Chibombo,Lusaka,,,-14.65685000,28.07057000,Chibombo;Chibombo District;Kabwe,"Chibombo|(-14.65685000,28.07057000);Chibombo District|(-14.65808000,28.07376000);Kabwe|(-14.44690000,28.44644000)"
+Zambia,ZM,Copperbelt,Chambishi,Lusaka,,,-12.63247000,28.05367000,Chambishi;Chililabombwe;Chingola,"Chambishi|(-12.63247000,28.05367000);Chililabombwe|(-12.36475000,27.82286000);Chingola|(-12.52897000,27.88382000)"
+Zambia,ZM,Eastern,Chadiza,Lusaka,,,-14.06779000,32.43917000,Chadiza;Chipata;Lundazi,"Chadiza|(-14.06779000,32.43917000);Chipata|(-13.63333000,32.65000000);Lundazi|(-12.29292000,33.17820000)"
+Zambia,ZM,Luapula,Kawambwa,Lusaka,,,-9.79150000,29.07913000,Kawambwa;Mansa;Mwense,"Kawambwa|(-9.79150000,29.07913000);Mansa|(-11.19976000,28.89431000);Mwense|(-10.38447000,28.69800000)"
+Zambia,ZM,Lusaka,Lusaka,Lusaka,,,-15.40669000,28.28713000,Chongwe;Kafue;Luangwa,"Chongwe|(-15.32916000,28.68204000);Kafue|(-15.76911000,28.18136000);Luangwa|(-15.61667000,30.41667000)"
+Zambia,ZM,Muchinga,Chama,Lusaka,,,-11.21303000,33.15210000,Chama;Chinsali;Isoka,"Chama|(-11.21303000,33.15210000);Chinsali|(-10.54142000,32.08162000);Isoka|(-10.16062000,32.63353000)"
+Zambia,ZM,Northern,Kaputa,Lusaka,,,-8.46887000,29.66193000,Kaputa;Kasama;Luwingu,"Kaputa|(-8.46887000,29.66193000);Kasama|(-10.21289000,31.18084000);Luwingu|(-10.26210000,29.92712000)"
+Zambia,ZM,Northwestern,Kabompo,Lusaka,,,-13.59268000,24.20081000,Kabompo;Kalengwa;Kansanshi,"Kabompo|(-13.59268000,24.20081000);Kalengwa|(-13.46586000,25.00271000);Kansanshi|(-12.09514000,26.42727000)"
+Zambia,ZM,Southern,Choma,Lusaka,,,-16.80889000,26.98750000,Choma;Gwembe;Itezhi-Tezhi District,"Choma|(-16.80889000,26.98750000);Gwembe|(-16.49755000,27.60691000);Itezhi-Tezhi District|(-15.74092000,26.04146000)"
+Zambia,ZM,Western,Kalabo,Lusaka,,,-14.99307000,22.67926000,Kalabo;Kaoma;Limulunga,"Kalabo|(-14.99307000,22.67926000);Kaoma|(-14.78333000,24.80000000);Limulunga|(-15.09691000,23.13757000)"
+Zimbabwe,ZW,Bulawayo,Bulawayo,Harare,EMEA,14,-20.15000000,28.58333000,Bulawayo,"Bulawayo|(-20.15000000,28.58333000)"
+Zimbabwe,ZW,Harare,Harare,Harare,EMEA,14,-17.82772000,31.05337000,Chitungwiza;Epworth;Harare,"Chitungwiza|(-18.01274000,31.07555000);Epworth|(-17.89000000,31.14750000);Harare|(-17.82772000,31.05337000)"
+Zimbabwe,ZW,Manicaland,Buhera District,Harare,EMEA,14,-19.45658000,31.93156000,Buhera District;Chimanimani;Chimanimani District,"Buhera District|(-19.45658000,31.93156000);Chimanimani|(-19.80000000,32.86667000);Chimanimani District|(-19.78295000,32.73338000)"
+Zimbabwe,ZW,Mashonaland Central,Bindura,Harare,EMEA,14,-17.30192000,31.33056000,Bindura;Bindura District;Centenary,"Bindura|(-17.30192000,31.33056000);Bindura District|(-17.21230000,31.30300000);Centenary|(-16.72289000,31.11462000)"
+Zimbabwe,ZW,Mashonaland East,Beatrice,Harare,EMEA,14,-18.25283000,30.84730000,Beatrice;Chivhu;Goromonzi District,"Beatrice|(-18.25283000,30.84730000);Chivhu|(-19.02112000,30.89218000);Goromonzi District|(-17.80695000,31.36372000)"
+Zimbabwe,ZW,Mashonaland West,Banket,Harare,EMEA,14,-17.38333000,30.40000000,Banket;Chakari;Chegutu,"Banket|(-17.38333000,30.40000000);Chakari|(-18.06294000,29.89246000);Chegutu|(-18.13021000,30.14074000)"
+Zimbabwe,ZW,Masvingo,Masvingo,Harare,EMEA,14,-20.06373000,30.82766000,Bikita District;Chiredzi;Chiredzi District,"Bikita District|(-20.13752000,31.93156000);Chiredzi|(-21.05000000,31.66667000);Chiredzi District|(-21.28585000,31.77039000)"
+Zimbabwe,ZW,Matabeleland North,Binga,Harare,EMEA,14,-17.62027000,27.34139000,Binga;Binga District;Bubi District,"Binga|(-17.62027000,27.34139000);Binga District|(-17.80460000,27.70088000);Bubi District|(-19.52508000,28.67998000)"
+Zimbabwe,ZW,Matabeleland South,Beitbridge,Harare,EMEA,14,-22.21667000,30.00000000,Beitbridge;Beitbridge District;Esigodini,"Beitbridge|(-22.21667000,30.00000000);Beitbridge District|(-21.89829000,30.07409000);Esigodini|(-20.28979000,28.92261000)"
+Zimbabwe,ZW,Midlands,Gokwe,Harare,EMEA,14,-18.20476000,28.93490000,Gokwe;Gweru;Gweru District,"Gokwe|(-18.20476000,28.93490000);Gweru|(-19.45000000,29.81667000);Gweru District|(-19.45665000,29.64495000)"


### PR DESCRIPTION
Fixes `ValueError` and `AttributeError` in `build_output_df` to enable successful generation of world provincial capitals datasets.

The `ValueError: The truth value of a Series is ambiguous` occurred because `country_index.get()` could return a pandas Series, which cannot be directly evaluated in a boolean context with `or {}`. This was resolved by explicitly checking for `None`. Additionally, `AttributeError: 'float' object has no attribute 'upper'` was encountered when country information was missing or malformed, leading to non-string values being passed to `.upper()`. This was addressed by casting values to `str()` before attempting string operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a090f36-d766-45a6-9d02-4e8524d783a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a090f36-d766-45a6-9d02-4e8524d783a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

